### PR TITLE
Extend JSON MimeTypes with 'charset=utf-8'

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Json/Json.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/Json.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.SignalR
         /// </summary>
         public static string MimeType
         {
-            get { return "application/json"; }
+            get { return "application/json; charset=UTF-8"; }
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.SignalR
         /// </summary>
         public static string JsonpMimeType
         {
-            get { return "text/javascript"; }
+            get { return "text/javascript; charset=UTF-8"; }
         }
 
         public static string CreateJsonpCallback(string callback, string payload)

--- a/tests/Microsoft.AspNet.SignalR.Tests/Json/JsonFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Json/JsonFacts.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Json
             string mimeType = Microsoft.AspNet.SignalR.Json.MimeType;
 
             // Assert
-            Assert.Equal("application/json", mimeType);
+            Assert.Equal("application/json; charset=UTF-8", mimeType);
         }
 
         [Fact]
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Json
             string mimeType = Microsoft.AspNet.SignalR.Json.JsonpMimeType;
 
             // Assert
-            Assert.Equal("text/javascript", mimeType);
+            Assert.Equal("text/javascript; charset=UTF-8", mimeType);
         }
 
         [Fact]


### PR DESCRIPTION
SignalR returns data encoded in UTF8.

This commit extends and explicitly sets the mimetype/content-type to 'charset=UTF-8', in order to help inform clients of the body's encoded format.
