### PR TITLE
Added a method to customize the JsonSerializerSettings

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
@@ -58,8 +58,8 @@ namespace Microsoft.AspNet.SignalR.Hubs
             {
                 throw new InvalidOperationException(Resources.Error_StateExceededMaximumLength);
             }
-
-            var settings = JsonUtility.CreateDefaultSerializerSettings();
+             
+            var settings = JsonUtility.CreateSerializerSettings();
             settings.Converters.Add(new SipHashBasedDictionaryConverter());
             var serializer = JsonSerializer.Create(settings);
             return serializer.Parse<IDictionary<string, object>>(json);

--- a/src/Microsoft.AspNet.SignalR.Core/Json/JsonUtility.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/JsonUtility.cs
@@ -24,6 +24,11 @@ namespace Microsoft.AspNet.SignalR.Json
         private static readonly string[] _jsKeywords = new[] { "break", "do", "instanceof", "typeof", "case", "else", "new", "var", "catch", "finally", "return", "void", "continue", "for", "switch", "while", "debugger", "function", "this", "with", "default", "if", "throw", "delete", "in", "try", "class", "enum", "extends", "super", "const", "export", "import", "implements", "let", "private", "public", "yield", "interface", "package", "protected", "static", "NaN", "undefined", "Infinity" };
 
         /// <summary>
+        /// A hanldler to enable the user to configure your own <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/>
+        /// </summary>
+        private static Func<JsonSerializerSettings> _createSerializerSettingsHandler = null;
+
+        /// <summary>
         /// Converts the specified name to camel case.
         /// </summary>
         /// <param name="name">The name to convert.</param>
@@ -66,12 +71,45 @@ namespace Microsoft.AspNet.SignalR.Json
         }
 
         /// <summary>
+        /// Set the handler that creates a new <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/>
+        /// </summary>
+        /// <param name="handler"></param>
+        /// <returns>The <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> to be used by the CreateDefaultSerializer() and the CreateSerializerSettings()</returns>
+        public static void SetCreateSerializerSettingsHandler(Func<JsonSerializerSettings> handler)
+        {
+            _createSerializerSettingsHandler = handler;
+        }
+
+        /// <summary>
         /// Creates a default <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/> instance.
         /// </summary>
         /// <returns>The newly created <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/>.</returns>
-        public static JsonSerializerSettings CreateDefaultSerializerSettings()
+        private static JsonSerializerSettings CreateDefaultSerializerSettings()
         {
-            return new JsonSerializerSettings() { MaxDepth = DefaultMaxDepth };
+            return new JsonSerializerSettings()
+            {
+                MaxDepth = DefaultMaxDepth,
+                Culture = CultureInfo.CurrentCulture
+            };
+        }
+
+        /// <summary>
+        /// Try call the handler informed in the method SetSerializerSettingsHandler, if none was informed, create a default JsonSerializerSettings
+        /// </summary>
+        /// <returns>The newly created <see cref="T:Newtonsoft.Json.JsonSerializerSettings"/>.</returns>
+        public static JsonSerializerSettings CreateSerializerSettings()
+        {
+            JsonSerializerSettings settings;
+
+            if (_createSerializerSettingsHandler == null)
+                settings = CreateDefaultSerializerSettings();
+            else
+            {
+                settings = _createSerializerSettingsHandler();
+                settings.MaxDepth = DefaultMaxDepth;
+            }
+
+            return settings;
         }
 
         /// <summary>
@@ -89,7 +127,7 @@ namespace Microsoft.AspNet.SignalR.Json
             {
                 return false;
             }
-
+             
             var identifiers = callback.Split('.');
 
             // Check each identifier to ensure it's a valid JS identifier

--- a/tests/Microsoft.AspNet.SignalR.Tests/Json/JsonFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Json/JsonFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.AspNet.SignalR.Json;
+using System.Globalization;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Extensions;
@@ -30,14 +31,85 @@ namespace Microsoft.AspNet.SignalR.Tests.Json
         }
 
         [Fact]
