### PR TITLE
Remove dependancy on .NET Framework 3.5

### DIFF
--- a/tools/ajaxmin/AjaxMin.exe.config
+++ b/tools/ajaxmin/AjaxMin.exe.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup useLegacyV2RuntimeActivationPolicy="true">
+    <supportedRuntime version="v4.0"/>
+    <supportedRuntime version="v2.0.50727"/>                
+  </startup>
+</configuration>


### PR DESCRIPTION
Our enlistment should not require installation of .net fx 3.5. See issue 1900. 
