### PR TITLE
Removed the RejoiningGroups method on hubs.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Hub.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Hub.cs
@@ -60,16 +60,6 @@ namespace Microsoft.AspNet.SignalR.Hubs
             return TaskAsyncHelper.Empty;
         }
 
-        /// <summary>
-        /// Called before a connection completes reconnecting to this <see cref="IHub"/> instance.
-        /// </summary>
-        /// <param name="groups">The groups the reconnecting client claims to be a member of.</param>
-        /// <returns>The groups the client will actually join.</returns>
-        public virtual IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
-        {
-            return Enumerable.Empty<string>();
-        }
-
         public virtual void Dispose()
         {
         }

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
@@ -170,11 +170,6 @@ namespace Microsoft.AspNet.SignalR.Hubs
             return hub.OnDisconnected();
         }
 
-        internal static IEnumerable<string> RejoiningGroups(IHub hub, IEnumerable<string> groups)
-        {
-            return hub.RejoiningGroups(groups);
-        }
-
         internal static Task<object> Incoming(IHubIncomingInvokerContext context)
         {
             var tcs = new TaskCompletionSource<object>();
@@ -248,14 +243,12 @@ namespace Microsoft.AspNet.SignalR.Hubs
 
         protected override IEnumerable<string> OnRejoiningGroups(IRequest request, IEnumerable<string> groups, string connectionId)
         {
-            return GetHubs(request, connectionId)
-                   .Select(hub =>
+            return _hubs.Select(hub =>
                    {
-                       string groupPrefix = hub.GetType().Name + ".";
-                       IEnumerable<string> groupsToRejoin = _pipelineInvoker.RejoiningGroups(hub, groups.Where(g => g.StartsWith(groupPrefix))
+                       string groupPrefix = hub.Type.Name + ".";
+                       IEnumerable<string> groupsToRejoin = _pipelineInvoker.RejoiningGroups(hub, request, groups.Where(g => g.StartsWith(groupPrefix))
                                                                                                          .Select(g => g.Substring(groupPrefix.Length)))
                                                                              .Select(g => groupPrefix + g).ToList();
-                       hub.Dispose();
                        return groupsToRejoin;
                    })
                    .SelectMany(groupsToRejoin => groupsToRejoin);

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/IHub.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/IHub.cs
@@ -22,13 +22,6 @@ namespace Microsoft.AspNet.SignalR.Hubs
         IGroupManager Groups { get; set; }
 
         /// <summary>
-        /// Called before a connection completes reconnecting to the <see cref="IHub"/> after a timeout.
-        /// </summary>
-        /// <param name="groups">The groups the reconnecting client claims to be a member of.</param>
-        /// <returns>The groups the client will actually join.</returns>
-        IEnumerable<string> RejoiningGroups(IEnumerable<string> groups);
-
-        /// <summary>
         /// Called when a new connection is made to the <see cref="IHub"/>.
         /// </summary>
         Task OnConnected();

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/AutoRejoiningGroupsModule.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/AutoRejoiningGroupsModule.cs
@@ -8,9 +8,9 @@ namespace Microsoft.AspNet.SignalR.Hubs
     /// </summary>
     public class AutoRejoiningGroupsModule : HubPipelineModule
     {
-        public override Func<IHub, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<IHub, IEnumerable<string>, IEnumerable<string>> rejoiningGroups)
+        public override Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> rejoiningGroups)
         {
-            return (hub, groups) => groups;
+            return (hub, request, groups) => groups;
         }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/HubPipeline.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/HubPipeline.cs
@@ -56,9 +56,9 @@ namespace Microsoft.AspNet.SignalR.Hubs
             return Pipeline.AuthorizeConnect(hubDescriptor, request);
         }
 
-        public IEnumerable<string> RejoiningGroups(IHub hub, IEnumerable<string> groups)
+        public IEnumerable<string> RejoiningGroups(HubDescriptor hubDescriptor, IRequest request, IEnumerable<string> groups)
         {
-            return Pipeline.RejoiningGroups(hub, groups);
+            return Pipeline.RejoiningGroups(hubDescriptor, request, groups);
         }
 
         public Task Send(IHubOutgoingInvokerContext context)
@@ -74,7 +74,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             public Func<IHub, Task> Reconnect;
             public Func<IHub, Task> Disconnect;
             public Func<HubDescriptor, IRequest, bool> AuthorizeConnect;
-            public Func<IHub, IEnumerable<string>, IEnumerable<string>> RejoiningGroups;
+            public Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> RejoiningGroups;
             public Func<IHubOutgoingInvokerContext, Task> Send;
 
             public ComposedPipeline(Stack<IHubPipelineModule> modules)
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
                 Reconnect = Compose<Func<IHub, Task>>(modules, (m, f) => m.BuildReconnect(f))(HubDispatcher.Reconnect);
                 Disconnect = Compose<Func<IHub, Task>>(modules, (m, f) => m.BuildDisconnect(f))(HubDispatcher.Disconnect);
                 AuthorizeConnect = Compose<Func<HubDescriptor, IRequest, bool>>(modules, (m, f) => m.BuildAuthorizeConnect(f))((h, r) => true);
-                RejoiningGroups = Compose<Func<IHub, IEnumerable<string>, IEnumerable<string>>>(modules, (m, f) => m.BuildRejoiningGroups(f))(HubDispatcher.RejoiningGroups);
+                RejoiningGroups = Compose<Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>>>(modules, (m, f) => m.BuildRejoiningGroups(f))((h, r, g) => Enumerable.Empty<string>());
                 Send = Compose<Func<IHubOutgoingInvokerContext, Task>>(modules, (m, f) => m.BuildOutgoing(f))(HubDispatcher.Outgoing);
             }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/HubPipelineModule.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/HubPipelineModule.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             };
         }
 
