### PR TITLE
Fixed a powershell build error in SignalR.Client.JS

### DIFF
--- a/SignalR.Client.JS/SignalR.Client.JS.csproj
+++ b/SignalR.Client.JS/SignalR.Client.JS.csproj
@@ -115,6 +115,6 @@
   </Target>
   <PropertyGroup>
     <PostBuildEvent>cd $(ProjectDir)
-powershell $(ProjectDir)build.ps1</PostBuildEvent>
+powershell -ExecutionPolicy Bypass $(ProjectDir)build.ps1</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
As of 3a8d61802ae4b5fd95f7c61aae192514957c34cd, the main SignalR JavaScript file is built via a PowerShell script. This has caused a build failure on my system, where the default PowerShell execution policy of "RemoteSigned" is active:

> File "D:\Dev\SignalR-fork\SignalR.Client.JS\build.ps1" cannot be loaded because the execution of scripts is disabled on this system. Please see "get-help about_signing" for more details. 

This PR fixes the issue by passing an argument to powershell.exe that allows scripts to be executed.
