### PR TITLE
Renamed SignalR methods to fit the OWIN convention.

### DIFF
--- a/samples/Microsoft.AspNet.SelfHost.Samples/Startup.cs
+++ b/samples/Microsoft.AspNet.SelfHost.Samples/Startup.cs
@@ -19,7 +19,7 @@ namespace Microsoft.AspNet.SelfHost.Samples
                 // Turns cors support on allowing everything
                 // In real applications, the origins should be locked down
                 map.UseCors(CorsOptions.AllowAll)
-                   .UseConnection<RawConnection>();
+                   .RunSignalR<RawConnection>();
             });
 
             app.Map("/signalr", map =>
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.SelfHost.Samples
                 // Turns cors support on allowing everything
                 // In real applications, the origins should be locked down
                 map.UseCors(CorsOptions.AllowAll)
-                   .UseHubs(config);
+                   .RunSignalR(config);
             });
 
             // Turn tracing on programmatically

--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Startup.cs
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Startup.cs
@@ -13,8 +13,8 @@ namespace Microsoft.AspNet.SignalR.LoadTestHarness
         {
             GlobalHost.Configuration.DisconnectTimeout = TimeSpan.FromSeconds(60);
 
-            app.MapConnection<TestConnection>("/TestConnection");
-            app.MapHubs();
+            app.MapSignalR<TestConnection>("/TestConnection");
+            app.MapSignalR();
 
             Dashboard.Init();
         }

