### PR TITLE
Updated Json.NET to version 4.5.11 in all projects.

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/Microsoft.AspNet.SignalR.Client.Samples.csproj
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/Microsoft.AspNet.SignalR.Client.Samples.csproj
@@ -39,7 +39,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/packages.config
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/samples/Microsoft.AspNet.SignalR.Hosting.AspNet.Samples/Microsoft.AspNet.SignalR.Hosting.AspNet.Samples.csproj
+++ b/samples/Microsoft.AspNet.SignalR.Hosting.AspNet.Samples/Microsoft.AspNet.SignalR.Hosting.AspNet.Samples.csproj
@@ -56,7 +56,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.10\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -369,12 +369,7 @@
     <Copy SourceFiles="$(SolutionDir)src\Microsoft.AspNet.SignalR.Client.JS\bin\jquery.signalR.min.js" DestinationFiles="Scripts\jquery.signalR.min.js" Condition=" '$(OS)' == 'Windows_NT' " />
   </Target>
   <Target Name="AfterBuild">
-    <Exec Condition="'$(ArtifactsDir)' == '' AND '$(OS)' == 'Windows_NT' AND $(KeyFile) == ''" 
-          Command="&quot;$(SolutionDir)src\Microsoft.AspNet.SignalR.Utils\bin\$(Configuration)\signalr.exe&quot; ghp /o:&quot;$(SolutionDir)samples\Microsoft.AspNet.SignalR.Hosting.AspNet.Samples\Scripts\hubs.js&quot;" 
-          WorkingDirectory="$(OutputPath)" />
-          
-    <Exec Condition="'$(ArtifactsDir)' != '' AND '$(OS)' == 'Windows_NT' AND $(KeyFile) == ''" 
-          Command="&quot;$(ArtifactsDir)\Microsoft.AspNet.SignalR.Utils\signalr.exe&quot; ghp /o:&quot;$(SolutionDir)samples\Microsoft.AspNet.SignalR.Hosting.AspNet.Samples\Scripts\hubs.js&quot;" 
-          WorkingDirectory="$(OutputPath)" />
+    <Exec Condition="'$(ArtifactsDir)' == '' AND '$(OS)' == 'Windows_NT' AND $(KeyFile) == ''" Command="&quot;$(SolutionDir)src\Microsoft.AspNet.SignalR.Utils\bin\$(Configuration)\signalr.exe&quot; ghp /o:&quot;$(SolutionDir)samples\Microsoft.AspNet.SignalR.Hosting.AspNet.Samples\Scripts\hubs.js&quot;" WorkingDirectory="$(OutputPath)" />
+    <Exec Condition="'$(ArtifactsDir)' != '' AND '$(OS)' == 'Windows_NT' AND $(KeyFile) == ''" Command="&quot;$(ArtifactsDir)\Microsoft.AspNet.SignalR.Utils\signalr.exe&quot; ghp /o:&quot;$(SolutionDir)samples\Microsoft.AspNet.SignalR.Hosting.AspNet.Samples\Scripts\hubs.js&quot;" WorkingDirectory="$(OutputPath)" />
   </Target>
 </Project>

--- a/samples/Microsoft.AspNet.SignalR.Hosting.AspNet.Samples/packages.config
+++ b/samples/Microsoft.AspNet.SignalR.Hosting.AspNet.Samples/packages.config
@@ -9,6 +9,6 @@
   <package id="jQuery.Templates" version="0.1" />
   <package id="jQuery.UI.Combined" version="1.9.0" targetFramework="net40" />
   <package id="json2" version="1.0.2" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="Twitter.Bootstrap" version="2.1.1" targetFramework="net40" />
 </packages>

--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Microsoft.AspNet.SignalR.LoadTestHarness.csproj
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Microsoft.AspNet.SignalR.LoadTestHarness.csproj
@@ -57,7 +57,7 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.10\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/packages.config
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/packages.config
@@ -5,5 +5,5 @@
   <package id="jQuery.UI.Combined" version="1.9.0" targetFramework="net40" />
   <package id="knockoutjs" version="2.1.0" targetFramework="net40" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
