### PR TITLE
Make Firefox gracefully abort when a tab is refreshed or closed

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -438,6 +438,15 @@
                         connection.stop(asyncAbort);
                     });
 
+                    if (signalR._.firefoxMajorVersion(window.navigator.userAgent) >= 11) {
+                        _pageWindow.bind("beforeunload", function () {
+                            // If connection.stop() runs in beforeunload and fails, it will also fail
+                            // in unload unless connection.stop() runs after a timeout.
+                            window.setTimeout(function () {
+                                connection.stop(asyncAbort);
+                            }, 0);
+                        });
+                    }
                 }, function () {
                     initialize(transports, index + 1);
                 });


### PR DESCRIPTION
Fix Firefox not disconnecting on refresh
- Change the withCredentials flag to only be auto-set when cross-domain is detected (can still be explicitly set)
- Conditionally do an async abort if the browser is Firefox 11+ AND withCredentials is true
  #2489

Make Firefox gracefully abort when a tab is closed
- This change is only needed for cross-domain scenarios
- This does not work when the entire browser window is closed
  #2517
