### PR TITLE
Ensure that group tokens are unique per connection id.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs
@@ -287,13 +287,14 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
 
         private void PopulateResponseState(PersistentResponse response)
         {
-            PopulateResponseState(response, _groups, _serializer, _protectedData);
+            PopulateResponseState(response, _groups, _serializer, _protectedData, _connectionId);
         }
 
         internal static void PopulateResponseState(PersistentResponse response,
                                                    DiffSet<string> groupSet,
                                                    IJsonSerializer serializer,
-                                                   IProtectedData protectedData)
+                                                   IProtectedData protectedData,
+                                                   string connectionId)
         {
             bool anyChanges = groupSet.DetectChanges();
 
@@ -306,7 +307,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
                 if (groups.Any())
                 {
                     // Remove group prefixes before any thing goes over the wire
-                    string groupsString = serializer.Stringify(PrefixHelper.RemoveGroupPrefixes(groups));
+                    string groupsString = connectionId + ':' + serializer.Stringify(PrefixHelper.RemoveGroupPrefixes(groups)); ;
 
                     // The groups token
                     response.GroupsToken = protectedData.Protect(groupsString, Purposes.Groups);

--- a/tests/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             [Fact]
             public void MissingGroupTokenReturnsEmptyList()
             {
-                var groups = DoVerifyGroups(groupsToken: null);
+                var groups = DoVerifyGroups(groupsToken: null, connectionId: null);
 
                 Assert.Equal(0, groups.Count);
             }
@@ -74,7 +74,15 @@ namespace Microsoft.AspNet.SignalR.Tests
             [Fact]
             public void NullProtectedDataTokenReturnsEmptyList()
             {
-                var groups = DoVerifyGroups(groupsToken: "groups", hasProtectedData: false);
+                var groups = DoVerifyGroups(groupsToken: "groups", connectionId: null, hasProtectedData: false);
+
+                Assert.Equal(0, groups.Count);
+            }
+
+            [Fact]
+            public void GroupsTokenWithInvalidConnectionIdReturnsEmptyList()
+            {
+                var groups = DoVerifyGroups(groupsToken: @"wrong:[""g1"",""g2""]", connectionId: "id");
 
                 Assert.Equal(0, groups.Count);
             }
@@ -82,14 +90,14 @@ namespace Microsoft.AspNet.SignalR.Tests
             [Fact]
             public void GroupsAreParsedFromToken()
             {
-                var groups = DoVerifyGroups(groupsToken: @"[""g1"",""g2""]");
+                var groups = DoVerifyGroups(groupsToken: @"id:[""g1"",""g2""]", connectionId: "id");
 
                 Assert.Equal(2, groups.Count);
                 Assert.Equal("g1", groups[0]);
                 Assert.Equal("g2", groups[1]);
             }
 
-            private static IList<string> DoVerifyGroups(string groupsToken, bool hasProtectedData = true)
+            private static IList<string> DoVerifyGroups(string groupsToken, string connectionId, bool hasProtectedData = true)
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
                 var req = new Mock<IRequest>();
@@ -113,7 +121,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 var context = new HostContext(req.Object, null);
                 connection.Object.Initialize(dr, context);
 
-                return connection.Object.VerifyGroups(context);
+                return connection.Object.VerifyGroups(context, connectionId);
             }
         }
 
@@ -124,7 +132,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
                 var req = new Mock<IRequest>();
-                
+
                 var protectedData = new Mock<IProtectedData>();
                 protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns<string, string>((value, purpose) => value);
@@ -144,7 +152,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
                 var req = new Mock<IRequest>();
-                
+
                 var protectedData = new Mock<IProtectedData>();
                 protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns<string, string>((value, purpose) => value);
@@ -163,7 +171,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
                 var req = new Mock<IRequest>();
-                
+
                 var protectedData = new Mock<IProtectedData>();
                 protectedData.Setup(m => m.Protect(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns<string, string>((value, purpose) => value);


### PR DESCRIPTION
- Added the connection id to the groups token.
- Verify that it's the same connection id when validating groups.
- Added test to verify that you can't listen to messages if you have
  the groups token alone.
#1506
