### PR TITLE
Bypass ASP.NET request validation

### DIFF
--- a/SignalR.Samples/Web.config
+++ b/SignalR.Samples/Web.config
@@ -20,7 +20,7 @@
   </connectionStrings>
   <system.web>
     <compilation debug="true" targetFramework="4.0" />
-    <httpRuntime requestValidationMode="2.0" />
+    <httpRuntime requestValidationMode="4.0" />
     <httpModules>
       <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
       <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />


### PR DESCRIPTION
I finally took a stab at fixing issue #36. Please review and comment on the changes.

I've aggressively bypassed request validation for all SignalR specific data. My justification is that their all part of the framework and shouldn't trigger protection mechanisms intended for the application developer.

The helper extension methods should come in handy in other transports as well. And if needed the nested private class could be promoted to public.

Sadly since the `ValidationUtility` class (from `Microsoft.Infrastructure.dll`) is static and tightly coupled with `HttpContext` I couldn't figure out a decent way to write tests for my `RequestValidationHelper`.

Anyway, the end result of these changes is that at the inclusion of SignalR in a web application it doesn't force application developers to disable the 4.0 request validation feature for the whole application.
