### PR TITLE
Fix pingServer to always use the baseUrl

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
@@ -64,7 +64,7 @@
             /// <summary>Pings the server</summary>
             /// <param name="connection" type="signalr">Connection associated with the server ping</param>
             /// <returns type="signalR" />
-            var baseUrl = transport === "webSockets" ? "" : connection.baseUrl,
+            var baseUrl = connection.baseUrl,
                 url = baseUrl + connection.appRelativeUrl + "/ping",
                 deferral = $.Deferred();
 


### PR DESCRIPTION
Remove "websockets" transport check from baseUrl assignment. pingServer - unlike getUrl() - always needs to use the base URL to create a proper http ping url (no Web Socket Urls are requested here).

This seems to fix a nasty bug when a Web Socket to a cross domain server times out or fails, would otherwise try to ping the client's page Web server using a relative path rather than the correct remote SignalR server.
