### PR TITLE
Mitigate csrf for authenticated users.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Purposes.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Purposes.cs
@@ -2,7 +2,7 @@
 {
     public static class Purposes
     {
-        public const string ConnectionId = "SignalR.ConnectionId";
+        public const string ConnectionToken = "SignalR.ConnectionToken";
         public const string Groups = "SignalR.Groups";
     }
 }

--- a/src/Microsoft.AspNet.SignalR.SystemWeb/Infrastructure/MachineKeyProtectedData.cs
+++ b/src/Microsoft.AspNet.SignalR.SystemWeb/Infrastructure/MachineKeyProtectedData.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.SignalR.SystemWeb.Infrastructure
 {
     public class MachineKeyProtectedData : IProtectedData
     {
-        private const uint ConnectionIdMagicHeader = 0x855d4ec9;
+        private const uint ConnectionTokenMagicHeader = 0x855d4ec9;
         private const uint GroupsMagicHeader = 0x85c8b45a;
 
         private static readonly UTF8Encoding _encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
@@ -38,8 +38,8 @@ namespace Microsoft.AspNet.SignalR.SystemWeb.Infrastructure
         {
             switch (purpose)
             {
-                case Purposes.ConnectionId:
-                    return new MachineKeyProtectedData40(ConnectionIdMagicHeader);
+                case Purposes.ConnectionToken:
+                    return new MachineKeyProtectedData40(ConnectionTokenMagicHeader);
                 case Purposes.Groups:
                     return new MachineKeyProtectedData40(GroupsMagicHeader);
             }

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/SecurityFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/SecurityFacts.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
         private string GetUrl(IProtectedData protectedData, Client.Connection connection)
         {
             // Generate a valid token
-            string token = protectedData.Protect(Guid.NewGuid().ToString("d"), Purposes.ConnectionId);
+            string token = protectedData.Protect(Guid.NewGuid().ToString("d") + ':', Purposes.ConnectionToken);
             string groupsToken = protectedData.Protect(JsonConvert.SerializeObject(new[] { connection.ConnectionToken }), Purposes.Groups);
 
             var sb = new StringBuilder("http://memoryhost/echo/");

--- a/tests/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Security.Principal;
 using Microsoft.AspNet.SignalR.Hosting;
 using Microsoft.AspNet.SignalR.Infrastructure;
 using Moq;
@@ -58,60 +59,14 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 Assert.Throws<InvalidOperationException>(() => connection.Object.ProcessRequest(context));
             }
+        }
 
-            [Fact]
-            public void UnprotectedConnectionTokenThrows()
-            {
-                var connection = new Mock<PersistentConnection>() { CallBase = true };
-                var req = new Mock<IRequest>();
-                req.Setup(m => m.Url).Returns(new Uri("http://foo"));
-                var qs = new NameValueCollection();
-                qs["transport"] = "serverSentEvents";
-                qs["connectionToken"] = "1";
-                req.Setup(m => m.QueryString).Returns(qs);
-
-                var protectedData = new Mock<IProtectedData>();
-                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns<string, string>((value, purpose) => value);
-                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>()))
-                             .Throws<InvalidOperationException>();
-
-                var dr = new DefaultDependencyResolver();
-                dr.Register(typeof(IProtectedData), () => protectedData.Object);
-                var context = new HostContext(req.Object, null);
-                connection.Object.Initialize(dr, context);
-
-                Assert.Throws<InvalidOperationException>(() => connection.Object.ProcessRequest(context));
-            }
-
-            [Fact]
-            public void NullUnprotectedConnectionTokenThrows()
-            {
-                var connection = new Mock<PersistentConnection>() { CallBase = true };
-                var req = new Mock<IRequest>();
-                req.Setup(m => m.Url).Returns(new Uri("http://foo"));
-                var qs = new NameValueCollection();
-                qs["transport"] = "serverSentEvents";
-                qs["connectionToken"] = "1";
-                req.Setup(m => m.QueryString).Returns(qs);
-
-                var protectedData = new Mock<IProtectedData>();
-                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
-                    .Returns<string, string>((value, purpose) => value);
-                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>())).Returns((string)null);
-
-                var dr = new DefaultDependencyResolver();
-                dr.Register(typeof(IProtectedData), () => protectedData.Object);
-                var context = new HostContext(req.Object, null);
-                connection.Object.Initialize(dr, context);
-
-                Assert.Throws<InvalidOperationException>(() => connection.Object.ProcessRequest(context));
-            }
-
+        public class VerifyGroups
+        {
             [Fact]
             public void MissingGroupTokenReturnsEmptyList()
             {
-                var groups = VerifyGroups(groupsToken: null);
+                var groups = DoVerifyGroups(groupsToken: null);
 
                 Assert.Equal(0, groups.Count);
             }
@@ -119,7 +74,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             [Fact]
             public void NullProtectedDataTokenReturnsEmptyList()
             {
-                var groups = VerifyGroups(groupsToken: "groups", hasProtectedData: false);
+                var groups = DoVerifyGroups(groupsToken: "groups", hasProtectedData: false);
 
                 Assert.Equal(0, groups.Count);
             }
@@ -127,14 +82,14 @@ namespace Microsoft.AspNet.SignalR.Tests
             [Fact]
             public void GroupsAreParsedFromToken()
             {
-                var groups = VerifyGroups(groupsToken: @"[""g1"",""g2""]");
+                var groups = DoVerifyGroups(groupsToken: @"[""g1"",""g2""]");
 
                 Assert.Equal(2, groups.Count);
                 Assert.Equal("g1", groups[0]);
                 Assert.Equal("g2", groups[1]);
             }
 
-            private static IList<string> VerifyGroups(string groupsToken, bool hasProtectedData = true)
+            private static IList<string> DoVerifyGroups(string groupsToken, bool hasProtectedData = true)
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
                 var req = new Mock<IRequest>();
@@ -159,6 +114,113 @@ namespace Microsoft.AspNet.SignalR.Tests
                 connection.Object.Initialize(dr, context);
 
                 return connection.Object.VerifyGroups(context);
+            }
+        }
+
+        public class GetConnectionId
+        {
+            [Fact]
+            public void UnprotectedConnectionTokenThrows()
+            {
+                var connection = new Mock<PersistentConnection>() { CallBase = true };
+                var req = new Mock<IRequest>();
+                
+                var protectedData = new Mock<IProtectedData>();
+                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns<string, string>((value, purpose) => value);
+                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>()))
+                             .Throws<InvalidOperationException>();
+
+                var dr = new DefaultDependencyResolver();
+                dr.Register(typeof(IProtectedData), () => protectedData.Object);
+                var context = new HostContext(req.Object, null);
+                connection.Object.Initialize(dr, context);
+
+                Assert.Throws<InvalidOperationException>(() => connection.Object.GetConnectionId(context, "1"));
+            }
+
+            [Fact]
+            public void NullUnprotectedConnectionTokenThrows()
+            {
+                var connection = new Mock<PersistentConnection>() { CallBase = true };
+                var req = new Mock<IRequest>();
+                
+                var protectedData = new Mock<IProtectedData>();
+                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns<string, string>((value, purpose) => value);
+                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>())).Returns((string)null);
+
+                var dr = new DefaultDependencyResolver();
+                dr.Register(typeof(IProtectedData), () => protectedData.Object);
+                var context = new HostContext(req.Object, null);
+                connection.Object.Initialize(dr, context);
+
+                Assert.Throws<InvalidOperationException>(() => connection.Object.GetConnectionId(context, "1"));
+            }
+
+            [Fact]
+            public void UnauthenticatedUserWithAuthenticatedTokenThrows()
+            {
+                var connection = new Mock<PersistentConnection>() { CallBase = true };
+                var req = new Mock<IRequest>();
+                
+                var protectedData = new Mock<IProtectedData>();
+                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns<string, string>((value, purpose) => value);
+                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>())).Returns<string, string>((value, purpose) => value);
+
+                var dr = new DefaultDependencyResolver();
+                dr.Register(typeof(IProtectedData), () => protectedData.Object);
+                var context = new HostContext(req.Object, null);
+                connection.Object.Initialize(dr, context);
+
+                Assert.Throws<InvalidOperationException>(() => connection.Object.GetConnectionId(context, "1:::11:::::::1:1"));
+            }
+
+            [Fact]
+            public void AuthenticatedUserNameMatches()
+            {
+                var connection = new Mock<PersistentConnection>() { CallBase = true };
+                var req = new Mock<IRequest>();
+                req.Setup(m => m.User).Returns(new GenericPrincipal(new GenericIdentity("Name"), new string[] { }));
+
+                var protectedData = new Mock<IProtectedData>();
+                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns<string, string>((value, purpose) => value);
+                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>())).Returns<string, string>((value, purpose) => value);
+
+                var dr = new DefaultDependencyResolver();
+                dr.Register(typeof(IProtectedData), () => protectedData.Object);
+                var context = new HostContext(req.Object, null);
+                connection.Object.Initialize(dr, context);
+
+                var connectionId = connection.Object.GetConnectionId(context, "1:Name");
+
+                Assert.Equal("1", connectionId);
+            }
+
+            [Fact]
+            public void AuthenticatedUserWithColonsInUserName()
+            {
+                var connection = new Mock<PersistentConnection>() { CallBase = true };
+                var req = new Mock<IRequest>();
+                req.Setup(m => m.User).Returns(new GenericPrincipal(new GenericIdentity("::11:::::::1:1"), new string[] { }));
+
+                string connectionId = Guid.NewGuid().ToString("d");
+
+                var protectedData = new Mock<IProtectedData>();
+                protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns<string, string>((value, purpose) => value);
+                protectedData.Setup(m => m.Unprotect(It.IsAny<string>(), It.IsAny<string>())).Returns<string, string>((value, purpose) => value);
+
+                var dr = new DefaultDependencyResolver();
+                dr.Register(typeof(IProtectedData), () => protectedData.Object);
+                var context = new HostContext(req.Object, null);
+                connection.Object.Initialize(dr, context);
+
+                string cid = connection.Object.GetConnectionId(context, connectionId + ":::11:::::::1:1");
+
+                Assert.Equal(connectionId, cid);
             }
         }
     }


### PR DESCRIPTION
- Use User.Identity.Name as part of connectionToken and verify
  that the token against the user name for all operations.
- Added tests.
