### PR TITLE
Fix performance counter hanging issues.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/PerformanceCounterManager.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/PerformanceCounterManager.cs
@@ -26,9 +26,6 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
         private volatile bool _initialized;
         private object _initLocker = new object();
 
-        // REVIEW: Is this long enough to determine if it *would* hang forever?
-        private readonly static TimeSpan _performanceCounterWaitTimeout = TimeSpan.FromSeconds(2);
-
         /// <summary>
         /// Creates a new instance.
         /// </summary>


### PR DESCRIPTION
- Always try to create the SignalR performance counters without checking
  for existence since that hangs.
#1158