+        public void CreateDefaultSerializerHasCorrectCulture()
+        {
+            // Arrange and Act
+            JsonUtility.SetCreateSerializerSettingsHandler(null);
+            JsonSerializer serializer = JsonUtility.CreateDefaultSerializer();
+
+            // Assert
+            Assert.NotNull(serializer);
+            Assert.Equal(CultureInfo.CurrentCulture, serializer.Culture);
+        }
+
+        [Fact]
         public void CreateDefaultJsonSerializerSettingsHasCorrectMaxDepth()
         {
             // Arrange and Act
-            JsonSerializerSettings settings = JsonUtility.CreateDefaultSerializerSettings();
+            JsonUtility.SetCreateSerializerSettingsHandler(null);
+            JsonSerializerSettings settings = JsonUtility.CreateSerializerSettings();
 
             // Assert
             Assert.NotNull(settings);
             Assert.Equal(20, settings.MaxDepth);
+        }
+
+        [Fact]
+        public void CreateDefaultJsonSerializerSettingsHasCorrectCulture()
+        {
+            // Arrange and Act
+            JsonUtility.SetCreateSerializerSettingsHandler(null);
+            JsonSerializerSettings settings = JsonUtility.CreateSerializerSettings();
+
+            // Assert
+            Assert.NotNull(settings);
+            Assert.Equal(CultureInfo.CurrentCulture, settings.Culture);
+        }
+
+        [Fact]
+        public void CreateSerializerHasCustomSerializerSettings()
+        {
+            // Arrange and Act
+            JsonUtility.SetCreateSerializerSettingsHandler(() =>
+                new JsonSerializerSettings
+                {
+                    MaxDepth = 10,
+                    Culture = new CultureInfo("pt-BR"),
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+
+            JsonSerializer serializer = JsonUtility.CreateDefaultSerializer();
+
+            // Assert
+            Assert.NotNull(serializer);
+
+            //The currect value must be 20. This value is override in the function CreateDefaultSerializer
+            Assert.Equal(20, serializer.MaxDepth);
+            Assert.Equal(new CultureInfo("pt-BR"), serializer.Culture);
+            Assert.Equal(NullValueHandling.Ignore, serializer.NullValueHandling);
+        }
+
+        [Fact]
+        public void CreateCustomJsonSerializerSettings()
+        {
+            // Arrange and Act
+            JsonUtility.SetCreateSerializerSettingsHandler(() =>
+                new JsonSerializerSettings
+                {
+                    MaxDepth = 10,
+                    Culture = new CultureInfo("pt-BR"),
+                    NullValueHandling = NullValueHandling.Ignore
+                });
+
+            JsonSerializerSettings settings = JsonUtility.CreateSerializerSettings();
+
+            // Assert
+            Assert.NotNull(settings);
+             
+            //The currect value must be 20. This value is override in the function CreateDefaultSerializer
+            Assert.Equal(20, settings.MaxDepth);
+            Assert.Equal(new CultureInfo("pt-BR"), settings.Culture);
+            Assert.Equal(NullValueHandling.Ignore, settings.NullValueHandling);
         }
 
         [Fact]
@@ -73,7 +145,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Json
         [Fact]
         public void CreateJsonPCallbackThrowsWithInvalidIdentifier()
         {
-            Assert.Throws(typeof(InvalidOperationException),() => JsonUtility.CreateJsonpCallback("1nogood", "1"));
+            Assert.Throws(typeof(InvalidOperationException), () => JsonUtility.CreateJsonpCallback("1nogood", "1"));
         }
 
         [Theory]


### PR DESCRIPTION
-The method CreateDefaultSerializerSettings was modified to private and
now it create a JsonSerializerSettings with the Culture of the current
Thread.

-The method SetCreateSerializerSettingsHandler was created to set a
handler to be called by the CreateSerializerSettings. If the handler was
not informed, the method CreateSerializerSettings will call the
CreateDefaultSerializerSettings.