--- a/samples/Microsoft.AspNet.SignalR.Samples/App_Start/Startup.cs
+++ b/samples/Microsoft.AspNet.SignalR.Samples/App_Start/Startup.cs
@@ -16,10 +16,10 @@ namespace Microsoft.AspNet.SignalR.Samples
     {
         public void Configuration(IAppBuilder app)
         {
-            app.MapConnection<SendingConnection>("/sending-connection");
-            app.MapConnection<TestConnection>("/test-connection");
-            app.MapConnection<RawConnection>("/raw-connection");
-            app.MapConnection<StreamingConnection>("/streaming-connection");
+            app.MapSignalR<SendingConnection>("/sending-connection");
+            app.MapSignalR<TestConnection>("/test-connection");
+            app.MapSignalR<RawConnection>("/raw-connection");
+            app.MapSignalR<StreamingConnection>("/streaming-connection");
 
             app.Use(typeof(ClaimsMiddleware));
 
@@ -30,13 +30,13 @@ namespace Microsoft.AspNet.SignalR.Samples
                 EnableDetailedErrors = true
             };
 
-            app.MapHubs(config);
+            app.MapSignalR(config);
 
             app.Map("/basicauth", map =>
             {
                 map.UseBasicAuthentication(new BasicAuthenticationProvider());
-                map.MapConnection<AuthenticatedEchoConnection>("/echo");
-                map.MapHubs();
+                map.MapSignalR<AuthenticatedEchoConnection>("/echo");
+                map.MapSignalR();
             });
 
             BackgroundThread.Start();

--- a/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
@@ -25,9 +25,9 @@ namespace Owin
         /// Maps SignalR hubs to the app builder pipeline at "/signalr".
         /// </summary>
         /// <param name="builder">The app builder</param>
-        public static IAppBuilder MapHubs(this IAppBuilder builder)
+        public static IAppBuilder MapSignalR(this IAppBuilder builder)
         {
-            return builder.MapHubs(new HubConfiguration());
+            return builder.MapSignalR(new HubConfiguration());
         }
 
         /// <summary>
@@ -35,9 +35,9 @@ namespace Owin
         /// </summary>
         /// <param name="builder">The app builder</param>
         /// <param name="configuration">The <see cref="HubConfiguration"/> to use</param>
-        public static IAppBuilder MapHubs(this IAppBuilder builder, HubConfiguration configuration)
+        public static IAppBuilder MapSignalR(this IAppBuilder builder, HubConfiguration configuration)
         {
-            return builder.MapHubs("/signalr", configuration);
+            return builder.MapSignalR("/signalr", configuration);
         }
 
         /// <summary>
@@ -46,23 +46,23 @@ namespace Owin
         /// <param name="builder">The app builder</param>
         /// <param name="path">The path to map signalr hubs</param>
         /// <param name="configuration">The <see cref="HubConfiguration"/> to use</param>
-        public static IAppBuilder MapHubs(this IAppBuilder builder, string path, HubConfiguration configuration)
+        public static IAppBuilder MapSignalR(this IAppBuilder builder, string path, HubConfiguration configuration)
         {
             if (configuration == null)
             {
                 throw new ArgumentNullException("configuration");
             }
 
-            return builder.Map(path, subApp => subApp.UseHubs(configuration));
+            return builder.Map(path, subApp => subApp.RunSignalR(configuration));
         }
 
         /// <summary>
         /// Adds SignalR hubs to the app builder pipeline.
         /// </summary>
         /// <param name="builder">The app builder</param>
-        public static IAppBuilder UseHubs(this IAppBuilder builder)
+        public static void RunSignalR(this IAppBuilder builder)
         {
-            return builder.UseHubs(new HubConfiguration());
+            builder.RunSignalR(new HubConfiguration());
         }
 
         /// <summary>
@@ -70,9 +70,9 @@ namespace Owin
         /// </summary>
         /// <param name="builder">The app builder</param>
         /// <param name="configuration">The <see cref="HubConfiguration"/> to use</param>
-        public static IAppBuilder UseHubs(this IAppBuilder builder, HubConfiguration configuration)
+        public static void RunSignalR(this IAppBuilder builder, HubConfiguration configuration)
         {
-            return builder.UseSignalR<HubDispatcherMiddleware>(configuration);
+            builder.UseSignalRMiddleware<HubDispatcherMiddleware>(configuration);
         }
 
         /// <summary>
@@ -83,9 +83,9 @@ namespace Owin
         /// <param name="builder">The app builder</param>
         /// <param name="path">The path to map the <see cref="PersistentConnection"/></param>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "The type parameter is syntactic sugar")]
-        public static IAppBuilder MapConnection<TConnection>(this IAppBuilder builder, string path) where TConnection : PersistentConnection
+        public static IAppBuilder MapSignalR<TConnection>(this IAppBuilder builder, string path) where TConnection : PersistentConnection
         {
-            return builder.MapConnection(path, typeof(TConnection), new ConnectionConfiguration());
+            return builder.MapSignalR(path, typeof(TConnection), new ConnectionConfiguration());
         }
 
         /// <summary>
@@ -98,9 +98,9 @@ namespace Owin
         /// <param name="configuration">The <see cref="ConnectionConfiguration"/> to use</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "The type parameter is syntactic sugar")]
-        public static IAppBuilder MapConnection<TConnection>(this IAppBuilder builder, string path, ConnectionConfiguration configuration) where TConnection : PersistentConnection
+        public static IAppBuilder MapSignalR<TConnection>(this IAppBuilder builder, string path, ConnectionConfiguration configuration) where TConnection : PersistentConnection
         {
-            return builder.MapConnection(path, typeof(TConnection), configuration);
+            return builder.MapSignalR(path, typeof(TConnection), configuration);
         }
 
         /// <summary>
@@ -111,14 +111,14 @@ namespace Owin
         /// <param name="path">The path to map the persistent connection</param>
         /// <param name="connectionType">The type of <see cref="PersistentConnection"/></param>
         /// <param name="configuration">The <see cref="ConnectionConfiguration"/> to use</param>
-        public static IAppBuilder MapConnection(this IAppBuilder builder, string path, Type connectionType, ConnectionConfiguration configuration)
+        public static IAppBuilder MapSignalR(this IAppBuilder builder, string path, Type connectionType, ConnectionConfiguration configuration)
         {
             if (configuration == null)
             {
                 throw new ArgumentNullException("configuration");
             }
 
-            return builder.Map(path, subApp => subApp.UseConnection(connectionType, configuration));
+            return builder.Map(path, subApp => subApp.RunSignalR(connectionType, configuration));
         }
 
         /// <summary>
@@ -127,9 +127,9 @@ namespace Owin
         /// <typeparam name="TConnection">The type of <see cref="PersistentConnection"/></typeparam>
         /// <param name="builder">The app builder</param>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "The type parameter is syntactic sugar")]
-        public static IAppBuilder UseConnection<TConnection>(this IAppBuilder builder) where TConnection : PersistentConnection
+        public static void RunSignalR<TConnection>(this IAppBuilder builder) where TConnection : PersistentConnection
         {
-            return builder.UseConnection<TConnection>(new ConnectionConfiguration());
+            builder.RunSignalR<TConnection>(new ConnectionConfiguration());
         }
 
         /// <summary>
@@ -140,9 +140,9 @@ namespace Owin
         /// <param name="configuration">The <see cref="ConnectionConfiguration"/> to use</param>
         /// <returns></returns>
         [SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "The type parameter is syntactic sugar")]
