### PR TITLE
Fix issue on .NET 4.0 where cancellation token is already disposed.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/CancellationTokenExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/CancellationTokenExtensions.cs
@@ -28,7 +28,15 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
                     // This normally waits until the callback is finished invoked but we don't care
                     if (Interlocked.Exchange(ref callbackInvoked, 1) == 0)
                     {
-                        registration.Dispose();
+                        try
+                        {
+                            registration.Dispose();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // Bug #1549, .NET 4.0 has a bug where this throws if the CTS
+                            // has been disposed
+                        }
                     }
                 });
             }

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/TransportHeartBeat.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/TransportHeartBeat.cs
@@ -104,7 +104,11 @@ namespace Microsoft.AspNet.SignalR.Transports
 
                 // Kick out the older connection. This should only happen when 
                 // a previous connection attempt fails on the client side (e.g. transport fallback).
-                EndConnection(oldMetadata);
+
+                // Don't bother disposing the registration here since the token source
+                // gets disposed after the request has ended
+                EndConnection(oldMetadata, disposeRegistration: false);
+
                 // If we have old metadata this isn't a new connection
                 isNewConnection = false;
             }
@@ -367,16 +371,19 @@ namespace Microsoft.AspNet.SignalR.Transports
             Dispose(true);
         }
 
-        private static void EndConnection(ConnectionMetadata metadata)
+        private static void EndConnection(ConnectionMetadata metadata, bool disposeRegistration = true)
         {
+            if (disposeRegistration)
+            {
+                // Dispose of the registration
+                if (metadata.Registration != null)
+                {
+                    metadata.Registration.Dispose();
+                }
+            }
+
             // End the connection
             metadata.Connection.End();
-
-            // Dispose of the registration
-            if (metadata.Registration != null)
-            {
-                metadata.Registration.Dispose();
-            }
         }
 
         private class ConnectionMetadata


### PR DESCRIPTION
- Dispose the token only if it's not a result of ending an existing
  connection.
- Dispose the token before ending the connection.
- Catch ObjectDisposedException in SafeRegister's DisposableAction.
