### PR TITLE
Add symlinks to Resources.resx

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resources
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resources
@@ -1,0 +1,1 @@
+Resources.resx

--- a/src/Microsoft.AspNet.SignalR.Core/Resources.resources
+++ b/src/Microsoft.AspNet.SignalR.Core/Resources.resources
@@ -1,0 +1,1 @@
+Resources.resx

--- a/src/Microsoft.AspNet.SignalR.Owin/Resources.resources
+++ b/src/Microsoft.AspNet.SignalR.Owin/Resources.resources
@@ -1,0 +1,1 @@
+Resources.resx


### PR DESCRIPTION
Building in Xamarin Studio looks for Resources.resources instead of .resx.

Related discussion. http://forums.xamarin.com/discussion/1278/signalr-port-coming-soon
