### PR TITLE
Removed race condition involving transitioning to the Connected state in .NET client

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -305,7 +305,7 @@ namespace Microsoft.AspNet.SignalR.Client
         private Task StartTransport(string data)
         {
             return _transport.Start(this, data, _disconnectCts.Token)
-                             .Then(() =>
+                             .RunSynchronously(() =>
                              {
                                  ChangeState(ConnectionState.Connecting, ConnectionState.Connected);
                              });

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -116,7 +116,8 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     tcs.SetResult(null);
                 }
 
-            });
+            },
+            TaskContinuationOptions.ExecuteSynchronously);
         }
 
         public Task Send(IConnection connection, string data)


### PR DESCRIPTION
Removed race where initializeCallback could be called in OnStart, but the Connection momentarily remain in the Connecting state.
