### PR TITLE
Improved the error message for incompatible protocol versions

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -432,8 +432,8 @@
                     }
 
                     if (!res.ProtocolVersion || res.ProtocolVersion !== "1.2") {
-                        $(connection).triggerHandler(events.onError, "SignalR: Incompatible protocol version.");
-                        deferred.reject("SignalR: Incompatible protocol version.");
+                        $(connection).triggerHandler(events.onError, "You are using a version of the client that isn't compatible with the server. Client version 1.2, server version " + res.ProtocolVersion + ".");
+                        deferred.reject("You are using a version of the client that isn't compatible with the server. Client version 1.2, server version " + res.ProtocolVersion + ".");
                         return;
                     }
 

--- a/src/Microsoft.AspNet.SignalR.Client.WinRT/Resources.resw
+++ b/src/Microsoft.AspNet.SignalR.Client.WinRT/Resources.resw
@@ -124,7 +124,7 @@
     <value>The connection has not been established.</value>
   </data>
   <data name="Error_IncompatibleProtocolVersion" xml:space="preserve">
-    <value>Incompatible protocol version.</value>
+    <value>You are using a version of the client that isn't compatible with the server. Client version {0}, server version {1}.</value>
   </data>
   <data name="Error_ProxiesCannotBeAddedConnectionStarted" xml:space="preserve">
     <value>A HubProxy cannot be added after the connection has been started.</value>

--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -334,12 +334,16 @@ namespace Microsoft.AspNet.SignalR.Client
 
         private static void VerifyProtocolVersion(string versionString)
         {
-            Version version;
+            Version version = null;
+
             if (String.IsNullOrEmpty(versionString) ||
                 !TryParseVersion(versionString, out version) ||
                 !(version.Major == 1 && version.Minor == 2))
             {
-                throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_IncompatibleProtocolVersion));
+                throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture,
+                                                                  Resources.Error_IncompatibleProtocolVersion,
+                                                                  "1.1",
+                                                                  versionString ?? "null"));
             }
         }
 

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -124,7 +124,7 @@
     <value>The connection has not been established.</value>
   </data>
   <data name="Error_IncompatibleProtocolVersion" xml:space="preserve">
-    <value>Incompatible protocol version.</value>
+    <value>You are using a version of the client that isn't compatible with the server. Client version {0}, server version {1}.</value>
   </data>
   <data name="Error_ProxiesCannotBeAddedConnectionStarted" xml:space="preserve">
     <value>A HubProxy cannot be added after the connection has been started.</value>

--- a/tests/Microsoft.AspNet.SignalR.Tests/Client/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Client/ConnectionFacts.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Threading;
 using Microsoft.AspNet.SignalR.Client;
 using Microsoft.AspNet.SignalR.Client.Transports;
@@ -39,7 +40,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 var aggEx = Assert.Throws<AggregateException>(() => connection.Start(transport.Object).Wait());
                 var ex = aggEx.Unwrap();
                 Assert.IsType(typeof(InvalidOperationException), ex);
-                Assert.Equal("Incompatible protocol version.", ex.Message);
+                Assert.Equal("You are using a version of the client that isn't compatible with the server. Client version 1.1, server version null." , ex.Message);
             }
 
             [Fact]


### PR DESCRIPTION
Improved the error message that is thrown when the client (.NET and JS) and server SignalR protocol versions do not match.
#1176