-  <package id="Newtonsoft.Json" version="4.5.10" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Client.Silverlight5/Microsoft.AspNet.SignalR.Client.Silverlight5.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.Silverlight5/Microsoft.AspNet.SignalR.Client.Silverlight5.csproj
@@ -52,8 +52,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\sl4\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\sl4\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
     <Reference Include="system" />

--- a/src/Microsoft.AspNet.SignalR.Client.Silverlight5/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Client.Silverlight5/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="sl50" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Client.WinRT/Microsoft.AspNet.SignalR.Client.WinRT.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.WinRT/Microsoft.AspNet.SignalR.Client.WinRT.csproj
@@ -244,14 +244,16 @@
     <Compile Include="Resources.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PRIResource Include="Resources.resw" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\winrt45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\winrt45\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
-    <PRIResource Include="Resources.resw" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' ">
     <VisualStudioVersion>11.0</VisualStudioVersion>

--- a/src/Microsoft.AspNet.SignalR.Client.WinRT/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Client.WinRT/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="win" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Client/Microsoft.AspNet.SignalR.Client.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client/Microsoft.AspNet.SignalR.Client.csproj
@@ -34,12 +34,13 @@
     <DocumentationFile>bin\Release\Microsoft.AspNet.SignalR.Client.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
@@ -115,13 +116,13 @@
     <Compile Include="Transports\TransportHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Common\Microsoft.AspNet.SignalR.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.AspNet.SignalR.Client/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Client/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Client45/Microsoft.AspNet.SignalR.Client45.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client45/Microsoft.AspNet.SignalR.Client45.csproj
@@ -34,8 +34,9 @@
     <DocumentationFile>bin\Release\Microsoft.AspNet.SignalR.Client.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Microsoft.AspNet.SignalR.Client45/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Client45/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
+++ b/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
@@ -36,12 +36,13 @@
     <DocumentationFile>bin\Release\Microsoft.AspNet.SignalR.Core.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
@@ -230,9 +231,6 @@
     <Compile Include="Transports\WebSocketTransport.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -240,7 +238,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Scripts\hubs.js" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="..\Common\Microsoft.AspNet.SignalR.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir).nuget\NuGet.targets" />

--- a/src/Microsoft.AspNet.SignalR.Core/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Redis/Microsoft.AspNet.SignalR.Redis.csproj
+++ b/src/Microsoft.AspNet.SignalR.Redis/Microsoft.AspNet.SignalR.Redis.csproj
@@ -39,8 +39,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\BookSleeve.1.2.0.2\lib\BookSleeve.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/Microsoft.AspNet.SignalR.Redis/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Redis/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BookSleeve" version="1.2.0.2" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="4.5.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.SqlServer/Microsoft.AspNet.SignalR.SqlServer.csproj
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/Microsoft.AspNet.SignalR.SqlServer.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -74,13 +74,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Common\Microsoft.AspNet.SignalR.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.AspNet.SignalR.SqlServer/packages.config
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
 </packages>

--- a/src/Microsoft.AspNet.SignalR.Stress/Microsoft.AspNet.SignalR.Stress.csproj
+++ b/src/Microsoft.AspNet.SignalR.Stress/Microsoft.AspNet.SignalR.Stress.csproj
@@ -41,7 +41,7 @@
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/src/Microsoft.AspNet.SignalR.Stress/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Stress/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="4.5.4" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
 </packages>

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
@@ -39,8 +39,9 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/packages.config
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.1" targetFramework="net45" />
 </packages>

--- a/tests/Microsoft.AspNet.SignalR.Tests/Microsoft.AspNet.SignalR.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Microsoft.AspNet.SignalR.Tests.csproj
@@ -35,14 +35,15 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.0.10827\lib\NET40\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\..\packages\Newtonsoft.Json.4.5.4\lib\net40\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="xunit, Version=1.9.1.1600, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>

--- a/tests/Microsoft.AspNet.SignalR.Tests/packages.config
+++ b/tests/Microsoft.AspNet.SignalR.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Moq" version="4.0.10827" />
-  <package id="Newtonsoft.Json" version="4.5.4" />
+  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net40" />
   <package id="xunit" version="1.9.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Json.NET has started strong naming WP Silverlight packages with this version
causing issue #1223.
