### PR TITLE
.Net Client JsonSerializer

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -43,6 +42,9 @@ namespace Microsoft.AspNet.SignalR.Client
 
         // Used to synchronize state changes
         private readonly object _stateLock = new object();
+
+        // The groups the connection is currently subscribed to
+        private readonly HashSet<string> _groups;
 
         /// <summary>
         /// Occurs when the <see cref="Connection"/> has received data from the server.
@@ -118,10 +120,17 @@ namespace Microsoft.AspNet.SignalR.Client
 
             Url = url;
             QueryString = queryString;
+            _groups = new HashSet<string>();
             _disconnectTimeoutOperation = DisposableAction.Empty;
             Items = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             State = ConnectionState.Disconnected;
+            JsonSerializer = new JsonSerializer();
         }
+
+        /// <summary>
+        /// Gets or sets the JsonSerializer for the connection;
+        /// </summary>
+        public JsonSerializer JsonSerializer { get; set; }
 
         /// <summary>
         /// Gets or sets the cookies associated with the connection.
@@ -141,6 +150,22 @@ namespace Microsoft.AspNet.SignalR.Client
 #endif
 
         /// <summary>
+        /// Gets a mutable collection of groups for the connection.
+        /// </summary>
+        ICollection<string> IConnection.Groups
+        {
+            get { return _groups; }
+        }
+
+        /// <summary>
+        /// Gets the groups for the connection.
+        /// </summary>
+        public IEnumerable<string> Groups
+        {
+            get { return _groups; }
+        }
+
+        /// <summary>
         /// Gets the url for the connection.
         /// </summary>
         public string Url { get; private set; }
@@ -154,16 +179,6 @@ namespace Microsoft.AspNet.SignalR.Client
         /// Gets or sets the connection id for the connection.
         /// </summary>
         public string ConnectionId { get; set; }
-        
-        /// <summary>
-        /// Gets or sets the connection token for the connection.
-        /// </summary>
-        public string ConnectionToken { get; set; }
-
-        /// <summary>
-        /// Gets or sets the groups token for the connection.
-        /// </summary>
-        public string GroupsToken { get; set; }
 
         /// <summary>
         /// Gets a dictionary for storing state for a the connection.
@@ -262,8 +277,6 @@ namespace Microsoft.AspNet.SignalR.Client
                 VerifyProtocolVersion(negotiationResponse.ProtocolVersion);
 
                 ConnectionId = negotiationResponse.ConnectionId;
-                ConnectionToken = negotiationResponse.ConnectionToken;
-
                 _disconnectTimeout = TimeSpan.FromSeconds(negotiationResponse.DisconnectTimeout);
 
                 var data = OnSending();
@@ -305,7 +318,7 @@ namespace Microsoft.AspNet.SignalR.Client
         private Task StartTransport(string data)
         {
             return _transport.Start(this, data, _disconnectCts.Token)
-                             .RunSynchronously(() =>
+                             .Then(() =>
                              {
                                  ChangeState(ConnectionState.Connecting, ConnectionState.Connected);
                              });
@@ -337,7 +350,7 @@ namespace Microsoft.AspNet.SignalR.Client
             Version version;
             if (String.IsNullOrEmpty(versionString) ||
                 !TryParseVersion(versionString, out version) ||
-                !(version.Major == 1 && version.Minor == 2))
+                !(version.Major == 1 && version.Minor == 1))
             {
                 throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_IncompatibleProtocolVersion));
             }

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -42,6 +42,11 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             }
         }
 
+        public JsonSerializer JsonSerializer
+        {
+            get { return _connection.JsonSerializer; }
+        }
+
         public Subscription Subscribe(string eventName)
         {
             if (eventName == null)
@@ -106,7 +111,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
                             if (result.Result != null)
                             {
-                                tcs.TrySetResult(result.Result.ToObject<T>());
+                                tcs.TrySetResult(result.Result.ToObject<T>(_connection.JsonSerializer));
                             }
                             else
                             {
@@ -158,12 +163,12 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             return tcs.Task;
         }
 
-        public void InvokeEvent(string eventName, IList<JToken> args)
+        public void InvokeEvent(string eventName, JToken[] args)
         {
-            Subscription subscription;
-            if (_subscriptions.TryGetValue(eventName, out subscription))
+            Subscription eventObj;
+            if (_subscriptions.TryGetValue(eventName, out eventObj))
             {
-                subscription.OnReceived(args);
+                eventObj.OnData(args);
             }
         }
     }

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxyExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxyExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Microsoft.AspNet.SignalR.Infrastructure;
@@ -32,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
                 throw new ArgumentNullException("name");
             }
 
-            return Convert<T>(proxy[name]);
+            return Convert<T>(proxy[name], proxy.JsonSerializer);
         }
 
         /// <summary>
