### PR TITLE
Use CreateDataProtector instead of the deprecated GetDataProtectionProvider

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
@@ -92,18 +92,22 @@ namespace Owin
 
                 // Use the data protection provider from app builder and fallback to the
                 // Dpapi provider
-                IDataProtectionProvider provider = builder.GetDataProtectionProvider() ?? new DpapiDataProtectionProvider();
+                IDataProtectionProvider provider = builder.GetDataProtectionProvider();
                 IProtectedData protectedData;
 
                 // If we're using DPAPI then fallback to the default protected data if running
                 // on mono since it doesn't support any of this
-                if (provider is DpapiDataProtectionProvider && 
-                    MonoUtility.IsRunningMono)
+                if (provider == null && MonoUtility.IsRunningMono)
                 {
                     protectedData = new DefaultProtectedData();
                 }
                 else
                 {
+                    if (provider == null)
+                    {
+                        provider = new DpapiDataProtectionProvider(instanceName);
+                    }
+
                     protectedData = new DataProtectionProviderProtectedData(provider);
                 }
 


### PR DESCRIPTION
- This unfortunately removes the ability to fall back to DefaultProtectedData
  on Mono

We _could_ call into CreateDataProtector just to see if it returns an object with a FullName of "Microsoft.Owin.Security.DataProtection.DpapiDataProtector" (the type is internal). Then if the return value is a DpapiDataProtector and we are running on Mono, we could use DefaultProtectedData instead, but that feels like such a hack. I think this is something Microsoft.Owin.Security could do for us.

BTW, all CreateDataProtector does is the following:

``` CSharp
public static IDataProtector CreateDataProtector(this IAppBuilder app, params string[] purposes)
{
    if (app == null)
    {
        throw new ArgumentNullException("app");
    }
    IDataProtectionProvider dataProtectionProvider = app.GetDataProtectionProvider();
    if (dataProtectionProvider == null)
    {
        dataProtectionProvider = FallbackDataProtectionProvider(app);
    }
    return dataProtectionProvider.Create(purposes);
}
```

where FallBackDataProtectionProvider is:

``` CSharp
private static IDataProtectionProvider FallbackDataProtectionProvider(IAppBuilder app)
{
    return new DpapiDataProtectionProvider(GetAppName(app));
}
```

This isn't really all that different from what we were already doing (I would argue what we were doing before was better since it supported Mono), and GetDataProtectionProvider() still exists in Microsoft.Owin.Security 2.0, so I think we should continue using GetDataProtectionProvider() until Microsoft.Owin.Security provides Mono support whether it's deprecated or not.
#2104
