### PR TITLE
Send X-Content-Type-Options:nosniff header for all responses

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Owin/Handlers/CallHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Owin/Handlers/CallHandler.cs
@@ -55,6 +55,9 @@ namespace Microsoft.AspNet.SignalR.Owin
                 }
             }
 
+            // Add the nosniff header for all responses to prevent IE from trying to sniff mime type from contents
+            serverResponse.ResponseHeaders.SetHeader("X-Content-Type-Options", "nosniff");
+
             hostContext.Items[HostConstants.SupportsWebSockets] = LazyInitializer.EnsureInitialized(
                 ref _supportWebSockets,
                 ref _supportWebSocketsInitialized,

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
@@ -123,6 +123,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 Assert.Equal("OnConnected", results[0].Method);
                 Assert.Equal(1, results[0].Keys.Length);
                 Assert.Equal("owin.environment", results[0].Keys[0]);
+                Assert.Equal("nosniff", results[0].XContentTypeOptions);
                 Assert.Equal("GetItems", results[1].Method);
                 Assert.Equal(1, results[1].Keys.Length);
                 Assert.Equal("owin.environment", results[1].Keys[0]);

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Hubs/MyItemsHub.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Hubs/MyItemsHub.cs
@@ -30,12 +30,14 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Hubs
             if (request.Items.TryGetValue("owin.environment", out owinEnv))
             {
                 var env = (IDictionary<string, object>)owinEnv;
+                var responseHeaders = (Dictionary<string, string[]>)env["owin.ResponseHeaders"];
                 return Clients.All.update(new
                 {
                     method = method,
                     count = env.Count,
                     owinKeys = env.Keys,
-                    keys = request.Items.Keys
+                    keys = request.Items.Keys,
+                    xContentTypeOptions = responseHeaders["X-Content-Type-Options"][0]
                 });
             }
 
@@ -45,6 +47,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Hubs
                 count = 0,
                 keys = new string[0],
                 owinKeys = new string[0],
+                xContentTypeOptions = ""
             });
         }
     }

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/RequestItemsResponse.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/RequestItemsResponse.cs
@@ -6,6 +6,7 @@
         public int Count { get; set; }
         public string[] OwinKeys { get; set; }
         public string[] Keys { get; set; }
+        public string XContentTypeOptions { get; set; }
 
         public override int GetHashCode()
         {


### PR DESCRIPTION
Changed CallHandler.cs to always add the X-Content-Type-Options:nosniff header.
Updated the VerifyOwinContext test to check for the header.
