### PR TITLE
Fix for 2413 - Memory leak in SignalR 1.1 on .NET 4.0 on self host

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/CancellationTokenExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/CancellationTokenExtensions.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
                     }
                     catch (ObjectDisposedException)
                     {
-                        // Bug #1549, .NET 4.0 has a bug where this throws if the CTS
+                        // Bug #1549, .NET 4.0 has a bug where this throws if the CTS is disposed.
                     }
                 }
             }


### PR DESCRIPTION
This fix avoid disposing an already disposed object, which causes a mem-leak in .NET 4.0 in SelfHost mode.