-        public static IAppBuilder UseConnection<TConnection>(this IAppBuilder builder, ConnectionConfiguration configuration) where TConnection : PersistentConnection
+        public static void RunSignalR<TConnection>(this IAppBuilder builder, ConnectionConfiguration configuration) where TConnection : PersistentConnection
         {
-            return builder.UseConnection(typeof(TConnection), configuration);
+            builder.RunSignalR(typeof(TConnection), configuration);
         }
 
         /// <summary>
@@ -152,13 +152,13 @@ namespace Owin
         /// <param name="connectionType">The type of <see cref="PersistentConnection"/></param>
         /// <param name="configuration">The <see cref="ConnectionConfiguration"/> to use</param>
         /// <returns></returns>
-        public static IAppBuilder UseConnection(this IAppBuilder builder, Type connectionType, ConnectionConfiguration configuration)
+        public static void RunSignalR(this IAppBuilder builder, Type connectionType, ConnectionConfiguration configuration)
         {
-            return builder.UseSignalR<PersistentConnectionMiddleware>(connectionType, configuration);
+            builder.UseSignalRMiddleware<PersistentConnectionMiddleware>(connectionType, configuration);
         }
 
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "This class wires up new dependencies from the host")]
-        private static IAppBuilder UseSignalR<T>(this IAppBuilder builder, params object[] args)
+        private static IAppBuilder UseSignalRMiddleware<T>(this IAppBuilder builder, params object[] args)
         {
             ConnectionConfiguration configuration = null;
 

--- a/src/Microsoft.AspNet.SignalR.Stress/Stress/StressRuns.cs
+++ b/src/Microsoft.AspNet.SignalR.Stress/Stress/StressRuns.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                     Resolver = new DefaultDependencyResolver()
                 };
 
-                app.MapHubs(config);
+                app.MapSignalR(config);
 
                 var configuration = config.Resolver.Resolve<IConfigurationManager>();
                 // The below effectively sets the heartbeat interval to five seconds.
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                     Resolver = new DefaultDependencyResolver()
                 };
 
-                app.MapHubs(config);
+                app.MapSignalR(config);
 
                 var configuration = config.Resolver.Resolve<IConfigurationManager>();
                 // The below effectively sets the heartbeat interval to five seconds.
@@ -160,7 +160,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                 {
                     Resolver = new DefaultDependencyResolver()
                 };
-                app.MapHubs(config);
+                app.MapSignalR(config);
             });
 
             for (int i = 0; i < concurrency; i++)
@@ -268,7 +268,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs(config);
+                    app.MapSignalR(config);
                 });
 
                 client = host;
@@ -295,7 +295,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                     var bus = new DelayedMessageBus(host.InstanceName, eventBus, config.Resolver, TimeSpan.Zero);
                     config.Resolver.Register(typeof(IMessageBus), () => bus);
 
-                    app.MapHubs(config);
+                    app.MapSignalR(config);
 
                     config.Resolver.Register(typeof(IProtectedData), () => protectedData);
                 });
@@ -327,7 +327,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                     var bus = new DelayedMessageBus(host.InstanceName, eventBus, config.Resolver, delay);
                     config.Resolver.Register(typeof(IMessageBus), () => bus);
 
-                    app.MapHubs(config);
+                    app.MapSignalR(config);
 
                     config.Resolver.Register(typeof(IProtectedData), () => protectedData);
                 });
@@ -396,7 +396,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                 };
 
                 config.Resolver.Resolve<IConfigurationManager>().ConnectionTimeout = TimeSpan.FromDays(1);
-                app.MapHubs(config);
+                app.MapSignalR(config);
             });
 
 
@@ -439,7 +439,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                     Resolver = new DefaultDependencyResolver()
                 };
 
-                app.MapConnection<MyRejoinGroupConnection>("/groups", config);
+                app.MapSignalR<MyRejoinGroupConnection>("/groups", config);
 
                 var configuration = config.Resolver.Resolve<IConfigurationManager>();
                 configuration.KeepAlive = null;
