### PR TITLE
Issue #205: Changed PrepareRequest from internal to public virtual

### DIFF
--- a/SignalR.Client/Connection.cs
+++ b/SignalR.Client/Connection.cs
@@ -260,7 +260,7 @@ namespace SignalR.Client
             }
         }
 
-        internal void PrepareRequest(HttpWebRequest request)
+        public virtual void PrepareRequest(HttpWebRequest request)
         {
 #if WINDOWS_PHONE
             // http://msdn.microsoft.com/en-us/library/ff637320(VS.95).aspx


### PR DESCRIPTION
Option 1 for exposing `HttpWebRequest.CookieContainer`
