### PR TITLE
HubRequestParser was always using  default serializer. Get serializer from dependency resolver instead  

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
@@ -23,7 +23,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             request.Hub = deserializedData.Hub;
             request.Method = deserializedData.Method;
             request.Id = deserializedData.Id;
-            request.State = GetState(deserializedData);
+            request.State = GetState(deserializedData, serializer);
             request.ParameterValues = (deserializedData.Args != null) ? deserializedData.Args.Select(value => new JRawValue(value)).ToArray() : _emptyArgs;
 
             return request;
@@ -44,7 +44,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             public JRaw[] Args { get; set; }
         }
 
-        private static IDictionary<string, object> GetState(HubInvocation deserializedData)
+        private static IDictionary<string, object> GetState(HubInvocation deserializedData, JsonSerializer serializer)
         {
             if (deserializedData.State == null)
             {
@@ -59,7 +59,6 @@ namespace Microsoft.AspNet.SignalR.Hubs
                 throw new InvalidOperationException(Resources.Error_StateExceededMaximumLength);
             }
 
-            var serializer = GlobalHost.DependencyResolver.Resolve<JsonSerializer>();
             return serializer.Parse<IDictionary<string, object>>(json); 
         }
     }


### PR DESCRIPTION
...ays using the default serialiser even if alternate was injected in dependency resolver