-        public virtual Func<IHub, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<IHub, IEnumerable<string>, IEnumerable<string>> rejoiningGroups)
+        public virtual Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> rejoiningGroups)
         {
             return rejoiningGroups;
         }

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/IHubPipelineInvoker.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/IHubPipelineInvoker.cs
@@ -54,9 +54,10 @@ namespace Microsoft.AspNet.SignalR.Hubs
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="hub"></param>
+        /// <param name="hubDescriptor"></param>
+        /// <param name="request"></param>
         /// <param name="groups"></param>
         /// <returns></returns>
-        IEnumerable<string> RejoiningGroups(IHub hub, IEnumerable<string> groups);
+        IEnumerable<string> RejoiningGroups(HubDescriptor hubDescriptor, IRequest request, IEnumerable<string> groups);
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/IHubPipelineModule.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Pipeline/IHubPipelineModule.cs
@@ -56,6 +56,6 @@ namespace Microsoft.AspNet.SignalR.Hubs
         /// </summary>
         /// <param name="rejoiningGroups"></param>
         /// <returns></returns>
-        Func<IHub, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<IHub, IEnumerable<string>, IEnumerable<string>> rejoiningGroups);
+        Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> rejoiningGroups);
     }
 }

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/Hubs/HubFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/Hubs/HubFacts.cs
@@ -394,59 +394,6 @@ namespace Microsoft.AspNet.SignalR.Tests
         }
 
         [Fact]
