### PR TITLE
Allow Self-Hosting to use HTTP Authentication

### DIFF
--- a/SignalR.Hosting.Self/Server.cs
+++ b/SignalR.Hosting.Self/Server.cs
@@ -42,6 +42,12 @@ namespace SignalR.Hosting.Self
             _listener.Prefixes.Add(url);
         }
 
+        public AuthenticationSchemes AuthenticationSchemes
+        {
+            get { return _listener.AuthenticationSchemes; }
+            set { _listener.AuthenticationSchemes = value; }
+        }
+
         /// <summary>
         /// Starts the server connection.
         /// </summary>


### PR DESCRIPTION
Expose the AuthenticationSchemes property from the underlying
HttpListener to allow use of different authentication protocols.
