### PR TITLE
Added OnRejoiningGroups to PersistentConnection

### DIFF
--- a/SignalR.Stress/Program.cs
+++ b/SignalR.Stress/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -500,6 +501,11 @@ namespace SignalR.Stress
             // Groups.Add(Context.ConnectionId, "one").Wait();
             Groups.Add(Context.ConnectionId, "one").Wait();
             return Clients["one"].Do(index);
+        }
+
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
         }
     }
 

--- a/SignalR/Hubs/Hub.cs
+++ b/SignalR/Hubs/Hub.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace SignalR.Hubs
@@ -35,7 +36,7 @@ namespace SignalR.Hubs
         public IGroupManager Groups { get; set; }
 
         /// <summary>
-        /// Called when a connection disconects from this hub instance.
+        /// Called when a connection disconnects from this hub instance.
         /// </summary>
         /// <returns>A <see cref="Task"/></returns>
         public virtual Task Disconnect()
@@ -60,6 +61,16 @@ namespace SignalR.Hubs
         public virtual Task Reconnect(IEnumerable<string> groups)
         {
             return TaskAsyncHelper.Empty;
+        }
+
+        /// <summary>
+        /// Called before a connection completes reconnecting to this <see cref="IHub"/> instance.
+        /// </summary>
+        /// <param name="groups">The groups the reconnecting client claims to be a member of.</param>
+        /// <returns>The groups the client will actually join.</returns>
+        public virtual IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return Enumerable.Empty<string>();
         }
     }
 }

--- a/SignalR/Hubs/IConnected.cs
+++ b/SignalR/Hubs/IConnected.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace SignalR.Hubs
 {
     /// <summary>
-    /// Enables connect and reconenct notificatins for a <see cref="IHub"/>
+    /// Enables connect and reconnect notifications for a <see cref="IHub"/>
     /// </summary>
     /// <example>
     /// public class MyHub : Hub, IConnected
@@ -28,9 +28,16 @@ namespace SignalR.Hubs
         Task Connect();
 
         /// <summary>
-        /// Called when a connection reconencts to the <see cref="IHub"/> after a timeout.
+        /// Called when a connection reconnects to the <see cref="IHub"/> after a timeout.
         /// </summary>
-        /// <param name="groups">The groups the connection are a member of.</param>
+        /// <param name="groups">The groups the connection is a member of.</param>
         Task Reconnect(IEnumerable<string> groups);
+
+        /// <summary>
+        /// Called before a connection completes reconnecting to the <see cref="IHub"/> after a timeout.
+        /// </summary>
+        /// <param name="groups">The groups the reconnecting client claims to be a member of.</param>
+        /// <returns>The groups the client will actually join.</returns>
+        IEnumerable<string> RejoiningGroups(IEnumerable<string> groups);
     }
 }

--- a/SignalR/MessageBus/DefaultSubscription.cs
+++ b/SignalR/MessageBus/DefaultSubscription.cs
@@ -35,29 +35,34 @@ namespace SignalR
             }
             else
             {
-                cursors = Cursor.GetCursors(cursor);
+               cursors = Cursor.GetCursors(cursor);
             }
 
             _cursors = new List<Cursor>(cursors);
             _cursorTopics = new List<Topic>();
 
+            if (!String.IsNullOrEmpty(cursor))
+            {
+                // Update all of the cursors so we're within the range
+                for (int i = _cursors.Count - 1; i >= 0; i--)
+                {
+                    Cursor c = _cursors[i];
+                    Topic topic;
+                    if (!eventKeys.Contains(c.Key))
+                    {
+                        _cursors.Remove(c);
+                    }
+                    else if (topics.TryGetValue(_cursors[i].Key, out topic) && _cursors[i].Id > topic.Store.GetMessageCount())
+                    {
+                        UpdateCursor(c.Key, 0);
+                    }
+                }
+            }
+
             // Add dummy entries so they can be filled in
             for (int i = 0; i < _cursors.Count; i++)
             {
                 _cursorTopics.Add(null);
-            }
-
-            if (!String.IsNullOrEmpty(cursor))
-            {
-                // Update all of the cursors so we're within the range
-                foreach (var pair in _cursors)
-                {
-                    Topic topic;
-                    if (topics.TryGetValue(pair.Key, out topic) && pair.Id > topic.Store.GetMessageCount())
-                    {
-                        UpdateCursor(pair.Key, 0);
-                    }
-                }
             }
         }
 

