### PR TITLE
Use async/await in the Subscription.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
@@ -80,7 +79,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
             return Invoke(result, state => { }, state: null);
         }
 
-        private Task<bool> Invoke(MessageResult result, Action<object> beforeInvoke, object state)
+        private async Task<bool> Invoke(MessageResult result, Action<object> beforeInvoke, object state)
         {
             // Change the state from idle to invoking callback
             var prevState = Interlocked.CompareExchange(ref _subscriptionState,
@@ -92,7 +91,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 // Only allow terminal messages after dispose
                 if (!result.Terminal)
                 {
-                    return TaskAsyncHelper.False;
+                    return false;
                 }
             }
 
@@ -101,27 +100,52 @@ namespace Microsoft.AspNet.SignalR.Messaging
             _counters.MessageBusMessagesReceivedTotal.IncrementBy(result.TotalCount);
             _counters.MessageBusMessagesReceivedPerSec.IncrementBy(result.TotalCount);
 
-            return _callback.Invoke(result, _callbackState).ContinueWith(task =>
+            try
+            {
+                return await _callback(result, _callbackState);
+            }
+            finally
             {
                 // Go from invoking callback to idle
                 Interlocked.CompareExchange(ref _subscriptionState,
                                             SubscriptionState.Idle,
                                             SubscriptionState.InvokingCallback);
-                return task;
-            },
-            TaskContinuationOptions.ExecuteSynchronously).FastUnwrap();
+            }
         }
 
-        public Task Work()
+        [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "We have a sync and async code path.")]
+        public async Task Work()
         {
             // Set the state to working
             Interlocked.Exchange(ref _state, State.Working);
 
-            var tcs = new TaskCompletionSource<object>();
+            while (Alive)
+            {
+                var items = new List<ArraySegment<Message>>();
+                int totalCount;
+                object state;
 
-            WorkImpl(tcs);
+                PerformWork(items, out totalCount, out state);
 
-            return tcs.Task;
+                if (items.Count > 0)
+                {
+                    var messageResult = new MessageResult(items, totalCount);
+
+                    bool result = await Invoke(messageResult, s => BeforeInvoke(s), state);
+
+                    if (!result)
+                    {
+                        Dispose();
+
+                        // If the callback said it's done then stop
+                        break;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
         }
 
         public bool SetQueued()
@@ -135,74 +159,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
             return Interlocked.CompareExchange(ref _state, State.Idle, State.Working) != State.Working;
         }
 
-        [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "We have a sync and async code path.")]
-        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to avoid user code taking the process down.")]
-        private void WorkImpl(TaskCompletionSource<object> taskCompletionSource)
-        {
-        Process:
-            if (!Alive)
-            {
-                // If this subscription is dead then return immediately
-                taskCompletionSource.TrySetResult(null);
-                return;
-            }
-
-            var items = new List<ArraySegment<Message>>();
-            int totalCount;
-            object state;
-
-            PerformWork(items, out totalCount, out state);
-
-            if (items.Count > 0)
-            {
-                var messageResult = new MessageResult(items, totalCount);
-                Task<bool> callbackTask = Invoke(messageResult, s => BeforeInvoke(s), state);
-
-                if (callbackTask.IsCompleted)
-                {
-                    try
-                    {
-                        // Make sure exceptions propagate
-                        callbackTask.Wait();
-
-                        if (callbackTask.Result)
-                        {
-                            // Sync path
-                            goto Process;
-                        }
-                        else
-                        {
-                            // If we're done pumping messages through to this subscription
-                            // then dispose
-                            Dispose();
-
-                            // If the callback said it's done then stop
-                            taskCompletionSource.TrySetResult(null);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ex.InnerException is TaskCanceledException)
-                        {
-                            taskCompletionSource.TrySetCanceled();
-                        }
-                        else
-                        {
-                            taskCompletionSource.TrySetUnwrappedException(ex);
-                        }
-                    }
-                }
-                else
-                {
-                    WorkImplAsync(callbackTask, taskCompletionSource);
-                }
-            }
-            else
-            {
-                taskCompletionSource.TrySetResult(null);
-            }
-        }
-
         protected virtual void BeforeInvoke(object state)
         {
         }
@@ -212,35 +168,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
         [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#", Justification = "The count needs to be returned")]
         [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#", Justification = "The state needs to be set by the callee")]
         protected abstract void PerformWork(IList<ArraySegment<Message>> items, out int totalCount, out object state);
-
-        private void WorkImplAsync(Task<bool> callbackTask, TaskCompletionSource<object> taskCompletionSource)
-        {
-            // Async path
-            callbackTask.ContinueWith(task =>
-            {
-                if (task.IsFaulted)
-                {
-                    taskCompletionSource.TrySetUnwrappedException(task.Exception);
-                }
-                else if (task.IsCanceled)
-                {
-                    taskCompletionSource.TrySetCanceled();
-                }
-                else if (task.Result)
-                {
-                    WorkImpl(taskCompletionSource);
-                }
-                else
-                {
-                    // If we're done pumping messages through to this subscription
-                    // then dispose
-                    Dispose();
-
-                    // If the callback said it's done then stop
-                    taskCompletionSource.TrySetResult(null);
-                }
-            });
-        }
 
         public virtual bool AddEvent(string key, Topic topic)
         {

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/SubscriptionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/SubscriptionFacts.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
                 return tcs.Task;
             };
 
-            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback)
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback, 1)
             {
                 CallBase = true
             };
@@ -51,7 +51,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
                 return await tcs.Task;
             };
 
