### PR TITLE
bearer

### DIFF
--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
@@ -45,6 +45,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Host.SystemWeb.2.0.0-rc1-20717-470\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.Security.2.0.0-rc1-20717-470\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.Security.OAuth.2.0.0-rc1-20717-470\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
     </Reference>
@@ -63,6 +71,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/packages.config
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/packages.config
@@ -3,6 +3,8 @@
   <package id="Microsoft.Owin" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="2.0.0-rc1-20717-470" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="2.0.0-rc1-20717-470" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.OAuth" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Connections/AuthenticatedEchoConnection.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Connections/AuthenticatedEchoConnection.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common.Connections
     {
         protected override bool AuthorizeRequest(IRequest request)
         {
-            return request.User != null && request.User.Identity.IsAuthenticated;
+            return request.User != null && request.User.Identity.IsAuthenticated && request.User.IsInRole("userRole");
         }
 
         protected override Task OnReceived(IRequest request, string connectionId, string data)

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/BasicAuthenticationProvider.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/BasicAuthenticationProvider.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System;
+using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +15,8 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
             {
                 var identity = new ClaimsIdentity("Basic");
                 identity.AddClaim(new Claim(ClaimTypes.Name, userName));
-                var principal = new ClaimsPrincipal(identity);
+                identity.AddClaim(new Claim(ClaimTypes.Role, "userRole"));
+                var principal = new ClaimsPrincipal(identity);                
                 return Task.FromResult<IPrincipal>(principal);
             }
 

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Microsoft.AspNet.SignalR.Tests.Common.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Microsoft.AspNet.SignalR.Tests.Common.csproj
@@ -44,9 +44,17 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Hosting.2.0.0-rc1-20717-470\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Owin.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.Security.2.0.0-rc1-20717-470\lib\net45\Microsoft.Owin.Security.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin.Security.Basic, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.Security.Basic.0.24.0-pre-20717-470\lib\net45\Microsoft.Owin.Security.Basic.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Owin.Security.OAuth.2.0.0-rc1-20717-470\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Administration, Version=7.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -204,7 +212,9 @@
     <EmbeddedResource Include="Infrastructure\IIS\site.web.config" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/packages.config
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/packages.config
@@ -4,7 +4,9 @@
   <package id="Microsoft.Owin" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Microsoft.Owin.Cors" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="2.0.0-rc1-20717-470" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Microsoft.Owin.Security.Basic" version="0.24.0-pre-20717-470" targetFramework="net45" />
+  <package id="Microsoft.Owin.Security.OAuth" version="2.0.0-rc1-20717-470" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />
   <package id="Owin.Extensions" version="0.6.4" targetFramework="net45" />


### PR DESCRIPTION
There are a few things I don't like about this approach:
1. User and Password are sent in a POST request to create a token and on every request to refresh the token
2. Requiring user and password during refresh token will not work with a JS client
3. In CSharp client, refreshing token requires a separate httpClient and thread
4. In JS client (not written here yet), we need AJAX calls to refresh token. Because JavaScript is single thread, there is less guarantee we will refresh the token before it expires.
