### PR TITLE
Disable firing of global Ajax events in jQuery

### DIFF
--- a/SignalR/Scripts/jquery.signalR.js
+++ b/SignalR/Scripts/jquery.signalR.js
@@ -87,36 +87,36 @@
                     url: connection.url + '/negotiate',
                     data: {},
                     success: function (res) {
-						connection.appRelativeUrl = res.Url;
-						connection.clientId = res.ClientId;
+                        connection.appRelativeUrl = res.Url;
+                        connection.clientId = res.ClientId;
 
-						$(connection).trigger("onStarting");
+                        $(connection).trigger("onStarting");
 
-						var transports = [],
-							supportedTransports = [];
+                        var transports = [],
+                            supportedTransports = [];
 
-						$.each(signalR.transports, function (key) {
-							supportedTransports.push(key);
-						});
+                        $.each(signalR.transports, function (key) {
+                            supportedTransports.push(key);
+                        });
 
-						if ($.isArray(config.transport)) {
-							// ordered list provided
-							$.each(config.transport, function () {
-								var transport = this;
-								if ($.type(transport) === "object" || ($.type(transport) === "string" && $.inArray("" + transport, supportedTransports) >= 0)) {
-									transports.push($.type(transport) === "string" ? "" + transport : transport);
-								}
-							});
-						} else if ($.type(config.transport) === "object" ||
-									   $.inArray(config.transport, supportedTransports) >= 0) {
-							// specific transport provided, as object or a named transport, e.g. "longPolling"
-							transports.push(config.transport);
-						} else { // default "auto"
-							transports = supportedTransports;
-						}
+                        if ($.isArray(config.transport)) {
+                            // ordered list provided
+                            $.each(config.transport, function () {
+                                var transport = this;
+                                if ($.type(transport) === "object" || ($.type(transport) === "string" && $.inArray("" + transport, supportedTransports) >= 0)) {
+                                    transports.push($.type(transport) === "string" ? "" + transport : transport);
+                                }
+                            });
+                        } else if ($.type(config.transport) === "object" ||
+                                       $.inArray(config.transport, supportedTransports) >= 0) {
+                            // specific transport provided, as object or a named transport, e.g. "longPolling"
+                            transports.push(config.transport);
+                        } else { // default "auto"
+                            transports = supportedTransports;
+                        }
 
-						initialize(transports);
-					}
+                        initialize(transports);
+                    }
                 });
             }, 0);
 
@@ -299,7 +299,7 @@
                             url = instance.url + (connect ? "/connect" : "");
 
                         instance.pollXhr = $.ajax(url, {
-						    global: false,
+                            global: false,
                             type: "POST",
                             data: {
                                 clientId: instance.clientId,
@@ -367,8 +367,8 @@
                 /// <param name="data" type="String">The data to send</param>
                 /// <param name="callback" type="Function">A callback to be invoked when the send has completed</param>
                 $.ajax(connection.url + '/send', {
- 				    global: false,
-					type: "POST",
+                    global: false,
+                    type: "POST",
                     dataType: "json",
                     data: {
                         data: data,


### PR DESCRIPTION
Hi,

Currently signalR causes the firing of global Ajax events (ajaxStart, ajaxStop etc.). As you probably want to use those for short term ajax request (like fetching data from server etc.) I have disabled them in the attached commits. Two questions:
1. Maybe it is better to create a (global) configuration setting for this so you can decide whether or not to have those events fire. However there does not seem to be a config for those types of settings just now.
2. Should I also update the minified version of the .js and the copies in the samples folder?

Thanks!