@@ -494,7 +494,7 @@ namespace Microsoft.AspNet.SignalR.Stress
                     Resolver = new DefaultDependencyResolver()
                 };
 
-                app.MapConnection<RawConnection>("/Raw-connection", config);
+                app.MapSignalR<RawConnection>("/Raw-connection", config);
             });
 
             for (int i = 0; i < concurrency; i++)

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Client/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Client/ConnectionFacts.cs
@@ -58,7 +58,7 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                     config.Resolver.Register(typeof(MyReconnect), () => myReconnect);
 
-                    app.MapConnection<MyReconnect>("/echo", config);
+                    app.MapSignalR<MyReconnect>("/echo", config);
                 });
 
                 var connection = new Connection("http://foo/echo");

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyConnection>("/echo", config);
+                        app.MapSignalR<MyConnection>("/echo", config);
                     });
 
                     var connection = new Connection("http://foo/echo");
@@ -105,7 +105,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyAuthenticatedConnection>("/authenticatedConnection", config);
+                        app.MapSignalR<MyAuthenticatedConnection>("/authenticatedConnection", config);
 
                     });
 
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
 
                         defaultTransportConnectTimeout = config.Resolver.Resolve<IConfigurationManager>().TransportConnectTimeout;
 
-                        app.MapConnection<MyConnection>("/echo", config);
+                        app.MapSignalR<MyConnection>("/echo", config);
                     });
 
                     var tcs = new TaskCompletionSource<string>();
@@ -244,8 +244,8 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyConnection>("/echo", config);
-                        app.MapConnection<MyConnection2>("/echo2", config);
+                        app.MapSignalR<MyConnection>("/echo", config);
+                        app.MapSignalR<MyConnection2>("/echo2", config);
                     });
 
                     var tcs = new TaskCompletionSource<string>();
@@ -278,8 +278,8 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyConnection>("/echo", config);
-                        app.MapConnection<MyConnection2>("/echo2", config);
+                        app.MapSignalR<MyConnection>("/echo", config);
+                        app.MapSignalR<MyConnection2>("/echo2", config);
                     });
 
                     var tcs = new TaskCompletionSource<string>();
@@ -312,8 +312,8 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyConnection>("/echo", config);
-                        app.MapConnection<MyConnection2>("/echo2", config);
+                        app.MapSignalR<MyConnection>("/echo", config);
+                        app.MapSignalR<MyConnection2>("/echo2", config);
                     });
 
                     var tcs = new TaskCompletionSource<string>();
@@ -561,7 +561,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<TransportResponse>("/transport-response", config);
+                        app.MapSignalR<TransportResponse>("/transport-response", config);
                     });
 
                     var transports = new List<IClientTransport>()

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/DisconnectFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/DisconnectFacts.cs
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = dr
                     };
 
-                    app.MapConnection<MyConnection>("/echo", config);
+                    app.MapSignalR<MyConnection>("/echo", config);
 
                     configuration.DisconnectTimeout = TimeSpan.FromSeconds(6);
 
@@ -126,7 +126,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = dr
                     };
 
-                    app.MapHubs("/signalr", config);
+                    app.MapSignalR("/signalr", config);
 
                     configuration.DisconnectTimeout = TimeSpan.FromSeconds(6);
                     dr.Register(typeof(MyHub), () => new MyHub(connectWh, disconnectWh));
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     IDependencyResolver resolver = node.Resolver;
                     node.Server.Configure(app =>
                     {
-                        app.MapConnection<FarmConnection>("/echo", new ConnectionConfiguration
+                        app.MapSignalR<FarmConnection>("/echo", new ConnectionConfiguration
                         {
                             Resolver = resolver
                         });

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/PersistentConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/PersistentConnectionFacts.cs
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyGroupEchoConnection>("/echo", config);
+                        app.MapSignalR<MyGroupEchoConnection>("/echo", config);
 
                         config.Resolver.Register(typeof(IProtectedData), () => new EmptyProtectedData());
                     });
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<MyGroupEchoConnection>("/echo", config);
+                        app.MapSignalR<MyGroupEchoConnection>("/echo", config);
 
                         config.Resolver.Register(typeof(IProtectedData), () => new EmptyProtectedData());
                     });
