### PR TITLE
Fixed #501

### DIFF
--- a/SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -19,7 +19,7 @@
                 frameId = (transportLogic.foreverFrame.count += 1),
                 url,
                 connectTimeOut,
-                frame = $("<iframe data-signalr-connection-id='" + connection.id + "' style='position:absolute;top:0;left:0;width:0;height:0;visibility:hidden;'></iframe>");
+                frame = $("<iframe data-signalr-connection-id='" + connection.id + "' style='position:absolute;top:0;left:0;width:0;height:0;visibility:hidden;' src=''></iframe>");
 
             if (window.EventSource) {
                 // If the browser supports SSE, don't use Forever Frame


### PR DESCRIPTION
Fixed Connect/Disconnect events not firing in IE.  Issue was browser
caching bug, but was fixed by setting the src tag of hte iFrame to
nothing.

https://github.com/SignalR/SignalR/issues/501 
