### PR TITLE
skip websocket tests on IE10 windows7

### DIFF
--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Scripts/test.utilities.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Scripts/test.utilities.js
@@ -2,7 +2,9 @@
 
 (function ($, window) {
     var ios = !!navigator.userAgent.match(/iPod|iPhone|iPad/),
+        windows = !!navigator.userAgent.match(/Windows NT/),
         rfcWebSockets = !!window.WebSocket,
+        windowsVersion,
         iosVersion;
 
     function wrapConnectionStart(connection, end, assert) {
@@ -13,6 +15,13 @@
                 assert.ok(false, "Failed to initiate signalr connection: " + window.JSON.stringify(reason));
                 end();
             });
+        }
+    }
+
+    if (windows && rfcWebSockets) {
+        windowsVersion = navigator.userAgent.match(/Windows NT (\d+[.]\d+)/);
+        if (windowsVersion && windowsVersion.length > 0) {
+            rfcWebSockets = parseFloat(windowsVersion[1]) > 6.1;
         }
     }
 


### PR DESCRIPTION
JS client tests are running both server and client on same machine. 
Win7 tests running on IE10 support websocket on browser but not on server and we should skip these tests