@@ -108,7 +108,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<BroadcastConnection>("/echo", configuration);
+                        app.MapSignalR<BroadcastConnection>("/echo", configuration);
                         connectionContext = configuration.Resolver.Resolve<IConnectionManager>().GetConnectionContext<BroadcastConnection>();
                     });
 
@@ -146,7 +146,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<BroadcastConnection>("/echo", configuration);
+                        app.MapSignalR<BroadcastConnection>("/echo", configuration);
                         connectionContext = configuration.Resolver.Resolve<IConnectionManager>().GetConnectionContext<BroadcastConnection>();
                     });
 
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<BroadcastConnection>("/echo", configuration);
+                        app.MapSignalR<BroadcastConnection>("/echo", configuration);
                         connectionContext = configuration.Resolver.Resolve<IConnectionManager>().GetConnectionContext<BroadcastConnection>();
                     });
 
@@ -223,7 +223,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                             Resolver = new DefaultDependencyResolver()
                         };
 
-                        app.MapConnection<BroadcastConnection>("/echo", configuration);
+                        app.MapSignalR<BroadcastConnection>("/echo", configuration);
                         connectionContext = configuration.Resolver.Resolve<IConnectionManager>().GetConnectionContext<BroadcastConnection>();
                     });
 
@@ -489,7 +489,7 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                         UseMessageBus(messageBusType, config.Resolver);
 
-                        app.MapConnection<MyReconnect>("/endpoint", config);
+                        app.MapSignalR<MyReconnect>("/endpoint", config);
                         var configuration = config.Resolver.Resolve<IConfigurationManager>();
                         configuration.DisconnectTimeout = TimeSpan.FromSeconds(6);
                         configuration.ConnectionTimeout = TimeSpan.FromSeconds(2);

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ReconnectFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ReconnectFacts.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 UseMessageBus(messageBusType, config.Resolver);
 
-                app.MapConnection<MyReconnect>("/endpoint", config);
+                app.MapSignalR<MyReconnect>("/endpoint", config);
 
                 var conn = new MyReconnect();
                 config.Resolver.Register(typeof(MyReconnect), () => conn);

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
 
                 });
 
@@ -66,7 +66,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
 
                 });
 
@@ -102,7 +102,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
 
                 });
 
@@ -140,7 +140,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
 
                 });
 
@@ -180,7 +180,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     configuration.Resolver.Resolve<IHubPipeline>().RequireAuthentication();
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -215,7 +215,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     configuration.Resolver.Resolve<IHubPipeline>().RequireAuthentication();
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -252,7 +252,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     configuration.Resolver.Resolve<IHubPipeline>().RequireAuthentication();
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -287,7 +287,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     configuration.Resolver.Resolve<IHubPipeline>().RequireAuthentication();
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -324,7 +324,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -357,7 +357,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -392,7 +392,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -425,7 +425,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -462,7 +462,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
                 var connection = CreateHubConnection("http://foo/");
 
@@ -494,7 +494,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -529,7 +529,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -562,7 +562,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -599,7 +599,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -632,7 +632,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -665,7 +665,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "User", "NotAdmin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -698,7 +698,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "User", "NotAdmin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -731,7 +731,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "User", "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -766,7 +766,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -803,7 +803,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("User"), new string[] { "User", "NotAdmin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -836,7 +836,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "User", "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -869,7 +869,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("User"), new string[] { "test", "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -904,7 +904,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("User"), new string[] { "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -941,7 +941,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { "User", "NotAdmin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -976,7 +976,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { "User", "NotAdmin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -1013,7 +1013,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("Admin"), new string[] { }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -1048,7 +1048,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("User"), new string[] { "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -1085,7 +1085,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity(""), new string[] { "Admin", "Invoker" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -1122,7 +1122,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "User", "NotAdmin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");
@@ -1159,7 +1159,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     };
 
                     WithUser(app, new GenericPrincipal(new GenericIdentity("test"), new string[] { "User", "Admin" }));
-                    app.MapHubs("/signalr", configuration);
+                    app.MapSignalR("/signalr", configuration);
                 });
 
                 var connection = CreateHubConnection("http://foo/");

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
@@ -617,7 +617,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs("/foo", config);
+                    app.MapSignalR("/foo", config);
                 });
 
                 var connection = new HubConnection("http://site/foo", useDefaultUrl: false, queryString: new Dictionary<string, string> { { "test", "ChangeHubUrl" } });
