### PR TITLE
Renamed 'New Rule Set' to 'Microsoft SignalR Rules'.

### DIFF
--- a/src/Common/Microsoft.AspNet.SignalR.ruleset
+++ b/src/Common/Microsoft.AspNet.SignalR.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="New Rule Set" Description=" " ToolsVersion="11.0">
+<RuleSet Name="Microsoft SignalR Rules" Description=" " ToolsVersion="11.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1000" Action="Error" />
     <Rule Id="CA1001" Action="Error" />


### PR DESCRIPTION
'New Rule Set' appears in global rule sets list, even if you work with different(form SignalR) solutions, so it should have more specific name.
