### PR TITLE
Updated HubPipelineModule.OnIncommingError signature

### DIFF
--- a/SignalR/Hubs/Pipeline/HubPipelineModule.cs
+++ b/SignalR/Hubs/Pipeline/HubPipelineModule.cs
@@ -18,7 +18,7 @@ namespace SignalR.Hubs
                 {
                     return invoke(context).OrEmpty()
                                           .Then(result => OnAfterIncoming(result, context))
-                                          .Catch(ex => OnIncomingError(ex));
+                                          .Catch(ex => OnIncomingError(ex, context));
                 }
 
                 return TaskAsyncHelper.FromResult<object>(null);
@@ -131,7 +131,7 @@ namespace SignalR.Hubs
             return result;
         }
 
-        protected virtual void OnIncomingError(Exception ex)
+        protected virtual void OnIncomingError(AggregateException ex, IHubIncomingInvokerContext context)
         {
 
         }

--- a/SignalR/TaskAsyncHelper.cs
+++ b/SignalR/TaskAsyncHelper.cs
@@ -86,7 +86,7 @@ namespace SignalR
         }
 #endif
 
-        public static TTask Catch<TTask>(this TTask task, Action<Exception> handler) where TTask : Task
+        public static TTask Catch<TTask>(this TTask task, Action<AggregateException> handler) where TTask : Task
         {
             if (task != null && task.Status != TaskStatus.RanToCompletion)
             {


### PR DESCRIPTION
OnIncommingError now takes an IHubIncomingInvokerContext and AggregateException
as parameters.
