### PR TITLE
2471 - Add product name assembly attribute

### DIFF
--- a/src/Common/CommonAssemblyInfo.cs
+++ b/src/Common/CommonAssemblyInfo.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyCompany("Microsoft Open Technologies, Inc.")]
 [assembly: AssemblyCopyright("© Microsoft Open Technologies, Inc. All rights reserved.")]
+[assembly: AssemblyProduct("Microsoft ASP.NET SignalR")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]


### PR DESCRIPTION
Added it to common assembly info, image below verifies it shows up in Explorer (from artifacts folder)

![image](https://f.cloud.github.com/assets/249088/1053458/e6fb109a-10f0-11e3-8021-9177cc1db663.png)
