### PR TITLE
Corrected the class JRawValue to use the dependency injected in IJsonSer...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
@@ -24,12 +24,9 @@ namespace Microsoft.AspNet.SignalR.Json
             // A non generic implementation of ToObject<T> on JToken
             using (var jsonReader = new StringReader(_value))
             {
-                var settings = new JsonSerializerSettings
-                {
-                    MaxDepth = 20
-                };
-                var serializer = JsonSerializer.Create(settings);
-                return serializer.Deserialize(jsonReader, type);
+				var serializer = GlobalHost.DependencyResolver.Resolve<IJsonSerializer>();
+
+                return serializer.Parse(jsonReader, type);
             }
         }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Json/JsonNetSerializer.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/JsonNetSerializer.cs
@@ -7,64 +7,64 @@ using Newtonsoft.Json;
 
 namespace Microsoft.AspNet.SignalR.Json
 {
-    /// <summary>
-    /// Default <see cref="IJsonSerializer"/> implementation over Json.NET.
-    /// </summary>
-    public class JsonNetSerializer : IJsonSerializer
-    {
-        private readonly JsonSerializer _serializer;
+	/// <summary>
+	/// Default <see cref="IJsonSerializer"/> implementation over Json.NET.
+	/// </summary>
+	public class JsonNetSerializer : IJsonSerializer
+	{
+		private readonly JsonSerializer _serializer;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonNetSerializer"/> class.
-        /// </summary>
-        public JsonNetSerializer()
-            : this(new JsonSerializerSettings())
-        {
-        }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="JsonNetSerializer"/> class.
+		/// </summary>
+		public JsonNetSerializer()
+			: this(new JsonSerializerSettings() { Culture = System.Globalization.CultureInfo.CurrentCulture })
+		{
+		}
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="JsonNetSerializer"/> class.
-        /// </summary>
-        /// <param name="settings">The <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> to use when serializing and deserializing.</param>
-        public JsonNetSerializer(JsonSerializerSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException("settings");
-            }
+		/// <summary>
+		/// Initializes a new instance of the <see cref="JsonNetSerializer"/> class.
+		/// </summary>
+		/// <param name="settings">The <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> to use when serializing and deserializing.</param>
+		public JsonNetSerializer(JsonSerializerSettings settings)
+		{
+			if (settings == null)
+			{
+				throw new ArgumentNullException("settings");
+			}
 
-            // Just override it anyways (we're saving the user)
-            settings.MaxDepth = 20;
-            _serializer = JsonSerializer.Create(settings);
-        }
+			// Just override it anyways (we're saving the user)
+			settings.MaxDepth = 20;
+			_serializer = JsonSerializer.Create(settings);
+		}
 
-        /// <summary>
-        /// Deserializes the JSON to a .NET object.
-        /// </summary>
-        /// <param name="reader">The JSON to deserialize.</param>
-        /// <param name="targetType">The <see cref="System.Type"/> of object being deserialized.</param>
-        /// <returns>The deserialized object from the JSON string.</returns>
-        public object Parse(TextReader reader, Type targetType)
-        {
-            return _serializer.Deserialize(reader, targetType);
-        }
+		/// <summary>
+		/// Deserializes the JSON to a .NET object.
+		/// </summary>
+		/// <param name="reader">The JSON to deserialize.</param>
+		/// <param name="targetType">The <see cref="System.Type"/> of object being deserialized.</param>
+		/// <returns>The deserialized object from the JSON string.</returns>
+		public object Parse(TextReader reader, Type targetType)
+		{
+			return _serializer.Deserialize(reader, targetType);
+		}
 
-        /// <summary>
-        /// Serializes the specified object to a <see cref="TextWriter"/>.
-        /// </summary>
-        /// <param name="value">The object to serialize</param>
-        /// <param name="writer">The <see cref="TextWriter"/> to serialize the object to.</param>
-        public void Serialize(object value, TextWriter writer)
-        {
-            var selfSerializer = value as IJsonWritable;
-            if (selfSerializer != null)
-            {
-                selfSerializer.WriteJson(writer);
-            }
-            else
-            {
-                _serializer.Serialize(writer, value);
-            }
-        }
-    }
+		/// <summary>
+		/// Serializes the specified object to a <see cref="TextWriter"/>.
+		/// </summary>
+		/// <param name="value">The object to serialize</param>
+		/// <param name="writer">The <see cref="TextWriter"/> to serialize the object to.</param>
+		public void Serialize(object value, TextWriter writer)
+		{
+			var selfSerializer = value as IJsonWritable;
+			if (selfSerializer != null)
+			{
+				selfSerializer.WriteJson(writer);
+			}
+			else
+			{
+				_serializer.Serialize(writer, value);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Corrected the class JRawValue to use the dependency injected in IJsonSerializer instead of the Newton.Json.Serializer directly. I was having problems with that because I use the pt-BR culture and the JRawValue class was not deserializing decimal numbers correctly, throwing a exception.

I modified the class JsonNetSerializer to pass the culture of the current Thread to the object JsonSerializerSettings, in the default constructor of the class JsonNetSerializer.