-            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback)
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback, 1)
             {
                 CallBase = true
             };
@@ -73,7 +73,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
                 return false;
             };
 
-            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback)
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback, 1)
             {
                 CallBase = true
             };
@@ -101,7 +101,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
                 return false;
             };
 
-            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback)
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback, 1)
             {
                 CallBase = true
             };
@@ -114,18 +114,69 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             }
         }
 
+        [Fact(Timeout = 5000)]
+        public void NoItemsCompletesTask()
+        {
+            Func<MessageResult, object, Task<bool>> callback = (result, state) =>
+            {
+                return TaskAsyncHelper.False;
+            };
+
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback, 0)
+            {
+                CallBase = true
+            };
+
+            using (subscription.Object)
+            {
+                Task task = subscription.Object.Work();
+                Assert.True(task.IsCompleted);
+            }
+        }
+
+        [Fact(Timeout = 5000)]
+        public void ReturningFalseFromCallbackCompletesTaskAndDisposesSubscription()
+        {
+            Func<MessageResult, object, Task<bool>> callback = (result, state) =>
+            {
+                return TaskAsyncHelper.False;
+            };
+
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback, 1)
+            {
+                CallBase = true
+            };
+
+            var disposableMock = new Mock<IDisposable>();
+            subscription.Object.Disposable = disposableMock.Object;
+            disposableMock.Setup(m => m.Dispose()).Verifiable();
+
+            using (subscription.Object)
+            {
+                Task task = subscription.Object.Work();
+                Assert.True(task.IsCompleted);
+                task.Wait();
+                disposableMock.Verify(m => m.Dispose(), Times.Once());
+            }
+        }
+
         public class TestSubscription : Subscription
         {
-            public TestSubscription(string identity, IList<string> eventKeys, Func<MessageResult, object, Task<bool>> callback)
+            private readonly int _itemCount;
+            public TestSubscription(string identity, IList<string> eventKeys, Func<MessageResult, object, Task<bool>> callback, int itemCount)
                 : base(identity, eventKeys, callback, 10, GetCounters(), state: null)
             {
-
+                _itemCount = itemCount;
             }
 
             protected override void PerformWork(IList<ArraySegment<Message>> items, out int totalCount, out object state)
             {
-                items.Add(new ArraySegment<Message>());
-                totalCount = 1;
+                for (int i = 0; i < _itemCount; i++)
+                {
+                    items.Add(new ArraySegment<Message>());
+                }
+
+                totalCount = _itemCount;
                 state = null;
             }
 


### PR DESCRIPTION
Small change to take advantage of async/await in the Subscription class. Readability is drastically improved (that's why so much code can be deleted).

New tests were added to verify that the behavior doesn't change untintentionally.
