### PR TITLE
Resolving problem with incorrect appRelativeUrl when SignalR is using with reverse proxy

### DIFF
--- a/SignalR.Client.JS/jquery.signalR.core.js
+++ b/SignalR.Client.JS/jquery.signalR.core.js
@@ -271,7 +271,7 @@
                         connection.stop();
                     },
                     success: function (res) {
-                        connection.appRelativeUrl = res.Url;
+                        connection.appRelativeUrl = connection.url.indexOf("/") === 0 ? connection.url : res.Url;
                         connection.id = res.ConnectionId;
                         connection.webSocketServerUrl = res.WebSocketServerUrl;
 


### PR DESCRIPTION
That commit fixes problem when SingnalR.Self.Hosting is listening for connection under: /events But reverse proxy has a separate url, e.g.: /virtualpath/events. "negotiation" request returns Url: /events which will be set in appRelativeUrl and all further requests will be passed to /events instead ofr /virtualpath/events. 

The fix checks if the Url is absolute path then it uses connection.url; otherwise the old logic is used. 
