### PR TITLE
Make buffer larger to send/receive larger message

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
@@ -84,6 +84,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             _connectionInfo.Connection.Trace(TraceLevels.Events, "WS: {0}", builder.Uri);
 
             var webSocket = new ClientWebSocket();
+            webSocket.Options.SetBuffer(1024 * 1024, 1024 * 1024);
             _connectionInfo.Connection.PrepareRequest(new WebSocketWrapperRequest(webSocket));
 
             await webSocket.ConnectAsync(builder.Uri, _disconnectToken);


### PR DESCRIPTION
Larger message can't be send over ClientWebSocket unless ClientWebSocket's buffer is large enough.
The buffer size must be set before using.

Here is a simple fix, or you can provide some options when creating WebSocketTransport. Thanks
