### PR TITLE
Fix fallback from sse to longpolling to avoid infinite reconnecting loop.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
@@ -19,7 +20,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         private int _startIndex = 0;
 
         // List of transports in fallback order
-        private readonly IClientTransport[] _transports;
+        private readonly IList<IClientTransport> _transports;
 
         public AutoTransport(IHttpClient httpClient)
         {
@@ -31,6 +32,12 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 new ServerSentEventsTransport(httpClient), 
                 new LongPollingTransport(httpClient) 
             };
+        }
+
+        public AutoTransport(IHttpClient httpClient, IList<IClientTransport> transports)
+        {
+            _httpClient = httpClient;
+            _transports = transports;
         }
 
         public string Name
@@ -96,7 +103,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
                     // If that transport fails to initialize then fallback
                     var next = index + 1;
-                    if (next < _transports.Length)
+                    if (next < _transports.Count)
                     {
                         // Try the next transport
                         ResolveTransport(connection, data, disconnectToken, tcs, next);

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             : base(httpClient, "serverSentEvents")
         {
             ReconnectDelay = TimeSpan.FromSeconds(2);
-            ConnectionTimeout = TimeSpan.FromSeconds(2);
+            ConnectionTimeout = TimeSpan.FromSeconds(5);
         }
 
         /// <summary>
@@ -222,6 +222,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 {
                     callbackInvoker.Invoke((conn, cb) =>
                     {
+                        // Abort the request before cancelling
+                        request.Abort();
+
                         // Connection timeout occurred
                         cb(new TimeoutException());
                     },

--- a/src/Microsoft.AspNet.SignalR.Hosting.Memory/Response.cs
+++ b/src/Microsoft.AspNet.SignalR.Hosting.Memory/Response.cs
@@ -156,7 +156,7 @@ namespace Microsoft.AspNet.SignalR.Hosting.Memory
                     {
                         if (!asyncResult.IsCompleted)
                         {
-                            asyncResult.SetAsCompleted(0, false);
+                            asyncResult.SetAsCompleted(new OperationCanceledException(), completedSynchronously: false);
                         }
                     }
                 },

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Client.Http;
+using Microsoft.AspNet.SignalR.Client.Transports;
 using Microsoft.AspNet.SignalR.FunctionalTests.Infrastructure;
 using Microsoft.AspNet.SignalR.Hosting.Memory;
 using Owin;
@@ -48,20 +50,36 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                 }
             }
 
-            [Theory]
-            [InlineData(HostType.Memory, TransportType.Auto)]
-            // [InlineData(HostType.IISExpress, TransportType.Auto)]
-            public void FallbackToLongPollingWorks(HostType hostType, TransportType transportType)
+            [Fact]
+            public void FallbackToLongPollingIIS()
             {
-                using (var host = CreateHost(hostType, transportType))
+                using (ITestHost host = new IISExpressTestHost())
                 {
                     host.Initialize();
 
                     var connection = CreateConnection(host.Url + "/fall-back");
-                    
-                    connection.Start(host.Transport).Wait();
+                    var tcs = new TaskCompletionSource<object>();
+
+                    connection.StateChanged += change =>
+                    {
+                        if (change.NewState == ConnectionState.Reconnecting)
+                        {
+                            tcs.TrySetException(new Exception("The connection should not be reconnecting"));
+                        }
+                    };
+
+                    var transports = new IClientTransport[]  {
+                        new ServerSentEventsTransport(),
+                        new LongPollingTransport()
+                    };
+
+                    var transport = new AutoTransport(new DefaultHttpClient(), transports);
+
+                    connection.Start(transport).Wait();
 
                     Assert.Equal(connection.Transport.Name, "longPolling");
+
+                    Assert.False(tcs.Task.Wait(TimeSpan.FromSeconds(10)));
 
                     connection.Stop();
                 }

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/App_Start/RegisterHubs.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/App_Start/RegisterHubs.cs
@@ -60,6 +60,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Infrastructure.IIS
             RouteTable.Routes.MapConnection<SyncErrorConnection>("sync-error", "sync-error");
             RouteTable.Routes.MapConnection<AddGroupOnConnectedConnection>("add-group", "add-group");
             RouteTable.Routes.MapConnection<UnusableProtectedConnection>("protected", "protected");
+            RouteTable.Routes.MapConnection<FallbackToLongPollingConnection>("fall-back", "/fall-back");
 
             // End point to hit to verify the webserver is up
             RouteTable.Routes.Add("test-endpoint", new Route("ping", new TestEndPoint()));

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Connections/FallbackToLongPollingConnection.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Connections/FallbackToLongPollingConnection.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests
 
             if (transport != "longPolling")
             {
-                await Task.Delay(5000);
+                await Task.Delay(7000);
             }
 
             await base.OnConnected(request, connectionId);


### PR DESCRIPTION
- Abort the SSE request when timing it out.
- Updated tests to detect this condition.
- Updated MemoryHost to throw OperationCancelledException to mimic iis.
#1121
