### PR TITLE
Setup a default trace listener if the host provides a "host.TraceOutput"

### DIFF
--- a/samples/Microsoft.AspNet.SelfHost.Samples/Startup.cs
+++ b/samples/Microsoft.AspNet.SelfHost.Samples/Startup.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNet.SignalR;
+﻿using System.Diagnostics;
+using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Samples;
+using Microsoft.AspNet.SignalR.Tracing;
 using Owin;
 
 namespace Microsoft.AspNet.SelfHost.Samples
@@ -10,6 +12,10 @@ namespace Microsoft.AspNet.SelfHost.Samples
         {
             app.MapConnection<RawConnection>("/raw-connection", new ConnectionConfiguration { EnableCrossDomain = true });
             app.MapHubs();
+
+            // Turn tracing on programmatically
+            ITraceManager traceManager= GlobalHost.DependencyResolver.Resolve<ITraceManager>();
+            traceManager.Switch.Level = SourceLevels.Information;
         }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Core/Owin/Infrastructure/OwinConstants.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/Infrastructure/OwinConstants.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNet.SignalR
         public const string HostOnAppDisposing = "host.OnAppDisposing";
         public const string HostAppNameKey = "host.AppName";
         public const string HostAppModeKey = "host.AppMode";
+        public const string HostTraceOutputKey = "host.TraceOutput";
         public const string HostReferencedAssembliesKey = "host.ReferencedAssemblies";
         public const string AppModeDevelopment = "development";
     }

--- a/src/Microsoft.AspNet.SignalR.Core/Owin/Infrastructure/OwinEnvironmentExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/Infrastructure/OwinEnvironmentExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Reflection;
 using System.Threading;
 
@@ -29,6 +30,17 @@ namespace Microsoft.AspNet.SignalR
                 {
                     return stringVal;
                 }
+            }
+
+            return null;
+        }
+
+        internal static TextWriter GetTraceOutput(this IDictionary<string, object> environment)
+        {
+            object value;
+            if (environment.TryGetValue(OwinConstants.HostTraceOutputKey, out value))
+            {
+                return value as TextWriter;
             }
 
             return null;


### PR DESCRIPTION
- Turned tracing on in self host sample.
  #2260
