### PR TITLE
Altered when we transition into the disconnected state during connection stop.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -731,7 +731,7 @@
                                 if ($.inArray(transport, supportedTransports) >= 0) {
                                     transports.push(transport);
                                 }
-                            });                        
+                            });
                         } else if (config.transport === "auto") {
                             transports = supportedTransports;
                         } else if ($.inArray(config.transport, supportedTransports) >= 0) {
@@ -896,48 +896,45 @@
                 return;
             }
 
-            try {
-                connection.log("Stopping connection.");
+            connection.log("Stopping connection.");
 
-                // Clear this no matter what
-                window.clearTimeout(connection._.beatHandle);
-                window.clearTimeout(connection._.onFailedTimeoutHandle);
-                window.clearInterval(connection._.pingIntervalId);
+            changeState(connection, connection.state, signalR.connectionState.disconnected);
 
-                if (connection.transport) {
-                    if (notifyServer !== false) {
-                        connection.transport.abort(connection, async);
-                    }
+            // Clear this no matter what
+            window.clearTimeout(connection._.beatHandle);
+            window.clearTimeout(connection._.onFailedTimeoutHandle);
+            window.clearInterval(connection._.pingIntervalId);
 
-                    if (connection.transport.supportsKeepAlive && connection._.keepAliveData.activated) {
-                        signalR.transports._logic.stopMonitoringKeepAlive(connection);
-                    }
-
-                    connection.transport.stop(connection);
-                    connection.transport = null;
+            if (connection.transport) {
+                if (notifyServer !== false) {
+                    connection.transport.abort(connection, async);
                 }
 
-                if (connection._.negotiateRequest) {
-                    // If the negotiation request has already completed this will noop.
-                    connection._.negotiateRequest.abort(_negotiateAbortText);
-                    delete connection._.negotiateRequest;
+                if (connection.transport.supportsKeepAlive && connection._.keepAliveData.activated) {
+                    signalR.transports._logic.stopMonitoringKeepAlive(connection);
                 }
 
-                // Trigger the disconnect event
-                $(connection).triggerHandler(events.onDisconnect);
-
-                delete connection.messageId;
-                delete connection.groupsToken;
-                delete connection.id;
-                delete connection._.pingIntervalId;
-                delete connection._.lastMessageAt;
-
-                // Clear out our message buffer
-                connection._.connectingMessageBuffer.clear();
+                connection.transport.stop(connection);
+                connection.transport = null;
             }
-            finally {
-                changeState(connection, connection.state, signalR.connectionState.disconnected);
+
+            if (connection._.negotiateRequest) {
+                // If the negotiation request has already completed this will noop.
+                connection._.negotiateRequest.abort(_negotiateAbortText);
+                delete connection._.negotiateRequest;
             }
+
+            // Trigger the disconnect event
+            $(connection).triggerHandler(events.onDisconnect);
+
+            delete connection.messageId;
+            delete connection.groupsToken;
+            delete connection.id;
+            delete connection._.pingIntervalId;
+            delete connection._.lastMessageAt;
+
+            // Clear out our message buffer
+            connection._.connectingMessageBuffer.clear();
 
             return connection;
         },

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Connections/ConnectionStateFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Connections/ConnectionStateFacts.js
@@ -2,6 +2,21 @@
 
 QUnit.module("Connection State Facts");
 
+QUnit.test("Connection state is disconnected in disconnected callback.", function () {
+    var connection = testUtilities.createHubConnection(function () { }, QUnit, "", undefined, false),
+        triggered = false;
+
+    connection.disconnected(function () {
+        QUnit.equal(connection.state, $.signalR.connectionState.disconnected, "Connection state is disconnected in disconnected callback.");
+        triggered = true;
+    });
+
+    connection.start();
+    connection.stop();
+
+    QUnit.isTrue(triggered, "Disconnected handler triggered.");
+});
+
 QUnit.test("Connection State Values", function () {
     var con = $.connection;
     QUnit.equal(con.connectionState.connecting, 0, "Verifies connecting state is 0.");


### PR DESCRIPTION
- This ensures that when the disconnected handler is called that we're in the disconnected state.
- Removed the try -> finally for this transition because the state transition now occurs prior to anything that would throw.
- Added a simple unit test to ensure that disconnected is triggered while in the disconnected state.

**NOTE:** PR looks much larger than it really is, all I did was move the changeState from the try -> finally to before the initial try.
#2554
