### PR TITLE
Don't emit the UTF8 BOM in the response stream

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Transports/TransportDisconnectBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/TransportDisconnectBase.cs
@@ -103,7 +103,7 @@ namespace Microsoft.AspNet.SignalR.Transports
             {
                 if (_outputWriter == null)
                 {
-                    _outputWriter = new StreamWriter(Context.Response.AsStream(), Encoding.UTF8);
+                    _outputWriter = new StreamWriter(Context.Response.AsStream(), new UTF8Encoding(false));
                     _outputWriter.NewLine = "\n";
                 }
 


### PR DESCRIPTION
By default, a `StreamWriter` opened with `Encoding.UTF8` includes the UTF 8 byte-order-mark, which causes issues with consumers that don't expect it (Java & Node.js apps being a couple examples).

The proposal here is to _not_ include the UTF8 BOM with the response, in order to make life easier on consumers (like `hubot-jabbr`), which fail upon reading the BOM.  This also saves an amazing 3 bytes!

Another minor benefit is that this brings consistency to `PersistentConnection`, `ForeverTransport`, and `LongPollingTransport`.  `PersistentConnection` doesn't send the BOM, while the other two do.