@@ -1012,7 +1012,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs("/signalr", config);
+                    app.MapSignalR("/signalr", config);
 
                     config.Resolver.Resolve<IHubPipeline>().AddModule(logRejoiningGroups);
                     var configuration = config.Resolver.Resolve<IConfigurationManager>();
@@ -1135,7 +1135,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs("/signalr", config);
+                    app.MapSignalR("/signalr", config);
 
                     var configuration = config.Resolver.Resolve<IConfigurationManager>();
                     // The below effectively sets the heartbeat interval to one second.
@@ -1170,7 +1170,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs("/signalr", config);
+                    app.MapSignalR("/signalr", config);
 
                     var configuration = config.Resolver.Resolve<IConfigurationManager>();
                     // The following sets the heartbeat to 1 s
@@ -1220,7 +1220,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs("/signalr", config);
+                    app.MapSignalR("/signalr", config);
 
                     config.Resolver.Register(typeof(IHub), () =>
                     {
@@ -1266,7 +1266,7 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                     UseMessageBus(messagebusType, config.Resolver);
 
-                    app.MapHubs(config);
+                    app.MapSignalR(config);
                 });
 
                 var connection = new HubConnection("http://foo");
@@ -1643,7 +1643,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs(configuration);
+                    app.MapSignalR(configuration);
                     hubContext = configuration.Resolver.Resolve<IConnectionManager>().GetHubContext("SendToSome");
                 });
 
@@ -1680,7 +1680,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs(configuration);
+                    app.MapSignalR(configuration);
                     hubContext = configuration.Resolver.Resolve<IConnectionManager>().GetHubContext("SendToSome");
                 });
 
@@ -1717,7 +1717,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs(configuration);
+                    app.MapSignalR(configuration);
                     hubContext = configuration.Resolver.Resolve<IConnectionManager>().GetHubContext("SendToSome");
                 });
 
@@ -1753,7 +1753,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs(configuration);
+                    app.MapSignalR(configuration);
                     hubContext = configuration.Resolver.Resolve<IConnectionManager>().GetHubContext("SendToSome");
                 });
 
@@ -1789,7 +1789,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapHubs(configuration);
+                    app.MapSignalR(configuration);
                     hubContext = configuration.Resolver.Resolve<IConnectionManager>().GetHubContext("SendToSome");
                 });
 

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/SecurityFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/SecurityFacts.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapConnection<MyGroupConnection>("/echo", config);
+                    app.MapSignalR<MyGroupConnection>("/echo", config);
 
                     protectedData = config.Resolver.Resolve<IProtectedData>();
                 });
@@ -95,7 +95,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
                         Resolver = new DefaultDependencyResolver()
                     };
 
-                    app.MapConnection<MyConnection>("/echo", config);
+                    app.MapSignalR<MyConnection>("/echo", config);
 
                     protectedData = config.Resolver.Resolve<IProtectedData>();
                 });

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/App_Start/Initializer.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/App_Start/Initializer.cs
@@ -89,9 +89,9 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
                 EnableDetailedErrors = true
             };
 
-            app.MapHubs(hubConfig);
+            app.MapSignalR(hubConfig);
 
-            app.MapHubs("/signalr2/test", new HubConfiguration()
+            app.MapSignalR("/signalr2/test", new HubConfiguration()
             {
                 Resolver = resolver
             });
@@ -104,19 +104,19 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
             app.Map("/multisend", map =>
             {
                 map.UseCors(CorsOptions.AllowAll);
-                map.UseConnection<MySendingConnection>(config);
+                map.RunSignalR<MySendingConnection>(config);
             });
 
             app.Map("/autoencodedjson", map =>
             {
                 map.UseCors(CorsOptions.AllowAll);
-                map.UseConnection<EchoConnection>(config);
+                map.RunSignalR<EchoConnection>(config);
             });
 
             app.Map("/redirectionConnection", map =>
             {
                 map.UseCors(CorsOptions.AllowAll);
-                map.UseConnection<RedirectionConnection>(config);
+                map.RunSignalR<RedirectionConnection>(config);
             });
 
             app.Map("/jsonp", map =>
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
                     EnableJSONP = true
                 };
 
-                map.MapConnection<EchoConnection>("/echo", jsonpConfig);
+                map.MapSignalR<EchoConnection>("/echo", jsonpConfig);
 
                 var jsonpHubsConfig = new HubConfiguration
                 {
@@ -135,24 +135,24 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
                     EnableJSONP = true
                 };
 
-                map.MapHubs(jsonpHubsConfig);
+                map.MapSignalR(jsonpHubsConfig);
             });
 
