### PR TITLE
Build against JSON.NET

### DIFF
--- a/SignalR/SignalR.csproj
+++ b/SignalR/SignalR.csproj
@@ -33,9 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.0.7.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+    <Reference Include="Newtonsoft.Json, Version=4.0.5.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.0.7\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.4.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/SignalR/packages.config
+++ b/SignalR/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.0.7" />
+  <package id="Newtonsoft.Json" version="4.0.5" />
 </packages>


### PR DESCRIPTION
SignalR now builds against JSON.NET 4.0.5 instead of 4.0.7.
Would be nice to have the NuGet Package with versioning greater than or equal 4.0.5 instead of 4.0.7 too.
