### PR TITLE
Fixed problem with using HubName attribute and groups.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
@@ -296,7 +296,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
         {
             return _hubs.Select(hubDescriptor =>
             {
-                string groupPrefix = hubDescriptor.HubType.Name + ".";
+                string groupPrefix = hubDescriptor.Name + ".";
                 IEnumerable<string> groupsToRejoin = _pipelineInvoker.RejoiningGroups(hubDescriptor,
                                                                                       request,
                                                                                       groups.Where(g => g.StartsWith(groupPrefix, StringComparison.OrdinalIgnoreCase))

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Hubs/ChatWithGroups.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Hubs/ChatWithGroups.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Hubs;
+
+namespace Microsoft.AspNet.SignalR.FunctionalTests.Hubs
+{
+    [HubName("groupChat")]
+    public class ChatWithGroups : Hub
+    {
+        public void Send(string group, string message)
+        {
+            Clients.Group(group).send(message);
+        }
+
+        public void Join(string group)
+        {
+            Groups.Add(Context.ConnectionId, group);
+        }
+
+        public void Leave(string group)
+        {
+            Groups.Remove(Context.ConnectionId, group);
+        }
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Connections\MyReconnect.cs" />
     <Compile Include="Connections\MyRejoinGroupsConnection.cs" />
     <Compile Include="Connections\MySendingConnection.cs" />
+    <Compile Include="Hubs\ChatWithGroups.cs" />
     <Compile Include="Hubs\MyItemsHub.cs" />
     <Compile Include="Infrastructure\ClientAssertExtensions.cs" />
     <Compile Include="Infrastructure\CountDownRange.cs" />


### PR DESCRIPTION
- When rejoining groups we were using the hub's type name
  instead of the resolved name (name with or without the attribute).
  This causes issues groups to fail on reconnect even with
  EnableRejoiningGroups turned on.
