### PR TITLE
Add -noprofile to powershell execution to prevent potential conflicts

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/Microsoft.AspNet.SignalR.Client.JS.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/Microsoft.AspNet.SignalR.Client.JS.csproj
@@ -118,6 +118,6 @@
   </Target>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
     <PostBuildEvent>cd $(ProjectDir)
-powershell -ExecutionPolicy Bypass $(ProjectDir)build.ps1</PostBuildEvent>
+powershell -NoProfile -ExecutionPolicy Bypass $(ProjectDir)build.ps1</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
I just added the -NoProfile argument since my custom profile conflicted with what the powershell scripts were doing.
