### PR TITLE
Stop using jQuery for managing the iframe in the foreverFrame transport (2.0.1)

### DIFF
--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Build/test.config.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Build/test.config.js
@@ -5,6 +5,8 @@
 
     function failConnection() {
         $("iframe").each(function () {
+            var loadEvent;
+
             if (this.stop) {
                 this.stop();
             } else {
@@ -18,7 +20,20 @@
                     console.log("Network Mock Error occured, unable to stop iframe.  Message = " + e.message);
                 }
             }
-            $(this).triggerHandler("readystatechange");
+
+            if (window.document.createEvent) {
+                loadEvent = window.document.createEvent("Event");
+                loadEvent.initEvent("load", true, true);
+            } else {
+                loadEvent = window.document.createEventObject();
+                loadEvent.eventType = "load";
+            }
+
+            if (this.dispatchEvent) {
+                this.dispatchEvent(loadEvent);
+            } else {
+                this.fireEvent("onload", loadEvent);
+            }
         });
     }
 


### PR DESCRIPTION
- Hopefully this will avoid "SCRIPT70: Permission denied" errors in IE
#1963
