### PR TITLE
Invalid POST form value escaping in HttpHelper.cs for LongPollingTransport clients

### DIFF
--- a/SignalR.ScaleOut/HttpHelper.cs
+++ b/SignalR.ScaleOut/HttpHelper.cs
@@ -94,7 +94,7 @@ namespace SignalR
                     continue;
                 }
 
-                sb.AppendFormat("{0}={1}", pair.Key, Uri.EscapeUriString(pair.Value));
+                sb.AppendFormat("{0}={1}", pair.Key, Uri.EscapeDataString(pair.Value));
             }
 
             byte[] buffer = Encoding.UTF8.GetBytes(sb.ToString());


### PR DESCRIPTION
When encoding the form data key value pairs for POST request in HttpHelper the values is currently being encoded using [Uri.EscapeUriString](http://msdn.microsoft.com/en-us/library/system.uri.escapeuristring.aspx).

EscapeUriString doesn't encode any of the reserved characters specified in [RFC2396](http://www.apps.ietf.org/rfc/rfc2396.html#sec-2.2). This causes characters such as the '+' sign to be sent over the wire unescaped instead of being sent as %2B. And if strings contains '=' it will break the request.

This in turn causes ASP.NET to treat it as a space sign instead of a plus. To reproduce simply send a plus sign in any string in the post data from a SignalR.Client application.

``` cs
hub.Invoke("Send", "foo+bar"); // Will be received server side as "foo bar"
```

Normally I'd use [HttpUtility.UrlEncode](http://msdn.microsoft.com/en-us/library/system.web.httputility.urlencode.aspx) for encoding forms but since SignalR.Client wasn't referencing System.Web I went for [EscapeDataString](http://msdn.microsoft.com/en-us/library/system.uri.escapedatastring.aspx) instead. Note however that EscapeDataString (as well as EscapeUriString) will throw an UriFormatException for strings larger than 32766 characters. I don't know if this is an issue but if it is perhaps it should be considered referencing System.Web or writing a custom escape method.
