### PR TITLE
Fix issue with scale out and groups.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs
@@ -261,7 +261,13 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
                         if (EventKeyAdded != null)
                         {
                             _groups.Add(name);
-                            _signals.Add(name);
+
+                            // Don't add dupes
+                            if (!_signals.Contains(name))
+                            {
+                                _signals.Add(name);
+                            }
+
                             EventKeyAdded(this, name);
                         }
                     }

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/MessageBusType.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/MessageBusType.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.AspNet.SignalR.FunctionalTests.Infrastructure
+{
+    public enum MessageBusType
+    {
+        Default,
+        Fake,
+        SqlServer,
+        ServiceBus,
+        Redis
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Microsoft.AspNet.SignalR.Tests.Common.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Microsoft.AspNet.SignalR.Tests.Common.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Infrastructure\MemoryTestHost.cs" />
     <Compile Include="Infrastructure\OwinTestHost.cs" />
     <Compile Include="Infrastructure\RequestItemsResponse.cs" />
+    <Compile Include="Infrastructure\MessageBusType.cs" />
     <Compile Include="Infrastructure\SystemNetLogging.cs" />
     <Compile Include="Infrastructure\TransportType.cs" />
     <Compile Include="Owin\BasicAuthApplication.cs" />

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/ScaleOutMessageBusFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/ScaleOutMessageBusFacts.cs
@@ -160,51 +160,6 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             }
         }
 
-        [Fact(Skip = "This isn't consistent yet")]
-        public void PayloadIdReset()
-        {
-            var dr = new DefaultDependencyResolver();
-            using (var bus = new TestScaleoutBus(dr))
-            {
-                var subscriber = new TestSubscriber(new[] { "key" });
-                IDisposable subscription = null;
-                var cd = new CountDownRange<int>(Enumerable.Range(1, 4));
-                var wh = new ManualResetEventSlim();
-
-                try
-                {
-                    subscription = bus.Subscribe(subscriber, null, (result, state) =>
-                    {
-                        if (!result.Terminal)
-                        {
-                            foreach (var m in result.GetMessages())
-                            {
-                                int n = Int32.Parse(m.GetString());
-                                Assert.True(cd.Mark(n));
-                            }
-                        }
-
-                        return TaskAsyncHelper.True;
-
-                    }, 10, null);
-
-                    bus.Publish(0, 0, new[] { new Message("test", "key", "1") });
-                    bus.Publish(0, 1, new[] { new Message("test", "key", "2") });
-                    bus.Publish(0, 2, new[] { new Message("test", "key", "3") });
-                    bus.Publish(0, 0, new[] { new Message("test", "key", "4") });
-
-                    Assert.True(cd.Wait(TimeSpan.FromSeconds(10)));
-                }
-                finally
-                {
-                    if (subscription != null)
-                    {
-                        subscription.Dispose();
-                    }
-                }
-            }
-        }
-
         private class TestScaleoutBus : ScaleoutMessageBus
         {
             private int _streams;


### PR DESCRIPTION
- Don't add the same signals to the list since scaleout uses these
  to process messages.
- Added tests for adding to groups multiple times for scaleout and non scaleout.
- Added initial infrastructure for testing scaleout combinations.
#1819
