### PR TITLE
GC topics on a background timer.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Configuration/DefaultConfigurationManager.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Configuration/DefaultConfigurationManager.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNet.SignalR
         public DefaultConfigurationManager()
         {
             ConnectionTimeout = TimeSpan.FromSeconds(110);
-            DisconnectTimeout = TimeSpan.FromSeconds(20);
+            DisconnectTimeout = TimeSpan.FromSeconds(40);
             HeartBeatInterval = TimeSpan.FromSeconds(10);
             KeepAlive = TimeSpan.FromSeconds(30);
         }

--- a/src/Microsoft.AspNet.SignalR.Stress/Infrastructure/Utility.cs
+++ b/src/Microsoft.AspNet.SignalR.Stress/Infrastructure/Utility.cs
@@ -14,5 +14,23 @@ namespace Microsoft.AspNet.SignalR.Stress.Infrastructure
         {
             resolver.InitializePerformanceCounters(Process.GetCurrentProcess().GetUniqueInstanceName(cancellationToken), cancellationToken);
         }
+
+        public static string FormatBytes(long bytes)
+        {
+            const int scale = 1024;
+            string[] orders = new string[] { "GB", "MB", "KB", "Bytes" };
+            long max = (long)Math.Pow(scale, orders.Length - 1);
+
+            foreach (string order in orders)
+            {
+                if (bytes > max)
+                {
+                    return String.Format("{0:##.##} {1}", Decimal.Divide(bytes, max), order);
+                }
+
+                max /= scale;
+            }
+            return "0 Bytes";
+        }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Stress/Program.cs
+++ b/src/Microsoft.AspNet.SignalR.Stress/Program.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.AspNet.SignalR.Stress.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Stress
 {
@@ -10,11 +11,25 @@ namespace Microsoft.AspNet.SignalR.Stress
         static void Main(string[] args)
         {
             IDisposable run = CreateRun(args);
+            long memory = 0;
 
             using (run)
             {
-                Console.ReadLine();
+                memory = GC.GetTotalMemory(forceFullCollection: false);
+
+                Console.WriteLine("Before GC {0}", Utility.FormatBytes(memory));
+                Console.ReadKey();
+
+                memory = GC.GetTotalMemory(forceFullCollection: true);
+
+                Console.WriteLine("After GC and before dispose {0}", Utility.FormatBytes(memory));
+                Console.ReadKey();
             }
+
+            memory = GC.GetTotalMemory(forceFullCollection: true);
+
+            Console.WriteLine("After GC and dispose {0}", Utility.FormatBytes(memory));
+            Console.ReadKey();
         }
 
         private static IDisposable CreateRun(string[] args)
@@ -30,7 +45,8 @@ namespace Microsoft.AspNet.SignalR.Stress
             // return MessageBusRun.Run(connections, senders, payload);
             // return ConnectionRun.LongRunningSubscriptionRun(connections, senders, payload);
             // return ConnectionRun.ReceiveLoopRun(connections, senders, payload);
-            return MemoryHostRun.Run(connections, senders, payload, "serverSentEvents");
+            // return MemoryHostRun.Run(connections, senders, payload, "serverSentEvents");
+            return StressRuns.RunConnectDisconnect(connections);
         }
 
         private static string GetPayload(int n = 32)

--- a/src/Microsoft.AspNet.SignalR.Stress/StressRuns.cs
+++ b/src/Microsoft.AspNet.SignalR.Stress/StressRuns.cs
@@ -59,9 +59,6 @@ namespace Microsoft.AspNet.SignalR.Stress
                 finally
                 {
                     connection.Stop();
-
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
                 }
             }
 
@@ -98,12 +95,6 @@ namespace Microsoft.AspNet.SignalR.Stress
                     connection.Stop();
                 }
             }
-
-            Console.WriteLine("Before GC");
-            Console.ReadLine();
-
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
 
             return host;
         }

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/DisconnectFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/DisconnectFacts.cs
@@ -76,7 +76,8 @@ namespace Microsoft.AspNet.SignalR.Tests
         {
             // Each node shares the same bus but are indepenent servers
             var counters = new SignalR.Infrastructure.PerformanceCounterManager();
-            using (var bus = new MessageBus(new TraceManager(), counters))
+            var configurationManager = new DefaultConfigurationManager();
+            using (var bus = new MessageBus(new TraceManager(), counters, configurationManager))
             {
                 var nodeCount = 3;
                 var nodes = new List<ServerNode>();


### PR DESCRIPTION
- Clean up topics so we don't leak indefinitely.
- Topics expire after the disconnect interval.
- Cleaned up stress.exe to show memory after run at different stages.
- Increased default disconnect timeout from 20 to 40 seconds.