-            app.MapConnection<MyBadConnection>("/ErrorsAreFun", config);
-            app.MapConnection<MyGroupEchoConnection>("/group-echo", config);
-            app.MapConnection<MyReconnect>("/my-reconnect", config);
-            app.MapConnection<ExamineHeadersConnection>("/examine-request", config);
-            app.MapConnection<ExamineReconnectPath>("/examine-reconnect", config);
-            app.MapConnection<MyGroupConnection>("/groups", config);
-            app.MapConnection<MyRejoinGroupsConnection>("/rejoin-groups", config);
-            app.MapConnection<BroadcastConnection>("/filter", config);
-            app.MapConnection<ConnectionThatUsesItems>("/items", config);
-            app.MapConnection<SyncErrorConnection>("/sync-error", config);
-            app.MapConnection<AddGroupOnConnectedConnection>("/add-group", config);
-            app.MapConnection<UnusableProtectedConnection>("/protected", config);
-            app.MapConnection<FallbackToLongPollingConnection>("/fall-back", config);
-            app.MapConnection<FallbackToLongPollingConnectionThrows>("/fall-back-throws", config);
-            app.MapConnection<PreserializedJsonConnection>("/preserialize", config);
+            app.MapSignalR<MyBadConnection>("/ErrorsAreFun", config);
+            app.MapSignalR<MyGroupEchoConnection>("/group-echo", config);
+            app.MapSignalR<MyReconnect>("/my-reconnect", config);
+            app.MapSignalR<ExamineHeadersConnection>("/examine-request", config);
+            app.MapSignalR<ExamineReconnectPath>("/examine-reconnect", config);
+            app.MapSignalR<MyGroupConnection>("/groups", config);
+            app.MapSignalR<MyRejoinGroupsConnection>("/rejoin-groups", config);
+            app.MapSignalR<BroadcastConnection>("/filter", config);
+            app.MapSignalR<ConnectionThatUsesItems>("/items", config);
+            app.MapSignalR<SyncErrorConnection>("/sync-error", config);
+            app.MapSignalR<AddGroupOnConnectedConnection>("/add-group", config);
+            app.MapSignalR<UnusableProtectedConnection>("/protected", config);
+            app.MapSignalR<FallbackToLongPollingConnection>("/fall-back", config);
+            app.MapSignalR<FallbackToLongPollingConnectionThrows>("/fall-back-throws", config);
+            app.MapSignalR<PreserializedJsonConnection>("/preserialize", config);
 
             // This subpipeline is protected by basic auth
             app.Map("/basicauth", subApp =>
@@ -164,14 +164,14 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
                     Resolver = resolver
                 };
 
-                subApp.MapConnection<AuthenticatedEchoConnection>("/echo", subConfig);
+                subApp.MapSignalR<AuthenticatedEchoConnection>("/echo", subConfig);
 
                 var subHubsConfig = new HubConfiguration
                 {
                     Resolver = resolver
                 };
 
-                subApp.MapHubs(subHubsConfig);
+                subApp.MapSignalR(subHubsConfig);
             });
 
             app.Map("/force-lp-reconnect", subApp =>
@@ -186,8 +186,8 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
 
                     return next();
                 });
-                subApp.MapConnection<ExamineReconnectPath>("/examine-reconnect", config);
-                subApp.MapHubs(hubConfig);
+                subApp.MapSignalR<ExamineReconnectPath>("/examine-reconnect", config);
+                subApp.MapSignalR(hubConfig);
             });
 
             // Perf/stress test related
@@ -196,7 +196,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
                 Resolver = resolver
             };
 
-            app.MapConnection<StressConnection>("/echo", performanceConfig);
+            app.MapSignalR<StressConnection>("/echo", performanceConfig);
 
             performanceConfig.Resolver.Register(typeof(IProtectedData), () => new EmptyProtectedData());
         }


### PR DESCRIPTION
Made this change to see how it would look if we decided to fit the owin convention. It actually isn't as bad as I thought it would look. What do you think @DamianEdwards? 

Also, we could optionally keep the old extension methods and mark them as obsolete.
