### PR TITLE
.Net Client custom JsonSerializer

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -121,7 +121,13 @@ namespace Microsoft.AspNet.SignalR.Client
             _disconnectTimeoutOperation = DisposableAction.Empty;
             Items = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             State = ConnectionState.Disconnected;
+            JsonSerializer = new JsonSerializer();
         }
+
+        /// <summary>
+        /// Gets or sets the JsonSerializer for the connection;
+        /// </summary>
+        public JsonSerializer JsonSerializer { get; set; }
 
         /// <summary>
         /// Gets or sets the cookies associated with the connection.

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -42,6 +42,11 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             }
         }
 
+        public JsonSerializer JsonSerializer
+        {
+            get { return _connection.JsonSerializer; }
+        }
+
         public Subscription Subscribe(string eventName)
         {
             if (eventName == null)
@@ -106,7 +111,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
                             if (result.Result != null)
                             {
-                                tcs.TrySetResult(result.Result.ToObject<T>());
+                                tcs.TrySetResult(result.Result.ToObject<T>(_connection.JsonSerializer));
                             }
                             else
                             {

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxyExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxyExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Microsoft.AspNet.SignalR.Infrastructure;
+using Newtonsoft.Json;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
 {
@@ -379,14 +380,14 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         }
 #endif
 
-        private static T Convert<T>(JToken obj)
+        private static T Convert<T>(JToken obj, JsonSerializer jsonSerializer)
         {
             if (obj == null)
             {
                 return default(T);
             }
 
-            return obj.ToObject<T>();
+            return obj.ToObject<T>(jsonSerializer);
         }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubProxy.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
@@ -40,5 +41,10 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         /// <param name="eventName">The name of the event</param>
         /// <returns>A <see cref="Subscription"/>.</returns>
         Subscription Subscribe(string eventName);
+
+        /// <summary>
+        /// Gets the JsonSerializer to use.
+        /// </summary>
+        JsonSerializer JsonSerializer { get; }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/IConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/IConnection.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Microsoft.AspNet.SignalR.Client.Http;
+using Newtonsoft.Json;
 
 namespace Microsoft.AspNet.SignalR.Client
 {
@@ -26,6 +27,8 @@ namespace Microsoft.AspNet.SignalR.Client
 
         ICredentials Credentials { get; set; }
         CookieContainer CookieContainer { get; set; }
+
+        JsonSerializer JsonSerializer { get; }
 
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Stop", Justification = "Works in VB.NET.")]
         void Stop();


### PR DESCRIPTION
Connection for .Net client now exposes a property making it possible to replace the JsonSerializer used for deserializing Hub messages.

https://github.com/SignalR/SignalR/issues/1373
