### PR TITLE
Made Hubs more testable.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hub.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hub.cs
@@ -16,15 +16,12 @@ namespace Microsoft.AspNet.SignalR
         protected Hub()
         {
             Clients = new HubConnectionContext();
-            Clients.All = new NullClientProxy();
-            Clients.Others = new NullClientProxy();
-            Clients.Caller = new NullClientProxy();
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public HubConnectionContext Clients { get; set; }
+        public IHubCallerConnectionContext Clients { get; set; }
 
         /// <summary>
         /// Provides information about the calling client.

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubConnectionContext.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubConnectionContext.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
     /// <summary>
     /// Encapsulates all information about an individual SignalR connection for an <see cref="IHub"/>.
     /// </summary>
-    public class HubConnectionContext : IHubConnectionContext
+    public class HubConnectionContext : IHubCallerConnectionContext
     {
         private readonly string _hubName;
         private readonly string _connectionId;
@@ -21,6 +21,9 @@ namespace Microsoft.AspNet.SignalR.Hubs
         /// </summary>
         public HubConnectionContext()
         {
+            All = new NullClientProxy();
+            Others = new NullClientProxy();
+            Caller = new NullClientProxy();
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/IHub.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/IHub.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
         /// <summary>
         /// Gets a dynamic object that represents all clients connected to this hub (not hub instance).
         /// </summary>
-        HubConnectionContext Clients { get; set; }
+        IHubCallerConnectionContext Clients { get; set; }
 
         /// <summary>
         /// Gets the <see cref="IGroupManager"/> the hub instance.

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/IHubCallerConnectionContext.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/IHubCallerConnectionContext.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Microsoft.AspNet.SignalR.Hubs
+{
+    /// <summary>
+    /// Encapsulates all information about an individual SignalR connection for an <see cref="IHub"/>.
+    /// </summary>
+    public interface IHubCallerConnectionContext : IHubConnectionContext
+    {
+        dynamic Caller { get; }
+        dynamic Others { get; }
+        dynamic OthersInGroup(string groupName);
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
+++ b/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Hubs\EmptyJavaScriptProxyGenerator.cs" />
     <Compile Include="Hubs\EnumerableOfAssemblyLocator.cs" />
     <Compile Include="Hubs\GroupProxy.cs" />
+    <Compile Include="Hubs\IHubCallerConnectionContext.cs" />
     <Compile Include="Hubs\Lookup\Descriptors\NullMethodDescriptor.cs" />
     <Compile Include="Hubs\Lookup\HubMethodDispatcher.cs" />
     <Compile Include="Infrastructure\AckHandler.cs" />

--- a/tests/Microsoft.AspNet.SignalR.Tests/DefaultActionResolverFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/DefaultActionResolverFacts.cs
@@ -301,7 +301,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 }
             }
 
-            public HubConnectionContext Clients
+            public IHubCallerConnectionContext Clients
             {
                 get
                 {

--- a/tests/Microsoft.AspNet.SignalR.Tests/Microsoft.AspNet.SignalR.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Microsoft.AspNet.SignalR.Tests.csproj
@@ -101,6 +101,7 @@
     <Compile Include="PrefixMatcherFacts.cs" />
     <Compile Include="BufferTextWriterFacts.cs" />
     <Compile Include="Server\AckHandlerFacts.cs" />
+    <Compile Include="Server\Hubs\HubFacts.cs" />
     <Compile Include="Server\ProtocolResolverFacts.cs" />
     <Compile Include="Server\ServiceBusConfigurationFacts.cs" />
     <Compile Include="Server\DiffSetFacts.cs" />

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/Hubs/HubFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/Hubs/HubFacts.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Dynamic;
+using Microsoft.AspNet.SignalR.Hubs;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.SignalR.Tests.Server.Hubs
+{
+    public class HubFacts
+    {
+        [Fact]
+        public void HubsAreMockableViaDynamic()
+        {
+            bool sendCalled = false;
+            var hub = new MyHub();
+            var mockClients = new Mock<IHubCallerConnectionContext>();
+
+            hub.Clients = mockClients.Object;
+
+            dynamic all = new ExpandoObject();
+            all.send = new Action<string>(message =>
+            {
+                sendCalled = true;
+            });
+
+            mockClients.Setup(m => m.All).Returns((ExpandoObject)all);
+            hub.Send("foo");
+
+            Assert.True(sendCalled);
+        }
+
+        [Fact]
+        public void HubsAreMockableViaType()
+        {
+            var hub = new MyHub();
+            var mockClients = new Mock<IHubCallerConnectionContext>();
+            var all = new Mock<IClientContract>();
+
+            hub.Clients = mockClients.Object;
+            all.Setup(m => m.send(It.IsAny<string>())).Verifiable();
+            mockClients.Setup(m => m.All).Returns(all.Object);
+            hub.Send("foo");
+
+            all.VerifyAll();
+        }
+
+        [Fact]
+        public void HubsGroupAreMockable()
+        {
+            var hub = new MyHub();
+            var mockClients = new Mock<IHubCallerConnectionContext>();
+            var groups = new Mock<IClientContract>();
+
+            hub.Clients = mockClients.Object;
+            groups.Setup(m => m.send(It.IsAny<string>())).Verifiable();
+            mockClients.Setup(m => m.Group("test")).Returns(groups.Object);
+            hub.SendGroup("test", "foo");
+
+            groups.VerifyAll();
+        }
+
+        [Fact]
+        public void HubsClientIsMockable()
+        {
+            var hub = new MyHub();
+            var mockClients = new Mock<IHubCallerConnectionContext>();
+            var clients = new Mock<IClientContract>();
+
+            hub.Clients = mockClients.Object;
+            clients.Setup(m => m.send(It.IsAny<string>())).Verifiable();
+            mockClients.Setup(m => m.Client("random")).Returns(clients.Object);
+            hub.SendIndividual("random", "foo");
+
+            clients.VerifyAll();
+        }
+
+        private class MyHub : Hub
+        {
+            public void Send(string messages)
+            {
+                Clients.All.send(messages);
+            }
+
+            public void SendGroup(string group, string message)
+            {
+                Clients.Group(group).send(message);
+            }
+
+            public void SendIndividual(string connectionId, string message)
+            {
+                Clients.Client(connectionId).send(message);
+            }
+        }
+
+        public interface IClientContract
+        {
+            void send(string messages);
+        }
+    }
+}


### PR DESCRIPTION
- Introduced new interface IHubCallerConnectionContext
- Changed IHub's Client property to that instead of the concrete class
- Added tests demonstrating how to use the new extensibility to mock method calls
#1899
