### PR TITLE
Silverlight cross-domain fix

### DIFF
--- a/SignalR.Hosting.Self/Server.cs
+++ b/SignalR.Hosting.Self/Server.cs
@@ -184,6 +184,23 @@ namespace SignalR.Hosting.Self
                     return connection.ProcessRequestAsync(hostContext);
                 }
 
+                if (path.Equals("/clientaccesspolicy.xml", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return context.Response.WriteAsync(@"<?xml version=""1.0"" encoding=""utf-8""?>
+ <access-policy>
+     <cross-domain-access>
+         <policy>
+             <allow-from http-request-headers=""*"">
+                 <domain uri=""*""/>
+             </allow-from>
+             <grant-to>
+                 <resource path=""/"" include-subpaths=""true""/>
+             </grant-to>
+         </policy>
+     </cross-domain-access>
+ </access-policy>");
+                }
+
                 return context.Response.NotFound();
             }
             catch (Exception ex)


### PR DESCRIPTION
Added serving of cross-domain client policy file to enable Silverlight app to connect to self-hosted server.
