### PR TITLE
Changed visibility of some types from internal to public [222]

### DIFF
--- a/SignalR/Infrastructure/NullJavaScriptMinifier.cs
+++ b/SignalR/Infrastructure/NullJavaScriptMinifier.cs
@@ -1,7 +1,7 @@
 ﻿
 namespace SignalR.Infrastructure
 {
-    internal class NullJavaScriptMinifier : IJavaScriptMinifier
+    public class NullJavaScriptMinifier : IJavaScriptMinifier
     {
         public static readonly NullJavaScriptMinifier Instance = new NullJavaScriptMinifier();
 

--- a/SignalR/Infrastructure/ReflectionHelper.cs
+++ b/SignalR/Infrastructure/ReflectionHelper.cs
@@ -6,12 +6,12 @@ using SignalR.Hubs;
 
 namespace SignalR.Infrastructure
 {
-    internal static class ReflectionHelper
+    public static class ReflectionHelper
     {
         private static readonly Type[] _excludeTypes = new[] { typeof(Hub), typeof(object) };
         private static readonly Type[] _excludeInterfaces = new[] { typeof(IHub), typeof(IDisconnect), typeof(IConnected) };
 
-        internal static IEnumerable<MethodInfo> GetExportedHubMethods(Type type)
+        public static IEnumerable<MethodInfo> GetExportedHubMethods(Type type)
         {
             if (!typeof(IHub).IsAssignableFrom(type))
             {
@@ -42,7 +42,7 @@ namespace SignalR.Infrastructure
             return type.GetInterfaceMap(iface).TargetMethods;
         }
 
-        internal static TResult GetAttributeValue<TAttribute, TResult>(ICustomAttributeProvider source, Func<TAttribute, TResult> valueGetter)
+        public static TResult GetAttributeValue<TAttribute, TResult>(ICustomAttributeProvider source, Func<TAttribute, TResult> valueGetter)
             where TAttribute : Attribute
         {
             var attributes = source.GetCustomAttributes(typeof(TAttribute), false)

--- a/SignalR/Json.cs
+++ b/SignalR/Json.cs
@@ -3,9 +3,9 @@ using System.Linq;
 
 namespace SignalR
 {
-    internal static class Json
+    public static class Json
     {
-        internal static string CamelCase(string value)
+        public static string CamelCase(string value)
         {
             if (value == null)
             {
@@ -14,7 +14,7 @@ namespace SignalR
             return String.Join(".", value.Split('.').Select(n => Char.ToLower(n[0]) + n.Substring(1)));
         }
 
-        internal static string MimeType
+        public static string MimeType
         {
             get { return "application/json"; }
         }


### PR DESCRIPTION
This is to allow reusage for the SignalR.Reactive project (aka Rx bindings for SignalR)

Issue Link: https://github.com/SignalR/SignalR/issues/222
SignalR.Reactive: https://github.com/cburgdorf/SignalR.Reactive
