### PR TITLE
Don't raise the error event when stopping the connection.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Owin45/WebSockets/WebSocketMessageReader.cs
+++ b/src/Microsoft.AspNet.SignalR.Owin45/WebSockets/WebSocketMessageReader.cs
@@ -26,27 +26,8 @@ namespace Microsoft.AspNet.SignalR.WebSockets
         public static async Task<WebSocketMessage> ReadMessageAsync(WebSocket webSocket, byte[] buffer, int maxMessageSize, CancellationToken disconnectToken)
         {
             var arraySegment = new ArraySegment<byte>(buffer);
-            WebSocketReceiveResult receiveResult = null;
 
-            try
-            {
-                receiveResult = await webSocket.ReceiveAsync(arraySegment, disconnectToken).ConfigureAwait(continueOnCapturedContext: false);
-            }
-            catch (Exception)
-            {
-                // If the websocket is aborted while we're reading then just rethrow
-                // an operaton cancelled exception so the caller can handle it
-                // appropriately
-                if (webSocket.State == WebSocketState.Aborted)
-                {
-                    throw new OperationCanceledException();
-                }
-                else
-                {
-                    // Otherwise rethrow the original exception
-                    throw;
-                }
-            }
+            WebSocketReceiveResult receiveResult = await webSocket.ReceiveAsync(arraySegment, disconnectToken).ConfigureAwait(continueOnCapturedContext: false);
 
             // special-case close messages since they might not have the EOF flag set
             if (receiveResult.MessageType == WebSocketMessageType.Close)

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
@@ -146,6 +146,31 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             }
 
             [Theory]
+            [InlineData(HostType.IISExpress, TransportType.Websockets)]
+            [InlineData(HostType.IISExpress, TransportType.ServerSentEvents)]
+            [InlineData(HostType.IISExpress, TransportType.LongPolling)]
+            public void StoppingDoesntRaiseErrorEvent(HostType hostType, TransportType transportType)
+            {
+                using (var host = CreateHost(hostType, transportType))
+                {
+                    host.Initialize();
+                    var connection = CreateHubConnection(host);
+
+                    var tcs = new TaskCompletionSource<object>();
+                    connection.Error += ex =>
+                    {
+                        tcs.TrySetException(ex);
+                    };
+
+                    connection.Start(host.Transport).Wait();
+
+                    connection.Stop();
+
+                    tcs.Task.Wait(TimeSpan.FromSeconds(5));
+                }
+            }
+
+            [Theory]
             [InlineData(HostType.Memory, TransportType.ServerSentEvents)]
             [InlineData(HostType.Memory, TransportType.LongPolling)]
             [InlineData(HostType.IISExpress, TransportType.ServerSentEvents)]


### PR DESCRIPTION
- Never throw an operation cancelled exception from the websocket handler,
  just let it throw normally.
- Added functional test.