-        public void HubGroupsRejoinWhenRejoiningGroupsOverridden()
-        {
-            var host = new MemoryHost();
-            host.Configuration.KeepAlive = null;
-            host.Configuration.ConnectionTimeout = TimeSpan.FromSeconds(1);
-            host.Configuration.HeartBeatInterval = TimeSpan.FromSeconds(1);
-            host.MapHubs();
-            int max = 10;
-
-            var countDown = new CountDownRange<int>(Enumerable.Range(0, max));
-            var countDownAfterReconnect = new CountDownRange<int>(Enumerable.Range(max, max));
-            var connection = new Client.Hubs.HubConnection("http://foo");
-            var proxy = connection.CreateProxy("RejoinMultGroupHub");
-
-            proxy.On<User>("onRoomJoin", u =>
-            {
-                if (u.Index < max)
-                {
-                    Assert.True(countDown.Mark(u.Index));
-                }
-                else
-                {
-                    Assert.True(countDownAfterReconnect.Mark(u.Index));
-                }
-            });
-
-            connection.Start(host).Wait();
-
-            var user = new User { Name = "tester" };
-            proxy.Invoke("login", user).Wait();
-
-            for (int i = 0; i < max; i++)
-            {
-                user.Index = i;
-                proxy.Invoke("joinRoom", user).Wait();
-            }
-
-            // Force Reconnect
-            Thread.Sleep(TimeSpan.FromSeconds(3));
-
-            for (int i = max; i < 2 * max; i++)
-            {
-                user.Index = i;
-                proxy.Invoke("joinRoom", user).Wait();
-            }
-
-            Assert.True(countDown.Wait(TimeSpan.FromSeconds(30)), "Didn't receive " + max + " messages. Got " + (max - countDown.Count) + " missed " + String.Join(",", countDown.Left.Select(i => i.ToString())));
-            Assert.True(countDownAfterReconnect.Wait(TimeSpan.FromSeconds(30)), "Didn't receive " + max + " messages. Got " + (max - countDownAfterReconnect.Count) + " missed " + String.Join(",", countDownAfterReconnect.Left.Select(i => i.ToString())));
-
-            connection.Stop();
-        }
-
-        [Fact]
         public void HubGroupsRejoinWhenAutoRejoiningGroupsEnabled()
         {
             var host = new MemoryHost();
@@ -503,19 +450,18 @@ namespace Microsoft.AspNet.SignalR.Tests
         [Fact]
         public void RejoiningGroupsOnlyReceivesGroupsBelongingToHub()
         {
+            var logRejoiningGroups = new LogRejoiningGroupsModule();
             var host = new MemoryHost();
-            var groupsRequestedToBeRejoined = new List<string>();
-            var groupsRequestedToBeRejoined2 = new List<string>();
-            host.DependencyResolver.Register(typeof(RejoinMultGroupHub), () => new RejoinMultGroupHub(groupsRequestedToBeRejoined));
-            host.DependencyResolver.Register(typeof(RejoinMultGroupHub2), () => new RejoinMultGroupHub2(groupsRequestedToBeRejoined2));
+            host.HubPipeline.AddModule(logRejoiningGroups);
+
             host.Configuration.KeepAlive = null;
             host.Configuration.ConnectionTimeout = TimeSpan.FromSeconds(1);
             host.Configuration.HeartBeatInterval = TimeSpan.FromSeconds(1);
             host.MapHubs();
 
             var connection = new Client.Hubs.HubConnection("http://foo");
-            var proxy = connection.CreateProxy("RejoinMultGroupHub");
-            var proxy2 = connection.CreateProxy("RejoinMultGroupHub2");
+            var proxy = connection.CreateProxy("MultGroupHub");
+            var proxy2 = connection.CreateProxy("MultGroupHub2");
 
             connection.Start(host).Wait();
 
@@ -531,14 +477,15 @@ namespace Microsoft.AspNet.SignalR.Tests
 
             Thread.Sleep(TimeSpan.FromSeconds(3));
 
-            Assert.True(groupsRequestedToBeRejoined.Contains("foo"));
-            Assert.True(groupsRequestedToBeRejoined.Contains("tester"));
-            Assert.False(groupsRequestedToBeRejoined.Contains("foo2"));
-            Assert.False(groupsRequestedToBeRejoined.Contains("tester2"));
-            Assert.True(groupsRequestedToBeRejoined2.Contains("foo2"));
-            Assert.True(groupsRequestedToBeRejoined2.Contains("tester2"));
-            Assert.False(groupsRequestedToBeRejoined2.Contains("foo"));
-            Assert.False(groupsRequestedToBeRejoined2.Contains("tester"));
+            //logRejoiningGroups.GroupsRejoined["RejoinMultGroupHub2"]
+            Assert.True(logRejoiningGroups.GroupsRejoined["MultGroupHub"].Contains("foo"));
+            Assert.True(logRejoiningGroups.GroupsRejoined["MultGroupHub"].Contains("tester"));
+            Assert.False(logRejoiningGroups.GroupsRejoined["MultGroupHub"].Contains("foo2"));
+            Assert.False(logRejoiningGroups.GroupsRejoined["MultGroupHub"].Contains("tester2"));
+            Assert.True(logRejoiningGroups.GroupsRejoined["MultGroupHub2"].Contains("foo2"));
+            Assert.True(logRejoiningGroups.GroupsRejoined["MultGroupHub2"].Contains("tester2"));
+            Assert.False(logRejoiningGroups.GroupsRejoined["MultGroupHub2"].Contains("foo"));
+            Assert.False(logRejoiningGroups.GroupsRejoined["MultGroupHub2"].Contains("tester"));
 
             connection.Stop();
         }
@@ -865,30 +812,8 @@ namespace Microsoft.AspNet.SignalR.Tests
             }
         }
 
-        public class RejoinMultGroupHub : MultGroupHub
+        public class MultGroupHub2 : MultGroupHub
         {
-            private List<string> _groupsRequestedToBeRejoined;
-
-            public RejoinMultGroupHub() : this(new List<string>()) { }
-
-            public RejoinMultGroupHub(List<string> groupsRequestedToBeRejoined)
-            {
-                _groupsRequestedToBeRejoined = groupsRequestedToBeRejoined;
-            }
-
-            public override IEnumerable<string> RejoiningGroups(IEnumerable<string> groups)
-            {
-                _groupsRequestedToBeRejoined.AddRange(groups);
-                return groups;
-            }
-        }
-
-        public class RejoinMultGroupHub2 : RejoinMultGroupHub
-        {
-            public RejoinMultGroupHub2() : this(new List<string>()) { }
-
-            public RejoinMultGroupHub2(List<string> groupsRequestedToBeRejoined) : base(groupsRequestedToBeRejoined) { }
-
             public override Task Login(User user)
             {
                 return Task.Factory.StartNew(
@@ -900,6 +825,27 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Groups.Remove(Context.ConnectionId, user.Name + "2").Wait();
                         Groups.Add(Context.ConnectionId, user.Name + "2").Wait();
                     });
+            }
+        }
+
+        public class LogRejoiningGroupsModule : HubPipelineModule
+        {
+            public Dictionary<string, List<string>> GroupsRejoined = new Dictionary<string,List<string>>();
+
+            public override Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> BuildRejoiningGroups(Func<HubDescriptor, IRequest, IEnumerable<string>, IEnumerable<string>> rejoiningGroups)
+            {
+                return (hub, request, groups) =>
+                {
+                    if (!GroupsRejoined.ContainsKey(hub.Name))
+                    {
+                        GroupsRejoined[hub.Name] = new List<string>(groups);
+                    }
+                    else
+                    {
+                        GroupsRejoined[hub.Name].AddRange(groups);
+                    }
+                    return groups;
+                };
             }
         }
 


### PR DESCRIPTION
No longer create new hubs before a connection is created.