@@ -61,14 +60,14 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
                 onData();
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -97,14 +96,14 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T>(args[0]));
+                onData(Convert<T>(args[0], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -133,15 +132,15 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T1>(args[0]),
-                       Convert<T2>(args[1]));
+                onData(Convert<T1>(args[0], proxy.JsonSerializer),
+                       Convert<T2>(args[1], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -170,16 +169,16 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T1>(args[0]),
-                       Convert<T2>(args[1]),
-                       Convert<T3>(args[2]));
+                onData(Convert<T1>(args[0], proxy.JsonSerializer),
+                       Convert<T2>(args[1], proxy.JsonSerializer),
+                       Convert<T3>(args[2], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -208,17 +207,17 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T1>(args[0]),
-                       Convert<T2>(args[1]),
-                       Convert<T3>(args[2]),
-                       Convert<T4>(args[3]));
+                onData(Convert<T1>(args[0], proxy.JsonSerializer),
+                       Convert<T2>(args[1], proxy.JsonSerializer),
+                       Convert<T3>(args[2], proxy.JsonSerializer),
+                       Convert<T4>(args[3], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
 #if !WINDOWS_PHONE && !SILVERLIGHT && !NET35
@@ -260,18 +259,18 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T1>(args[0]),
-                       Convert<T2>(args[1]),
-                       Convert<T3>(args[2]),
-                       Convert<T4>(args[3]),
-                       Convert<T5>(args[4]));
+                onData(Convert<T1>(args[0], proxy.JsonSerializer),
+                       Convert<T2>(args[1], proxy.JsonSerializer),
+                       Convert<T3>(args[2], proxy.JsonSerializer),
+                       Convert<T4>(args[3], proxy.JsonSerializer),
+                       Convert<T5>(args[4], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -300,19 +299,19 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T1>(args[0]),
-                       Convert<T2>(args[1]),
-                       Convert<T3>(args[2]),
-                       Convert<T4>(args[3]),
-                       Convert<T5>(args[4]),
-                       Convert<T6>(args[5]));
+                onData(Convert<T1>(args[0], proxy.JsonSerializer),
+                       Convert<T2>(args[1], proxy.JsonSerializer),
+                       Convert<T3>(args[2], proxy.JsonSerializer),
+                       Convert<T4>(args[3], proxy.JsonSerializer),
+                       Convert<T5>(args[4], proxy.JsonSerializer),
+                       Convert<T6>(args[5], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -341,20 +340,20 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Subscription subscription = proxy.Subscribe(eventName);
 
-            Action<IList<JToken>> handler = args =>
+            Action<JToken[]> handler = args =>
             {
-                onData(Convert<T1>(args[0]),
-                       Convert<T2>(args[1]),
-                       Convert<T3>(args[2]),
-                       Convert<T4>(args[3]),
-                       Convert<T5>(args[4]),
-                       Convert<T6>(args[5]),
-                       Convert<T7>(args[6]));
+                onData(Convert<T1>(args[0], proxy.JsonSerializer),
+                       Convert<T2>(args[1], proxy.JsonSerializer),
+                       Convert<T3>(args[2], proxy.JsonSerializer),
+                       Convert<T4>(args[3], proxy.JsonSerializer),
+                       Convert<T5>(args[4], proxy.JsonSerializer),
+                       Convert<T6>(args[5], proxy.JsonSerializer),
+                       Convert<T7>(args[6], proxy.JsonSerializer));
             };
 
-            subscription.Received += handler;
+            subscription.Data += handler;
 
-            return new DisposableAction(() => subscription.Received -= handler);
+            return new DisposableAction(() => subscription.Data -= handler);
         }
 
         /// <summary>
@@ -363,7 +362,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         /// <param name="proxy">The <see cref="IHubProxy"/></param>
         /// <param name="eventName">The name of the event.</param>
         /// <returns>An <see cref="T:IObservable{object[]}"/>.</returns>
-        public static IObservable<IList<JToken>> Observe(this IHubProxy proxy, string eventName)
+        public static IObservable<JToken[]> Observe(this IHubProxy proxy, string eventName)
         {
             if (proxy == null)
             {
@@ -379,14 +378,14 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         }
 #endif
 
-        private static T Convert<T>(JToken obj)
+        private static T Convert<T>(JToken obj, Newtonsoft.Json.JsonSerializer jsonSerializer)
         {
             if (obj == null)
             {
                 return default(T);
             }
 
-            return obj.ToObject<T>();
+            return obj.ToObject<T>(jsonSerializer);
         }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubConnection.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System;
+using Newtonsoft.Json;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
 {
     public interface IHubConnection : IConnection
     {
         string RegisterCallback(Action<HubResult> callback);
+        JsonSerializer JsonSerializer { get; }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubProxy.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
@@ -40,5 +41,10 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         /// <param name="eventName">The name of the event</param>
         /// <returns>A <see cref="Subscription"/>.</returns>
         Subscription Subscribe(string eventName);
+
+        /// <summary>
+        /// Gets the JsonSerializer to use.
+        /// </summary>
+        JsonSerializer JsonSerializer { get; }
     }
 }


### PR DESCRIPTION
Connection for .Net client now exposes a property making it possible to replace the JsonSerializer used for deserializing Hub messages. https://github.com/SignalR/SignalR/issues/1373
