### PR TITLE
Removing unused namespace in SignalR project.

### DIFF
--- a/SignalR/Hubs/IJavaScriptProxyGenerator.cs
+++ b/SignalR/Hubs/IJavaScriptProxyGenerator.cs
@@ -1,6 +1,4 @@
-﻿using System.Web;
-using SignalR.Hosting;
-
+﻿
 namespace SignalR.Hubs
 {
     public interface IJavaScriptProxyGenerator

--- a/SignalR/IConnection.cs
+++ b/SignalR/IConnection.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace SignalR
 {

--- a/SignalR/IConnectionManager.cs
+++ b/SignalR/IConnectionManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using SignalR.Hubs;
+﻿using SignalR.Hubs;
 
 namespace SignalR
 {

--- a/SignalR/MessageBus/Message.cs
+++ b/SignalR/MessageBus/Message.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace SignalR
+namespace SignalR.MessageBus
 {
     public class Message
     {


### PR DESCRIPTION
Also moved Message to correct namespace SignalR.MessageBus instead of SignalR
