### PR TITLE
Properly handle async task failures

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
@@ -199,11 +199,7 @@ namespace Microsoft.AspNet.SignalR
 
                     task.ContinueWith(t =>
                     {
-                        if (t.IsCompleted)
-                        {
-                            tcs.TrySetResult(null);
-                        }
-                        else 
+                        if (t.IsFaulted || t.IsCanceled)
                         {
                             try
                             {
@@ -222,6 +218,10 @@ namespace Microsoft.AspNet.SignalR
                             {
                                 tcs.TrySetException(e);
                             }
+                        }
+                        else
+                        {
+                            tcs.TrySetResult(null);
                         }
                     },
                     TaskContinuationOptions.ExecuteSynchronously);


### PR DESCRIPTION
- I once again confused Task.IsCompleted with
  Task.Status == TaskStatus.RanToCompletion in
  ContinueWithNotComplete
