### PR TITLE
Fixed Mono support

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hosting/HostDependencyResolverExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hosting/HostDependencyResolverExtensions.cs
@@ -20,8 +20,10 @@ namespace Microsoft.AspNet.SignalR.Hosting
                 throw new ArgumentNullException("instanceName");
             }
 
+#if !MONO
             // Initialize the performance counters
             resolver.InitializePerformanceCounters(instanceName, hostShutdownToken);
+#endif
 
             // Dispose the dependency resolver on host shut down (cleanly)
             resolver.InitializeResolverDispose(hostShutdownToken);

--- a/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
+++ b/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;PERFCOUNTERS</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;PERFCOUNTERS;MONO</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Microsoft.AspNet.SignalR.Core.XML</DocumentationFile>


### PR DESCRIPTION
- Fixed Mono support (disabled performance counters when using the Mono solution as described here: https://github.com/SignalR/SignalR/issues/1914)
- Added MONO define symbol to the Microsoft.AspNet.SignalR.Core project in the Mono solution
