### PR TITLE
Change Hub.Clients to be of type IHubConnectionContext instead of HubConnectionContext

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Hub.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Hub.cs
@@ -14,16 +14,18 @@ namespace Microsoft.AspNet.SignalR.Hubs
     {
         protected Hub()
         {
-            Clients = new HubConnectionContext();
-            Clients.All = new NullClientProxy();
-            Clients.Others = new NullClientProxy();
-            Clients.Caller = new NullClientProxy();
+            Clients = new HubConnectionContext
+                {
+                    All = new NullClientProxy(), 
+                    Others = new NullClientProxy(), 
+                    Caller = new NullClientProxy()
+                };
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public HubConnectionContext Clients { get; set; }
+        public IHubConnectionContext Clients { get; set; }
 
         /// <summary>
         /// Provides information about the calling client.

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubContext.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubContext.cs
@@ -35,6 +35,16 @@ namespace Microsoft.AspNet.SignalR.Hubs
                 get;
                 private set;
             }
+            public dynamic Others
+            {
+                get;
+                private set;
+            }
+            public dynamic Caller
+            {
+                get;
+                private set;
+            }
 
             public dynamic AllExcept(params string[] exclude)
             {
@@ -44,6 +54,11 @@ namespace Microsoft.AspNet.SignalR.Hubs
             public dynamic Group(string groupName, params string[] exclude)
             {
                 return new SignalProxy(_send, groupName, _hubName, exclude);
+            }
+
+            public dynamic OthersInGroup(string groupName)
+            {
+               return Group(groupName);
             }
 
             public dynamic Client(string connectionId)

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/IHub.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/IHub.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
         /// <summary>
         /// Gets a dynamic object that represents all clients connected to this hub (not hub instance).
         /// </summary>
-        HubConnectionContext Clients { get; set; }
+        IHubConnectionContext Clients { get; set; }
 
         /// <summary>
         /// Gets the <see cref="IGroupManager"/> the hub instance.

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/IHubConnectionContext.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/IHubConnectionContext.cs
@@ -11,7 +11,10 @@ namespace Microsoft.AspNet.SignalR.Hubs
     {
         dynamic All { get; }
         dynamic AllExcept(params string[] exclude);
+        dynamic Others { get; }
+        dynamic Caller { get; }
         dynamic Client(string connectionId);
         dynamic Group(string groupName, params string[] exclude);
+        dynamic OthersInGroup(string groupName);
     }
 }


### PR DESCRIPTION
Makes mocking the clients property much easier
