### PR TITLE
Set a max depth when deserializing into specific type.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
@@ -24,7 +24,11 @@ namespace Microsoft.AspNet.SignalR.Json
             // A non generic implementation of ToObject<T> on JToken
             using (var jsonReader = new StringReader(_value))
             {
-                var serializer = new JsonSerializer();
+                var settings = new JsonSerializerSettings
+                {
+                    MaxDepth = 20
+                };
+                var serializer = JsonSerializer.Create(settings);
                 return serializer.Deserialize(jsonReader, type);
             }
         }


### PR DESCRIPTION
This is a specific place where we weren't setting the max depth on the serializer. So use the default setting of 20.
