### PR TITLE
Handle failing transport errors more gracefully.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/TaskQueue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/TaskQueue.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
 #if NET45
                 Task newTask = _lastQueuedTask.ContinueWith(_ => taskFunc(), TaskContinuationOptions.OnlyOnRanToCompletion).Unwrap();
 #else
-                Task newTask = _lastQueuedTask.ContinueWith(_ => taskFunc(), TaskContinuationOptions.OnlyOnRanToCompletion).FastUnwrap();
+                Task newTask = _lastQueuedTask.Then(next => next(), taskFunc);
 #endif
                 _lastQueuedTask = newTask;
                 return newTask;

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverFrameTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverFrameTransport.cs
@@ -53,7 +53,7 @@ namespace Microsoft.AspNet.SignalR.Transports
                 OutputWriter.Write(");</script>\r\n");
                 OutputWriter.Flush();
 
-                return Context.Response.FlushAsync().Catch(IncrementErrorCounters);
+                return Context.Response.FlushAsync();
             });
         }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNet.SignalR.Transports
                 JsonSerializer.Serialize(value, OutputWriter);
                 OutputWriter.Flush();
 
-                return Context.Response.EndAsync();
+                return Context.Response.EndAsync().Catch(IncrementErrorCounters);
             });
         }
 
@@ -301,7 +301,9 @@ namespace Microsoft.AspNet.SignalR.Transports
                     }
                     else
                     {
-                        return Send(response).Then(() => TaskAsyncHelper.True);
+                        return Send(response).Then(() => TaskAsyncHelper.True)
+                                             .Catch(IncrementErrorCounters)
+                                             .Catch(ex => End());
                     }
                 },
                 MaxMessages);

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ServerSentEventsTransport.cs
@@ -38,7 +38,7 @@ namespace Microsoft.AspNet.SignalR.Transports
                 OutputWriter.WriteLine();
                 OutputWriter.Flush();
 
-                return Context.Response.FlushAsync().Catch(IncrementErrorCounters);
+                return Context.Response.FlushAsync();
             });
         }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/TransportHeartBeat.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/TransportHeartBeat.cs
@@ -210,7 +210,15 @@ namespace Microsoft.AspNet.SignalR.Transports
                 // of us handling timeout's or disconnects gracefully
                 if (RaiseKeepAlive(metadata))
                 {
-                    metadata.Connection.KeepAlive().Catch();
+                    // If the keep alive send fails then kill the connection
+                    metadata.Connection.KeepAlive()
+                                       .Catch(ex =>
+                                       {
+                                           RemoveConnection(metadata.Connection);
+
+                                           metadata.Connection.End();
+                                       });
+
                     metadata.UpdateKeepAlive(_configurationManager.KeepAlive);
                 }
 


### PR DESCRIPTION
- When failing to send to a transport, end the connection
  under the assumption that the transport failing because the
  connection is "broken".
- Optimize the task queue on .NET 4.0 so that it's synchronous,
  if the function isn't async or completes quickly. Also
  avoid creating a closure.
- Kill the connection if keep alive fails to be sent.
- Handle transport errors in a more central place.
