### PR TITLE
#1776 - Fixed race with Post request and PollingRequestHandler triggering events...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/LongPolling/PollingRequestHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/LongPolling/PollingRequestHandler.cs
@@ -91,6 +91,10 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     return;
                 }
 
+                // This is called just prior to posting the request to ensure that any in-flight polling request
+                // is always executed before an OnAfterPoll
+                OnPolling();
+
                 // A url is required
                 string url = ResolveUrl();
 
@@ -130,11 +134,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     },
                     exception);
                 });
-            }
-
-            // This is called at the bottom since the above code is run async
-            // Represents when the PollingRequestHandler has a poll in flight
-            OnPolling();
+            }            
         }
 
         /// <summary>


### PR DESCRIPTION
... nearly synchronously
- Not sure how this was reproduced "easily", it's a super small race (an
  entire function has to execute before executing a single line).
- Lastly with this fix, it deems that this is not a regression but
  rather just a very difficult stress bug to repro
- I was unable to reproduce the issue due to the craziness of the race.
#1776
