### PR TITLE
Fix to EnsureCookies

### DIFF
--- a/SignalR/Hosting/RequestCookieCollection.cs
+++ b/SignalR/Hosting/RequestCookieCollection.cs
@@ -48,17 +48,10 @@ namespace SignalR.Hosting
 
         private void EnsureCookies()
         {
-            if (_cookies == null)
-            {
-                if (_cookieSource != null)
-                {
-                    _cookies = new List<Cookie>(_cookieSource);
-                }
-                else
-                {
-                    _cookieSource = new List<Cookie>();
-                }
-            }
+    		if (_cookies != null)
+				return;
+
+			_cookies = new List<Cookie>(_cookieSource ?? new Cookie[0]);
         }
     }
 }


### PR DESCRIPTION
If the source collection is null the Cookie collection is set only to the second call of EnsureCookies.
