### PR TITLE
Custom JsonSerializer on .Net Client

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -134,20 +134,21 @@ namespace Microsoft.AspNet.SignalR.Client
             Items = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             State = ConnectionState.Disconnected;
 
-            _serializerSettings = serializerSettings;
-            JsonSerializer = JsonSerializer.Create(serializerSettings);            
+            if (serializerSettings == null)
+            {
+                _serializerSettings = new JsonSerializerSettings();
+            }
+            else
+            {
+                _serializerSettings = serializerSettings;
+            }
         }
 
         readonly JsonSerializerSettings _serializerSettings = null;
-        public JsonSerializerSettings SerializerSettings
+        public JsonSerializerSettings GetCurrentJsonSerializerSettings()
         {
-            get { return _serializerSettings; }
+            return _serializerSettings;
         }
-
-        /// <summary>
-        /// Gets or sets the JsonSerializer for the connection;
-        /// </summary>
-        public JsonSerializer JsonSerializer { get; private set; }        
 
         /// <summary>
         /// Gets or sets the cookies associated with the connection.
@@ -437,7 +438,7 @@ namespace Microsoft.AspNet.SignalR.Client
         /// <returns>A task that represents when the data has been sent.</returns>
         public Task Send(object value)
         {
-            return Send(JsonConvert.SerializeObject(value, SerializerSettings));
+            return Send(JsonConvert.SerializeObject(value, GetCurrentJsonSerializerSettings()));
         }
         
 

--- a/src/Microsoft.AspNet.SignalR.Client/ConnectionExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/ConnectionExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.SignalR.Client
 
         public static IObservable<T> AsObservable<T>(this Connection connection)
         {
-            return connection.AsObservable(value => JsonConvert.DeserializeObject<T>(value,connection.SerializerSettings));
+            return connection.AsObservable(value => JsonConvert.DeserializeObject<T>(value, connection.GetCurrentJsonSerializerSettings()));
         }
 
         public static IObservable<T> AsObservable<T>(this Connection connection, Func<string, T> selector)

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubConnection.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         {
             if (message["I"] != null)
             {
-                var result = message.ToObject<HubResult>(JsonSerializer);
+                var result = message.ToObject<HubResult>(JsonSerializer.Create(GetCurrentJsonSerializerSettings()));
                 Action<HubResult> callback;
 
                 lock (_callbacks)
@@ -118,7 +118,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             }
             else
             {
-                var invocation = message.ToObject<HubInvocation>(JsonSerializer);
+                var invocation = message.ToObject<HubInvocation>(JsonSerializer.Create(GetCurrentJsonSerializerSettings()));
                 HubProxy hubProxy;
                 if (_hubs.TryGetValue(invocation.Hub, out hubProxy))
                 {
@@ -144,7 +144,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
                 Name = p.Key
             });
 
-            return JsonConvert.SerializeObject(data, SerializerSettings);
+            return JsonConvert.SerializeObject(data, GetCurrentJsonSerializerSettings());
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -42,9 +42,9 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             }
         }
 
-        public JsonSerializer JsonSerializer
+        public JsonSerializerSettings GetCurrentJsonSerializerSettings()
         {
-            get { return _connection.JsonSerializer; }
+            return _connection.GetCurrentJsonSerializerSettings();
         }
 
         public Subscription Subscribe(string eventName)
@@ -85,7 +85,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             var tokenifiedArguments = new JToken[args.Length];
             for (int i = 0; i < tokenifiedArguments.Length; i++)
             {
-                tokenifiedArguments[i] = JToken.FromObject(args[i], _connection.JsonSerializer);
+                tokenifiedArguments[i] = JToken.FromObject(args[i], JsonSerializer.Create(_connection.GetCurrentJsonSerializerSettings()));
             }
 
             var tcs = new TaskCompletionSource<T>();
@@ -111,7 +111,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
                             if (result.Result != null)
                             {
-                                tcs.TrySetResult(result.Result.ToObject<T>(_connection.JsonSerializer));
+                                tcs.TrySetResult(result.Result.ToObject<T>(JsonSerializer.Create(_connection.GetCurrentJsonSerializerSettings())));
                             }
                             else
                             {
@@ -145,7 +145,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
                 hubData.State = _state;
             }
 
-            var value = JsonConvert.SerializeObject(hubData, _connection.SerializerSettings);
+            var value = JsonConvert.SerializeObject(hubData, _connection.GetCurrentJsonSerializerSettings());
 
             _connection.Send(value).ContinueWith(task =>
             {

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxyExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxyExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
                 throw new ArgumentNullException("name");
             }
 
-            return Convert<T>(proxy[name], proxy.JsonSerializer);
+            return Convert<T>(proxy[name], JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings()));
         }
 
         /// <summary>
@@ -100,7 +100,8 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T>(args[0], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T>(args[0], jsonSerializer));
             };
 
             subscription.Received += handler;
@@ -136,8 +137,9 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T1>(args[0], proxy.JsonSerializer),
-                       Convert<T2>(args[1], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T1>(args[0], jsonSerializer),
+                       Convert<T2>(args[1], jsonSerializer));
             };
 
             subscription.Received += handler;
