### PR TITLE
Mark personal builds as private

### DIFF
--- a/build-ci-perf.cmd
+++ b/build-ci-perf.cmd
@@ -9,10 +9,18 @@ if "%branch%" == "" (
    set branch=dev
 )
 
+set privateRun=true
+if /i "%branch%" == "dev" (
+  set privateRun=false
+)
+if /i "%branch%" == "release" (
+  set privateRun=false
+)
+
 call \PerfRuns\SignalR-Env.cmd
 
 cmd /c build-ci Release 1 true
 
 if %ERRORLEVEL% neq 0 exit /b %ERRORLEVEL%
 
-cmd /c %PerfToolsBin%\PerfRun /TeamName:SignalR /LabConfigPath:%PerfLabConfig% /RemotePasswordFile:%PerfPasswordFile% /UpdateMetadata:true /Import:true /Branch:%branch% /Build:%build% /Run:artifacts\Release\Microsoft.AspNet.SignalR.Stress
+cmd /c %PerfToolsBin%\PerfRun /TeamName:SignalR /LabConfigPath:%PerfLabConfig% /RemotePasswordFile:%PerfPasswordFile% /UpdateMetadata:true /Import:true /Branch:%branch% /Build:%build% /Run:artifacts\Release\Microsoft.AspNet.SignalR.Stress /Archive:true /PrivateRun:%privateRun%


### PR DESCRIPTION
-private runs are excluded from report card and trend graphs
-note: personal builds / private runs are working!
