### PR TITLE
Stress fixes and enabling external scenario

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Microsoft.AspNet.SignalR.LoadTestHarness.csproj
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Microsoft.AspNet.SignalR.LoadTestHarness.csproj
@@ -212,6 +212,10 @@
       <Project>{1b9a82c4-bca1-4834-a33e-226f17be070b}</Project>
       <Name>Microsoft.AspNet.SignalR.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.AspNet.SignalR.StressServer\Microsoft.AspNet.SignalR.StressServer.csproj">
+      <Project>{9ac65ed5-48c2-4c5c-8498-dc340b313fdf}</Project>
+      <Name>Microsoft.AspNet.SignalR.StressServer</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/src/Microsoft.AspNet.SignalR.Stress/Microsoft.AspNet.SignalR.Stress.csproj
+++ b/src/Microsoft.AspNet.SignalR.Stress/Microsoft.AspNet.SignalR.Stress.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/src/Microsoft.AspNet.SignalR.Stress/RunBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Stress/RunBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Stress.Infrastructure;
@@ -251,9 +252,17 @@ namespace Microsoft.AspNet.SignalR.Stress
                 median = median + values[(values.Length / 2) - 1] / 2;
             }
 
-            var average = values.Average();
-            var sumOfSquaresDiffs = values.Select(v => (v - average) * (v - average)).Sum();
-            var stdDevP = Math.Sqrt(sumOfSquaresDiffs / values.Length) / average * 100;
+            var sum = values.Select(i => new BigInteger(i)).Aggregate((aggregate, bi) => aggregate + bi);
+            BigInteger remainder;
+            var average = (double)BigInteger.DivRem(sum, values.Length, out remainder) + ((double)remainder / values.Length);
+            
+            double stdDevP = 0;
+            if (average > 0)
+            {
+                var sumOfSquares = values.Sum(i => Math.Pow(i - average, 2.0));
+                stdDevP = Math.Sqrt(sumOfSquares / values.Length) / average * 100;
+            }
+            
             Console.WriteLine("{0} (MEDIAN):  {1}", key, Math.Round(median));
             Console.WriteLine("{0} (AVERAGE): {1}", key, Math.Round(average));
             Console.WriteLine("{0} (STDDEV%): {1}%", key, Math.Round(stdDevP));

--- a/src/Microsoft.AspNet.SignalR.Stress/TPlan.Perf.xml
+++ b/src/Microsoft.AspNet.SignalR.Stress/TPlan.Perf.xml
@@ -16,24 +16,24 @@
     </trackingVariation>
     <trackingVariation name="SendReceive-Memory-ServerSentEvents">
       <metric name="Message Bus Messages Received/Sec" selection="Average" units="Numeric">
-        <target value="5719925.40" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="4000000" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
     
     <!--Memory Host with Hubs-->
     <trackingVariation name="HubInvocation">
       <metric name="Message Bus Messages Published/Sec" selection="Average" units="Numeric">
-        <target value="17323.64" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="17000" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
     <trackingVariation name="SimpleEchoHub-Memory-LongPolling">
       <metric name="Latency In Milliseconds" selection="Average" units="Numeric">
-        <target value="0" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="250" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
     <trackingVariation name="SimpleEchoHub-Memory-ServerSentEvents">
       <metric name="Latency In Milliseconds" selection="Average" units="Numeric">
-        <target value="0" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="250" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
 
@@ -45,19 +45,19 @@
     </trackingVariation>
     <trackingVariation name="RedisMessageBus">
       <metric name="Message Bus Messages Received/Sec" selection="Average" units="Numeric">
-        <target value="1492096.12" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="780000" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
     <trackingVariation name="SqlMessageBus">
       <metric name="Message Bus Messages Received/Sec" selection="Average" units="Numeric">
-        <target value="418655.70" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="655000" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
   
     <!-- External Host-->
-    <trackingVariation name="SimpleEchoHub-LongPolling-External">
+    <trackingVariation name="SimpleEchoHub-External-LongPolling">
       <metric name="Latency In Milliseconds" selection="Average" units="Numeric">
-        <target value="0" labConfig="XSPPERF8S_WIN8_X64" />
+        <target value="250" labConfig="XSPPERF8S_WIN8_X64" />
       </metric>
     </trackingVariation>
     
@@ -102,8 +102,8 @@
     <command name="SetupIIS" wait="Exit">
       powershell -executionpolicy remotesigned -command "{bin}\RegisterIIS.ps1 {currentdir}\www
     </command>
-    <command name="SimpleEchoHub-LongPolling-External" wait="Exit">
-      Microsoft.AspNet.SignalR.Stress.exe /Run:SimpleEchoHub /Transport:LongPolling /Host:External /Connections:5 /Url:http://{server-01}:81/
+    <command name="SimpleEchoHub-External-LongPolling" wait="Exit">
+      Microsoft.AspNet.SignalR.Stress.exe /Run:SimpleEchoHub /Transport:LongPolling /Host:External /Connections:5 /Url:http://{server-01}:81/ /Duration:150
     </command>
   
   </commands>
@@ -129,10 +129,8 @@
     <run command="RedisMessageBus" role="server-01" output="true" />
   
     <!--External host hub tests-->
-    <!-- Disabling until this scenario is fixed
     <run command="CopyWWW" role="controller" output="true" profile="None" />
     <run command="SetupIIS" role="server-01" output="true" profile="None" />
-    <run command="SimpleEchoHub-LongPolling-External" role="client-01" output="true" />
-    -->
+    <run command="SimpleEchoHub-External-LongPolling" role="client-01" output="true" />
   </plan>
 </config>


### PR DESCRIPTION
-Fixed SimpleEchoHub-External by adding LoadTestHarness reference
-Fixed SimpleEchoHub-External variation name in TPlan
-Increased SimpleEchoHub-External duration due to long latencies for
remote client
-Fixed ArithmeticOverflow when calculating samples average
-Adjusting targets for scenarios with stable trends
