### PR TITLE
No-content http post issue with ancient browsers + IIS

### DIFF
--- a/SignalR/Scripts/jquery.signalR.js
+++ b/SignalR/Scripts/jquery.signalR.js
@@ -88,7 +88,7 @@
                 $.ajax(connection.url + '/negotiate', {
                     global: false,
                     type: "POST",
-                    data: {},
+                    data: {'x':'x'},
                     success: function (res) {
                         connection.appRelativeUrl = res.Url;
                         connection.id = res.ConnectionId;


### PR DESCRIPTION
Found an issue: some ancient browsers (for example Mozilla 5.0, running in Cisco Digital Media Player 4400G) do not set content-length header at all when issuing a POST without actual data. And that makes IIS to return a HTTP 411 Length Required error, breaking SignalR communication.

The first negotiate request did exactly that, spent roughly half a day when finally could catch this with WireShark.

Simply changing 
   data: {} 
to 
   data: {'x':'x'} 
solves this issue.

Great work anyway :)
