### PR TITLE
Forever frames throw an Access Denied error document.domain is explicitly set

### DIFF
--- a/SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -117,7 +117,7 @@
                 if (connection.frame.stop) {
                     connection.frame.stop();
                 } else {
-                    cw = connection.frame.contentWindow || connection.frame.contentDocument;
+                    cw = connection.frame.contentWindow.parent || connection.frame.contentDocument.parent;
                     if (cw.document && cw.document.execCommand) {
                         cw.document.execCommand("Stop");
                     }


### PR DESCRIPTION
Explicitly setting document.domain on a page causes the forever frame transport to throw an Access Denied error.  Grabbing the parent of `contentWindow` or `contentDocument` seems to fix the issue.
