### PR TITLE
Routing needs updating to work with MVC

### DIFF
--- a/SignalR/Routing/IncomingOnlyRouteConstraint.cs
+++ b/SignalR/Routing/IncomingOnlyRouteConstraint.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.Routing;
+using System.Web;
+
+namespace SignalR.Routing
+{
+    public class IncomingOnlyRouteConstraint : IRouteConstraint
+    {
+        public bool Match(HttpContextBase httpContext, Route route, string parameterName, RouteValueDictionary values, RouteDirection routeDirection)
+        {
+            if (routeDirection == RouteDirection.IncomingRequest)
+            {
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/SignalR/Routing/RouteExtensions.cs
+++ b/SignalR/Routing/RouteExtensions.cs
@@ -10,6 +10,8 @@ namespace SignalR.Routing {
 
         public static RouteBase MapConnection(this RouteCollection routes, string name, string url, Type type) {
             var route = new Route(url, new PersistentRouteHandler(DependencyResolver.Current, type));
+            route.Constraints = new RouteValueDictionary();
+            route.Constraints.Add("PersistentConnectionConstraint", new IncomingOnlyRouteConstraint());
             routes.Add(name, route);
             return route;
         }

--- a/SignalR/SignalR.csproj
+++ b/SignalR/SignalR.csproj
@@ -85,6 +85,7 @@
     <Compile Include="ISignalBus.cs" />
     <Compile Include="JavaScriptSerializerAdapter.cs" />
     <Compile Include="Json.cs" />
+    <Compile Include="Routing\IncomingOnlyRouteConstraint.cs" />
     <Compile Include="Routing\PersistentRouteHandler.cs" />
     <Compile Include="Routing\RouteExtensions.cs" />
     <Compile Include="SignalCommand.cs" />


### PR DESCRIPTION
Update Routing such that only incoming routing is matched otherwise having outbound routing  results in corruption of MVC default outbound routes.

See ... 
http://stackoverflow.com/questions/7265140/how-do-i-fix-a-routing-issue-with-mvc3-when-rendered-action-links-get-returned-as
