### PR TITLE
Added IJsonWritable interface

### DIFF
--- a/SignalR/Json/IJsonSerializer.cs
+++ b/SignalR/Json/IJsonSerializer.cs
@@ -4,14 +4,14 @@ using System.IO;
 namespace SignalR
 {
     /// <summary>
-    /// Used to serialize and deserialze outgoing/incoming data.
+    /// Used to serialize and deserialize outgoing/incoming data.
     /// </summary>
     public interface IJsonSerializer
     {
         /// <summary>
         /// Serializes the specified object to a JSON string.
         /// </summary>
-        /// <param name="value">The object to serailize.</param>
+        /// <param name="value">The object to serialize.</param>
         /// <returns>A JSON string representation of the object.</returns>
         string Stringify(object value);
 

--- a/SignalR/Json/IJsonWritable.cs
+++ b/SignalR/Json/IJsonWritable.cs
@@ -1,0 +1,16 @@
+﻿using System.IO;
+
+namespace SignalR
+{
+    /// <summary>
+    /// Implementations handle their own serialization to JSON.
+    /// </summary>
+    public interface IJsonWritable
+    {
+        /// <summary>
+        /// Serializes itself to JSON via a <see cref="System.IO.TextWriter"/>.
+        /// </summary>
+        /// <param name="writer">The <see cref="System.IO.TextWriter"/> that receives the JSON serialized object.</param>
+        void WriteJson(TextWriter writer);
+    }
+}

--- a/SignalR/SignalR.csproj
+++ b/SignalR/SignalR.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Hubs\Lookup\Descriptors\Descriptor.cs" />
     <Compile Include="Infrastructure\DisposableAction.cs" />
     <Compile Include="Json\IJsonValue.cs" />
+    <Compile Include="Json\IJsonWritable.cs" />
     <Compile Include="Json\JTokenValue.cs" />
     <Compile Include="Hubs\StatefulSignalProxy.cs" />
     <Compile Include="Infrastructure\ConnectionExtensions.cs" />


### PR DESCRIPTION
JsonNetSerializer no longer explicitly checks for a PersistentResponse to decide
whether to perform special serialization logic and instead will execute custom
serialization for any class that implements the IJsonWritable interface.
