### PR TITLE
2484 - JS - Added extra verifyReconnect checks to ensure that if the client goes to sleep that we do not mark it active prior to trying to reconnect.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
@@ -450,6 +450,11 @@
             // We should only set a reconnectTimeout if we are currently connected
             // and a reconnectTimeout isn't already set.
             if (isConnectedOrReconnecting(connection) && !connection._.reconnectTimeout) {
+                // Need to verify before the setTimeout occurs because an application sleep could occur during the setTimeout duration.
+                if (!transportLogic.verifyReconnect(connection)) {
+                    return;
+                }
+
                 connection._.reconnectTimeout = window.setTimeout(function () {
                     if (!transportLogic.verifyReconnect(connection)) {
                         return;

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -120,6 +120,12 @@
 
         reconnect: function (connection) {
             var that = this;
+
+            // Need to verify before the setTimeout occurs because an application sleep could occur during the setTimeout duration.
+            if (!transportLogic.verifyReconnect(connection)) {
+                return;
+            }
+
             window.setTimeout(function () {
                 // Verify that we're ok to reconnect.
                 if (!transportLogic.verifyReconnect(connection)) {

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Scripts/test.utilities.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Scripts/test.utilities.js
@@ -32,7 +32,7 @@ window.sessionStorage.clear();
                 enabled: true
             },
             foreverFrame: {
-                enabled: !window.EventSource && !window.document.commandLineTest && navigator.appName === "Microsoft Internet Explorer"
+                enabled: !window.EventSource && !window.document.commandLineTest
             },
             serverSentEvents: {
                 enabled: !!window.EventSource


### PR DESCRIPTION
- Also added a test to verify that this scenario is covered.
- Changed how the test utilities verify that foreverFrame is enabled.
#2484
