### PR TITLE
ReflectedMethodDescriptorProvider::TryGetMethod method caching

### DIFF
--- a/SignalR.Tests/HubFacts.cs
+++ b/SignalR.Tests/HubFacts.cs
@@ -92,6 +92,22 @@ namespace SignalR.Tests
         }
 
         [Fact]
+        public void UnsupportedOverloads()
+        {
+            var host = new MemoryHost();
+            host.MapHubs();
+            var connection = new Client.Hubs.HubConnection("http://foo/");
+
+            var hub = connection.CreateProxy("demo");
+
+            connection.Start(host).Wait();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => hub.Invoke("UnsupportedOverload", 13177).Wait());
+
+            Assert.Equal("'UnsupportedOverload' method could not be resolved.", ex.GetBaseException().Message);
+        }
+
+        [Fact]
         public void ChangeHubUrl()
         {
             var host = new MemoryHost();

--- a/SignalR/Hubs/Lookup/ReflectedMethodDescriptorProvider.cs
+++ b/SignalR/Hubs/Lookup/ReflectedMethodDescriptorProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
@@ -11,10 +12,12 @@ namespace SignalR.Hubs
     public class ReflectedMethodDescriptorProvider : IMethodDescriptorProvider
     {
         private readonly ConcurrentDictionary<string, IDictionary<string, IEnumerable<MethodDescriptor>>> _methods;
+        private readonly ConcurrentDictionary<string, MethodDescriptor> _executableMethods;
 
         public ReflectedMethodDescriptorProvider()
         {
             _methods = new ConcurrentDictionary<string, IDictionary<string, IEnumerable<MethodDescriptor>>>(StringComparer.OrdinalIgnoreCase);
+            _executableMethods = new ConcurrentDictionary<string, MethodDescriptor>(StringComparer.OrdinalIgnoreCase);
         }
 
         public IEnumerable<MethodDescriptor> GetMethods(HubDescriptor hub)
@@ -57,31 +60,55 @@ namespace SignalR.Hubs
                                       Invoker = oload.Invoke,
                                       Parameters = oload.GetParameters()
                                           .Select(p => new ParameterDescriptor
-                                          {
-                                              Name = p.Name,
-                                              Type = p.ParameterType,
-                                          })
+                                              {
+                                                  Name = p.Name,
+                                                  Type = p.ParameterType,
+                                              })
                                           .ToList()
                                   }),
                               StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Searches the specified <paramref name="hub">Hub</paramref> for the specified <paramref name="method"/>.
+        /// </summary>
+        /// <remarks>
+        /// In the case that there are multiple overloads of the specified <paramref name="method"/>, the <paramref name="parameter">parameter set</paramref> helps determine exactly which instance of the overload should be resolved. 
+        /// If there are multiple overloads found with the same number of matching paramters, none of the methods will be returned because it is not possible to determine which overload of the method was intended to be resolved.
+        /// </remarks>
+        /// <param name="hub">Hub to search for the specified <paramref name="method"/> on.</param>
+        /// <param name="method">The method name to search for.</param>
+        /// <param name="descriptor">If successful, the <see cref="MethodDescriptor"/> that was resolved.</param>
+        /// <param name="parameters">The set of parameters that will be used to help locate a specific overload of the specified <paramref name="method"/>.</param>
+        /// <returns>True if the method matching the name/parameter set is found on the hub, otherwise false.</returns>
         public bool TryGetMethod(HubDescriptor hub, string method, out MethodDescriptor descriptor, params JToken[] parameters)
         {
-            IEnumerable<MethodDescriptor> overloads;
+            string hubMethodKey = hub.Name + "::" + method.ToUpperInvariant() + "(" + (parameters != null ? parameters.Length.ToString(CultureInfo.InvariantCulture) : "0") + ")";
 
-            if (FetchMethodsFor(hub).TryGetValue(method, out overloads))
+            if(!_executableMethods.TryGetValue(hubMethodKey, out descriptor))
             {
-                var matches = overloads.Where(o => o.Matches(parameters)).ToList();
-                if (matches.Count == 1)
+                IEnumerable<MethodDescriptor> overloads;
+
+                if(FetchMethodsFor(hub).TryGetValue(method, out overloads))
                 {
-                    descriptor = matches.First();
-                    return true;
+                    var matches = overloads.Where(o => o.Matches(parameters)).ToList();
+
+                    // If only one match is found, that is the "executable" version, otherwise none of the methods can be returned because we don't know which one was actually being targeted
+                    descriptor =  matches.Count == 1 ? matches[0] : null;
+                }
+                else
+                {
+                    descriptor = null;
+                }
+
+                // If an executable method was found, cache it for future lookups (NOTE: we don't cache null instances because it could be a surface area for DoS attack by supplying random method names to flood the cache)
+                if(descriptor != null)
+                {
+                    _executableMethods.TryAdd(hubMethodKey, descriptor);
                 }
             }
 
-            descriptor = null;
-            return false;
+            return descriptor != null;
         }
 
         private static string GetMethodName(MethodInfo method)

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/DemoHub/DemoHub.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/DemoHub/DemoHub.cs
@@ -114,6 +114,16 @@ namespace SignalR.Samples.Hubs.DemoHub
             return n;
         }
 
+        public void UnsupportedOverload(string x)
+        {
+
+        }
+
+        public void UnsupportedOverload(int x)
+        {
+
+        }
+
         public class Person
         {
             public string Name { get; set; }


### PR DESCRIPTION
Fixes #351.

This version of the implementation now properly caches executable hub methods using not only the name, but also the number of parameters passed so that overloads are properly supported. On top of the unit test that @davidfowl added for supported overload scenarios, I also added a unit test for _unsupported_ overload scenarios to test to make sure there was no regression there either.