--- a/SignalR/PersistentConnection.cs
+++ b/SignalR/PersistentConnection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using SignalR.Infrastructure;
 using SignalR.Transports;
@@ -120,9 +121,10 @@ namespace SignalR
                 throw new InvalidOperationException("Protocol error: Missing connection id.");
             }
 
-            var groups = new List<string>(_transport.Groups);
+            IEnumerable<string> signals = GetSignals(connectionId, context.Request);
+            IEnumerable<string> groups = OnRejoiningGroups(context.Request, _transport.Groups, connectionId);
 
-            Connection connection = CreateConnection(connectionId, groups, context.Request);
+            Connection connection = CreateConnection(connectionId, signals, groups);
 
             Connection = connection;
             Groups = new GroupManager(connection, DefaultSignal);
@@ -161,13 +163,13 @@ namespace SignalR
             return _transport.ProcessRequest(connection).OrEmpty().Catch(_allErrorsTotalCounter, _allErrorsPerSecCounter);
         }
 
-        protected virtual Connection CreateConnection(string connectionId, IEnumerable<string> groups, IRequest request)
+        protected virtual Connection CreateConnection(string connectionId, IEnumerable<string> signals, IEnumerable<string> groups)
         {
             return new Connection(_newMessageBus,
                                   _jsonSerializer,
                                   DefaultSignal,
                                   connectionId,
-                                  GetDefaultSignals(connectionId),
+                                  signals,
                                   groups,
                                   _trace,
                                   _counters);
@@ -190,6 +192,28 @@ namespace SignalR
                 connectionId,
                 "ACK_" + connectionId
             };
+        }
+
+        /// <summary>
+        /// Returns the signals used in the <see cref="PersistentConnection"/>.
+        /// </summary>
+        /// <param name="connectionId">The id of the incoming connection.</param>
+        /// <returns>The signals used for this <see cref="PersistentConnection"/>.</returns>
+        protected virtual IEnumerable<string> GetSignals(string connectionId, IRequest request)
+        {
+            return GetDefaultSignals(connectionId);
+        }
+
+        /// <summary>
+        /// Called when a connection reconnects after a timeout to determine which groups should be rejoined.
+        /// </summary>
+        /// <param name="request">The <see cref="IRequest"/> for the current connection.</param>
+        /// <param name="groups">The groups the calling connection claims to be part of.</param>
+        /// <param name="connectionId">The id of the reconnecting client.</param>
+        /// <returns>A collection of group names that should be joined on reconnect</returns>
+        protected virtual IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+        {
+            return Enumerable.Empty<string>();
         }
 
         /// <summary>

--- a/samples/SignalR.Client.Samples/Program.cs
+++ b/samples/SignalR.Client.Samples/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using SignalR.Client.Hubs;
+using System.Collections.Generic;
 #if !NET35
 using SignalR.Hosting.Memory;
 #endif
@@ -200,6 +201,11 @@ namespace SignalR.Client.Samples
             protected override Task OnReceivedAsync(IRequest request, string connectionId, string data)
             {
                 return Connection.Broadcast(data);
+            }
+
+            protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+            {
+                return groups;
             }
         }
 #endif

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/Benchmark/HubBench.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/Benchmark/HubBench.cs
@@ -43,5 +43,10 @@ namespace SignalR.Samples.Hubs.Benchmark
             Interlocked.Decrement(ref HubBench.Connections);
             return null;
         }
+
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
+        }
     }
 }

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/Chat/Chat.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/Chat/Chat.cs
@@ -149,6 +149,11 @@ namespace SignalR.Samples.Hubs.Chat
             return null;
         }
 
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
+        }
+
         public IEnumerable<ChatUser> GetUsers()
         {
             string room = Caller.room;

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/ConnectDisconnect/Status.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/ConnectDisconnect/Status.cs
@@ -22,5 +22,10 @@ namespace SignalR.Samples.Hubs.ConnectDisconnect
         {
             return Clients.rejoined(Context.ConnectionId, DateTime.Now.ToString());
         }
+
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
+        }
     }
 }

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/DemoHub/DemoHub.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/DemoHub/DemoHub.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using SignalR.Hubs;
@@ -145,6 +146,11 @@ namespace SignalR.Samples.Hubs.DemoHub
         public void MispelledClientMethod()
         {
             Caller.clientMethd();
+        }
+
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
         }
 
         public class Person

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/DrawingPad/DrawingPad.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/DrawingPad/DrawingPad.cs
@@ -1,5 +1,6 @@
 ﻿using SignalR.Hubs;
 using System.Threading;
