### PR TITLE
Fixed failing tests on non-English OS (#338)

### DIFF
--- a/SignalR.Tests/HubFacts.cs
+++ b/SignalR.Tests/HubFacts.cs
@@ -77,7 +77,8 @@ namespace SignalR.Tests
 
             var ex = Assert.Throws<AggregateException>(() => hub.Invoke("TaskWithException").Wait());
 
-            Assert.Equal("Exception of type 'System.Exception' was thrown.", ex.GetBaseException().Message);
+            Assert.IsType<InvalidOperationException>(ex.GetBaseException());
+            Assert.Contains("System.Exception", ex.GetBaseException().Message);
             connection.Stop();
         }
 
@@ -94,7 +95,8 @@ namespace SignalR.Tests
 
             var ex = Assert.Throws<AggregateException>(() => hub.Invoke("GenericTaskWithException").Wait());
 
-            Assert.Equal("Exception of type 'System.Exception' was thrown.", ex.GetBaseException().Message);
+            Assert.IsType<InvalidOperationException>(ex.GetBaseException());
+            Assert.Contains("System.Exception", ex.GetBaseException().Message);
             connection.Stop();
         }
 


### PR DESCRIPTION
This PR fixes #338. Instead of checking against the string, this checks if the exception type is correct. 

There is however a small gotcha here, as you can't really check against the exception type that was thrown inside a hub method, because only the exception message is returned back to the client (see [HubDispatcher.cs#L243](https://github.com/akoeplinger/SignalR/blob/5cabbcbc63d4bb68f1acdb7cfaab77e86db596ba/SignalR/Hubs/HubDispatcher.cs#L243)). The message is then wrapped into a `InvalidOperationException` in [HubProxy.cs#L94](https://github.com/akoeplinger/SignalR/blob/5cabbcbc63d4bb68f1acdb7cfaab77e86db596ba/SignalR.Client/Hubs/HubProxy.cs#L94) if it's not null.

This means that the exception message gets localized on the server, so I now simply check if the message contains "System.Exception", which should be present in every localized message.
