### PR TITLE
2189 - Modified connection.stop to no longer deffer itself until the page has loaded

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -434,7 +434,7 @@
                 connection._.deferredStartHandler = function () {
                     connection.start(options, callback);
                 };
-                _pageWindow.load(connection._.deferredStartHandler);
+                _pageWindow.bind("load", connection._.deferredStartHandler);
 
                 return deferred.promise();
             }
@@ -862,16 +862,19 @@
             /// <returns type="signalR" />
             var connection = this;
 
+            // Verify that we've bound a load event.
+            if (connection._.deferredStartHandler) {
+                // Unbind the event.
+                _pageWindow.unbind("load", connection._.deferredStartHandler);
+            }
+
             // This needs to be checked despite the connection state because a connection start can be deferred until page load.
             // If we've deferred the start due to a page load we need to unbind the "onLoad" -> start event.
             if (!_pageLoaded && (!connection._.config || connection._.config.waitForPageLoad === true)) {
                 connection.log("Stopping connection prior to negotiate.");
 
-                // Unbind the event so it's not triggered.
-                _pageWindow.unbind("load", connection._.deferredStartHandler);
-
                 // Reject any promises for the current connections deferred.
-                connection._deferral.reject(signalR._.error(resources.stoppedWhileLoading));                
+                connection._deferral.reject(signalR._.error(resources.stoppedWhileLoading));
 
                 return;
             }


### PR DESCRIPTION
- It now unbinds the load event handler for the connection start.
- This allows for multiple starts/stops to occur during page load.
- This issue cannot be unit/functionally tested directly because it requires the page to be in the loading state.
#2189
