### PR TITLE
Fixed bug in DefaultHubManager

### DIFF
--- a/SignalR/Hubs/Lookup/DefaultHubManager.cs
+++ b/SignalR/Hubs/Lookup/DefaultHubManager.cs
@@ -51,7 +51,7 @@ namespace SignalR.Hubs
             }
 
             MethodDescriptor descriptor = null;
-            if (_methodProviders.Count(p => p.TryGetMethod(hub, method, out descriptor, parameters)) == 1)
+            if (_methodProviders.FirstOrDefault(p => p.TryGetMethod(hub, method, out descriptor, parameters)) != null)
             {
                 return descriptor;
             }


### PR DESCRIPTION
Fixed bug that in some cases caused a successful method resolve to appear as unsuccessful and throw an error.
