### PR TITLE
Updated WebActivator package reference for the samples project. 

### DIFF
--- a/SignalR.Samples/SignalR.Samples.csproj
+++ b/SignalR.Samples/SignalR.Samples.csproj
@@ -44,6 +44,10 @@
       <HintPath>..\packages\AntiXSS.4.0.1\lib\net35\HtmlSanitizationLibrary.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data.Entity" />
@@ -64,8 +68,9 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WebActivator">
-      <HintPath>..\packages\WebActivator.1.4.1\lib\net40\WebActivator.dll</HintPath>
+    <Reference Include="WebActivator, Version=1.5.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\WebActivator.1.5\lib\net40\WebActivator.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SignalR.Samples/packages.config
+++ b/SignalR.Samples/packages.config
@@ -12,5 +12,6 @@
   <package id="jQuery.Templates" version="0.1" />
   <package id="jQuery.UI.Combined" version="1.8.13" />
   <package id="json2" version="1.0" />
-  <package id="WebActivator" version="1.4.1" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
+  <package id="WebActivator" version="1.5" />
 </packages>


### PR DESCRIPTION
Had a problem with deploying the samples project to Azure. Turns out the issue was due to a missing reference for Microsoft.Web.Infrastructure. When I updated the WebActivator package it correctly detected the dependency and added the reference.
