### PR TITLE
Prevent hang on Connection.Start()

### DIFF
--- a/SignalR.Client/Transports/AutoTransport.cs
+++ b/SignalR.Client/Transports/AutoTransport.cs
@@ -88,7 +88,8 @@ namespace SignalR.Client.Transports
 
         public void Stop(IConnection connection)
         {
-            _transport.Stop(connection);
+            if(_transport != null)
+                _transport.Stop(connection);
         }
     }
 }


### PR DESCRIPTION
Hi

After debugging SignalR to find out why Connection.Start() was hanging I found it was due to inconsistencies in versions of Newtonsoft.Json. But I wasn't quite sure why it was hanging instead of returning a faulted Task.

After digging a little deeper it was throwing a second exception because `_transport` was null when calling `Stop()`. The second exception was thrown on this line...

https://github.com/jamesfoster/SignalR/blob/5752d6007b8751a3bc723fea0405d7a0994ed82e/SignalR.Client/Connection.cs#L237

I'm still not quite sure why the exception didn't bubble up because that task is marked with `TaskContinuationOptions.ExecuteSynchronously`. Nevertheless, this simple change solved it.

Thanks

James
