### PR TITLE
Always set response state within the task queue.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverFrameTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverFrameTransport.cs
@@ -96,10 +96,10 @@ namespace Microsoft.AspNet.SignalR.Transports
             return base.InitializeResponse(connection)
                 .Then(initScript =>
                 {
-                    Context.Response.ContentType = "text/html";
-
                     return EnqueueOperation(() =>
                     {
+                        Context.Response.ContentType = "text/html";
+
                         HTMLOutputWriter.WriteRaw(initScript);
                         HTMLOutputWriter.Flush();
 

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
@@ -157,10 +157,10 @@ namespace Microsoft.AspNet.SignalR.Transports
 
         public virtual Task Send(object value)
         {
-            Context.Response.ContentType = JsonUtility.MimeType;
-
             return EnqueueOperation(() =>
             {
+                Context.Response.ContentType = JsonUtility.MimeType;
+
                 JsonSerializer.Serialize(value, OutputWriter);
                 OutputWriter.Flush();
 

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/LongPollingTransport.cs
@@ -177,10 +177,10 @@ namespace Microsoft.AspNet.SignalR.Transports
 
         public Task Send(object value)
         {
-            Context.Response.ContentType = IsJsonp ? JsonUtility.JsonpMimeType : JsonUtility.MimeType;
-
             return EnqueueOperation(() =>
             {
+                Context.Response.ContentType = IsJsonp ? JsonUtility.JsonpMimeType : JsonUtility.MimeType;
+
                 if (IsJsonp)
                 {
                     OutputWriter.Write(JsonpCallback);

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ServerSentEventsTransport.cs
@@ -53,10 +53,10 @@ namespace Microsoft.AspNet.SignalR.Transports
             return base.InitializeResponse(connection)
                        .Then(() =>
                        {
-                           Context.Response.ContentType = "text/event-stream";
-
                            return EnqueueOperation(() =>
                            {
+                               Context.Response.ContentType = "text/event-stream";
+
                                // "data: initialized\n\n"
                                OutputWriter.Write("data: initialized");
                                OutputWriter.WriteLine();


### PR DESCRIPTION
All forever transports except websockets (SSE and FF) can end the request before settings headers. This is a race as it's possible to end up writing headers to the OWIN dictionary after the request has finished.

To fix this we queue all actions that touch the response so that we can never touch the response after the request queue is drained.