+using System.Collections.Generic;
 
 namespace SignalR.Hosting.AspNet.Samples.Hubs.DrawingPad
 {
@@ -40,6 +41,11 @@ namespace SignalR.Hosting.AspNet.Samples.Hubs.DrawingPad
         {
             // ... propagate it to all users
             Clients.lineDrawed(Caller.id, data);
+        }
+
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
         }
     }
 }

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/MouseTracking/MouseTracking.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/MouseTracking/MouseTracking.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 using SignalR.Hubs;
 
 namespace SignalR.Samples.Hubs.MouseTracking
@@ -15,6 +16,11 @@ namespace SignalR.Samples.Hubs.MouseTracking
         public void Move(int x, int y)
         {
             Clients.moveMouse(Caller.id, x, y);
+        }
+
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
         }
     }
 }

--- a/samples/SignalR.Hosting.AspNet.Samples/Hubs/ShapeShare/ShapeShare.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Hubs/ShapeShare/ShapeShare.cs
@@ -112,6 +112,11 @@ namespace SignalR.Samples.Hubs.ShapeShare
             Clients.shapesDeleted(shapes);
         }
 
+        public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
+        {
+            return groups;
+        }
+
         private Shape FindShape(string id)
         {
             return _shapes[id];

--- a/samples/SignalR.Hosting.AspNet.Samples/Raw/Raw.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Raw/Raw.cs
@@ -103,6 +103,11 @@ namespace SignalR.Samples.Raw
             return base.OnReceivedAsync(request, connectionId, data);
         }
 
+        protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+        {
+            return groups;
+        }
+
         private string GetUser(string connectionId)
         {
             string user;

--- a/samples/SignalR.Hosting.AspNet.Samples/Raw/SendingConnection.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Raw/SendingConnection.cs
@@ -17,5 +17,10 @@ namespace SignalR.Hosting.AspNet.Samples
             tcs.TrySetResult(null);
             return tcs.Task;
         }
+
+        protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+        {
+            return groups;
+        }
     }
 }

--- a/samples/SignalR.Hosting.AspNet.Samples/Raw/TestConnection.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Raw/TestConnection.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SignalR.Hosting.AspNet.Samples
 {
@@ -7,6 +8,11 @@ namespace SignalR.Hosting.AspNet.Samples
         protected override Task OnReceivedAsync(IRequest request, string connectionId, string data)
         {
             return Connection.Send(connectionId, data);
+        }
+
+        protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+        {
+            return groups;
         }
     }
 }

--- a/samples/SignalR.Hosting.AspNet.Samples/Streaming/Streaming.cs
+++ b/samples/SignalR.Hosting.AspNet.Samples/Streaming/Streaming.cs
@@ -1,7 +1,12 @@
-﻿
+﻿using System.Collections.Generic;
+
 namespace SignalR.Samples.Streaming
 {
     public class Streaming : PersistentConnection
     {
+        protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+        {
+            return groups;
+        }
     }
 }

--- a/samples/SignalR.Hosting.Self.Samples/Program.cs
+++ b/samples/SignalR.Hosting.Self.Samples/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using SignalR.Samples.Raw;
@@ -52,6 +53,11 @@ namespace SignalR.Hosting.Self.Samples
             {
                 Console.WriteLine("{0} left", connectionId);
                 return base.OnDisconnectAsync(connectionId);
+            }
+
+            protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
+            {
+                return groups;
             }
         }
     }


### PR DESCRIPTION
Fixes Issue #525

OnRejoiningGroups takes a list of groups a reconnecting client claims to be a
member of and returns a list of groups the client should actually rejoin.

The default implementation of OnRejoiningGroups always returns an empty
list of groups since the list of groups a client claims to be a member of
cannot be trusted.

Hub.RejoiningGroups is analogous to PersistentConnection.OnRejoiningGroups
