### PR TITLE
Ensure Subscriptions are successfully added to Topics on reconnect.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
@@ -323,16 +323,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "")]
         public abstract string GetCursor();
 
-        public override int GetHashCode()
-        {
-            return Identity.GetHashCode();
-        }
-
-        public override bool Equals(object obj)
-        {
-            return Identity.Equals(((Subscription)obj).Identity);
-        }
-
         private static class State
         {
             public const int Idle = 0;

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Topic.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Topic.cs
@@ -8,7 +8,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
 {
     public class Topic
     {
-        private readonly HashSet<string> _subscriptionIdentities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private readonly TimeSpan _lifespan;
 
         // Keeps track of the last time this subscription was used
@@ -69,11 +68,8 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
                 _lastUsed = DateTime.UtcNow;
 
-                if (_subscriptionIdentities.Add(subscription.Identity))
-                {
-                    Subscriptions.Add(subscription);
-                }
-
+                Subscriptions.Add(subscription);
+                
                 // Created -> HasSubscriptions
                 Interlocked.CompareExchange(ref State,
                                             TopicState.HasSubscriptions,
@@ -98,10 +94,9 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
                 _lastUsed = DateTime.UtcNow;
 
-                if (_subscriptionIdentities.Remove(subscription.Identity))
-                {
-                    Subscriptions.Remove(subscription);
-                }
+              
+                Subscriptions.Remove(subscription);
+               
 
                 if (Subscriptions.Count == 0)
                 {


### PR DESCRIPTION
Addresses issue #1144

Since the SCTS.Cancel uses UnsafeQueueUserWorkItem, old Subscriptions
are often not removed before new ones are added when reconnecting.
Topic.AddSubscription would then block the addition of reconnecting
Subscriptions, since reconnecting Subscriptions have the same Identities as
the yet undeleted old subscriptions.

This change removes the check inside of Topic.AddSubscription preventing
two Subscriptions with the same Identity from being subscribed to the topic
at once.