@@ -173,9 +175,10 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T1>(args[0], proxy.JsonSerializer),
-                       Convert<T2>(args[1], proxy.JsonSerializer),
-                       Convert<T3>(args[2], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T1>(args[0], jsonSerializer),
+                       Convert<T2>(args[1], jsonSerializer),
+                       Convert<T3>(args[2], jsonSerializer));
             };
 
             subscription.Received += handler;
@@ -211,10 +214,11 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T1>(args[0], proxy.JsonSerializer),
-                       Convert<T2>(args[1], proxy.JsonSerializer),
-                       Convert<T3>(args[2], proxy.JsonSerializer),
-                       Convert<T4>(args[3], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T1>(args[0], jsonSerializer),
+                       Convert<T2>(args[1], jsonSerializer),
+                       Convert<T3>(args[2], jsonSerializer),
+                       Convert<T4>(args[3], jsonSerializer));
             };
 
             subscription.Received += handler;
@@ -263,11 +267,12 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T1>(args[0], proxy.JsonSerializer),
-                       Convert<T2>(args[1], proxy.JsonSerializer),
-                       Convert<T3>(args[2], proxy.JsonSerializer),
-                       Convert<T4>(args[3], proxy.JsonSerializer),
-                       Convert<T5>(args[4], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T1>(args[0], jsonSerializer),
+                       Convert<T2>(args[1], jsonSerializer),
+                       Convert<T3>(args[2], jsonSerializer),
+                       Convert<T4>(args[3], jsonSerializer),
+                       Convert<T5>(args[4], jsonSerializer));
             };
 
             subscription.Received += handler;
@@ -303,12 +308,13 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T1>(args[0], proxy.JsonSerializer),
-                       Convert<T2>(args[1], proxy.JsonSerializer),
-                       Convert<T3>(args[2], proxy.JsonSerializer),
-                       Convert<T4>(args[3], proxy.JsonSerializer),
-                       Convert<T5>(args[4], proxy.JsonSerializer),
-                       Convert<T6>(args[5], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T1>(args[0], jsonSerializer),
+                       Convert<T2>(args[1], jsonSerializer),
+                       Convert<T3>(args[2], jsonSerializer),
+                       Convert<T4>(args[3], jsonSerializer),
+                       Convert<T5>(args[4], jsonSerializer),
+                       Convert<T6>(args[5], jsonSerializer));
             };
 
             subscription.Received += handler;
@@ -344,13 +350,14 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
 
             Action<IList<JToken>> handler = args =>
             {
-                onData(Convert<T1>(args[0], proxy.JsonSerializer),
-                       Convert<T2>(args[1], proxy.JsonSerializer),
-                       Convert<T3>(args[2], proxy.JsonSerializer),
-                       Convert<T4>(args[3], proxy.JsonSerializer),
-                       Convert<T5>(args[4], proxy.JsonSerializer),
-                       Convert<T6>(args[5], proxy.JsonSerializer),
-                       Convert<T7>(args[6], proxy.JsonSerializer));
+                var jsonSerializer = JsonSerializer.Create(proxy.GetCurrentJsonSerializerSettings());
+                onData(Convert<T1>(args[0], jsonSerializer),
+                       Convert<T2>(args[1], jsonSerializer),
+                       Convert<T3>(args[2], jsonSerializer),
+                       Convert<T4>(args[3], jsonSerializer),
+                       Convert<T5>(args[4], jsonSerializer),
+                       Convert<T6>(args[5], jsonSerializer),
+                       Convert<T7>(args[6], jsonSerializer));
             };
 
             subscription.Received += handler;

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/IHubProxy.cs
@@ -43,8 +43,9 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
         Subscription Subscribe(string eventName);
 
         /// <summary>
-        /// Gets the JsonSerializer to use.
+        /// Gets the JsonSerializerSettings the connecition is using.
         /// </summary>
-        JsonSerializer JsonSerializer { get; }
+        /// <returns>A <see cref="JsonSerializerSettings"/>.</returns>
+        JsonSerializerSettings GetCurrentJsonSerializerSettings();
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/IConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/IConnection.cs
@@ -28,8 +28,7 @@ namespace Microsoft.AspNet.SignalR.Client
         ICredentials Credentials { get; set; }
         CookieContainer CookieContainer { get; set; }
 
-        JsonSerializer JsonSerializer { get; }
-        JsonSerializerSettings SerializerSettings { get; }
+        JsonSerializerSettings GetCurrentJsonSerializerSettings();
 
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Stop", Justification = "Works in VB.NET.")]
         void Stop();

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_ServerNegotiationFailed));
                 }
 
-                return JsonConvert.DeserializeObject<NegotiationResponse>(raw, connection.SerializerSettings);
+                return JsonConvert.DeserializeObject<NegotiationResponse>(raw, connection.GetCurrentJsonSerializerSettings());
             });
         }
 


### PR DESCRIPTION
Connection for .Net client now exposes a property making it possible to replace the JsonSerializer used for deserializing Hub messages.
Solving this issue: https://github.com/SignalR/SignalR/issues/1373

Hope I got it right this time ... Kind of newbie on this GitHub thing.
