### PR TITLE
Allow invoking of client-side method when the name is not known until runtime. (For use with Dynamic Hubs)

### DIFF
--- a/SignalR/Hubs/SignalAgent.cs
+++ b/SignalR/Hubs/SignalAgent.cs
@@ -24,11 +24,16 @@ namespace SignalR.Hubs
 
         public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
         {
-            result = Invoke(binder.Name, args);
+            result = Invoker(binder.Name, args);
             return true;
         }
 
-        private Task Invoke(string method, params object[] args)
+        public Task Invoke(string method, params object[] args)
+        {
+            return Invoker(method, args);
+        }
+
+        private Task Invoker(string method, params object[] args)
         {
             var invocation = GetInvocationData(method, args);
 


### PR DESCRIPTION
I've implemented `IMethodDescriptorProvider` and am pulling together my hubs dynamically at run time. One of the hurdles is calling a dynamically constructed method on a hub when I don't know the name of my methods until runtime. 

Generally, in an `IHub` instance, you invoke a client-side method by calling the strongly typed javascript method: `Clients.addMessage(...)` but I don't know what these method names are, yet I still need to invoke them. To do this, I modified the `SignalAgent` class to allow for the dynamic invocation of these methods by passing the name of the method and the object[] params.

This doesn't break any other functionality.

Hope this makes sense. Thanks!
