### PR TITLE
ReflectedMethodDescriptorProvider::TryGetMethod Performance Optimization

### DIFF
--- a/SignalR/Hubs/Lookup/ReflectedMethodDescriptorProvider.cs
+++ b/SignalR/Hubs/Lookup/ReflectedMethodDescriptorProvider.cs
@@ -33,7 +33,7 @@ namespace SignalR.Hubs
         private IDictionary<string, IEnumerable<MethodDescriptor>> FetchMethodsFor(HubDescriptor hub)
         {
             return _methods.GetOrAdd(
-                hub.Name, 
+                hub.Name,
                 key => BuildMethodCacheFor(hub));
         }
 
@@ -49,7 +49,7 @@ namespace SignalR.Hubs
             return ReflectionHelper.GetExportedHubMethods(hub.Type)
                 .GroupBy(GetMethodName, StringComparer.OrdinalIgnoreCase)
                 .ToDictionary(group => group.Key,
-                              group => group.Select(oload => 
+                              group => group.Select(oload =>
                                   new MethodDescriptor
                                   {
                                       ReturnType = oload.ReturnType,
@@ -57,12 +57,12 @@ namespace SignalR.Hubs
                                       Invoker = oload.Invoke,
                                       Parameters = oload.GetParameters()
                                           .Select(p => new ParameterDescriptor
-                                              {
-                                                  Name = p.Name,
-                                                  Type = p.ParameterType,
-                                              })
+                                          {
+                                              Name = p.Name,
+                                              Type = p.ParameterType,
+                                          })
                                           .ToList()
-                                  }), 
+                                  }),
                               StringComparer.OrdinalIgnoreCase);
         }
 
@@ -72,12 +72,9 @@ namespace SignalR.Hubs
 
             if(FetchMethodsFor(hub).TryGetValue(method, out overloads))
             {
-                var matches = overloads.Where(o => o.Matches(parameters)).ToList();
-                if(matches.Count == 1)
-                {
-                    descriptor = matches.First();
-                    return true;
-                }
+                descriptor = overloads.Where(o => o.Matches(parameters)).FirstOrDefault();
+
+                return descriptor != null;
             }
 
             descriptor = null;


### PR DESCRIPTION
@KrzysFR was doing some profiling on SignalR and noticed that 5% of the time was being spent in HubDispatcher::OnReceivedAsync. I began to look for low hanging fruit in that execution path and one of the first things I noticed was that the ReflectedMethodDescriptorProvider::TryGetMethod was performing a LINQ query, allocating a List<MethodDescriptor> with .ToList() and checking if .Count > 1. If only 1 item was found then that item was being returned with a .First(), otherwise no descriptor would be returned.

Obviously this is a hot code path. The cost of allocating the List<MethodDescriptor>, populating it, checking the .Count and then doing a .First() is extreme just avoid the possibility of selecting a duplicate method when you could just select the first method that is found and allow the existence of exact duplicates to be documented as undefined/unsupported behavior. In speaking to @davidfowl he thought this might be an acceptable trade off.
