### PR TITLE
Update src/Microsoft.AspNet.SignalR.Client/Transports/HttpBasedTransport.cs

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/HttpBasedTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/HttpBasedTransport.cs
@@ -308,7 +308,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         {
             return String.IsNullOrEmpty(connection.QueryString)
                             ? ""
-                            : "&" + connection.QueryString;
+                            : connection.QueryString;
         }
     }
 }


### PR DESCRIPTION
There was a very minor bug where, if you supplied a query string during the definition of a hub connection in a client, the resultant full URL would have two ampersands before the custom query string. I removed the deeper nested ampersand addition.

---

For query string handling, the addition of the ampersand is being done in HttpBasedTransport.cs, line 134.  I removed a similar piece of code, that was causing two ampersands to appear, from line 311
