### PR TITLE
Added extra verifyReconnect checks to ensure that if the client goes to sleep that we do not mark it active prior to trying to reconnect.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -66,6 +66,12 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
         private void Reconnect(IConnection connection, string data, CancellationToken disconnectToken)
         {
+            // Need to verify before the task delay occurs because an application sleep could occur during the delayed duration.
+            if (!TransportHelper.VerifyReconnect(connection))
+            {
+                return;
+            }
+
             // Wait for a bit before reconnecting
             TaskAsyncHelper.Delay(ReconnectDelay).Then(() =>
             {

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/HostedTest.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/HostedTest.cs
@@ -61,6 +61,25 @@ namespace Microsoft.AspNet.SignalR.Tests.Common.Infrastructure
             }
         }
 
+        protected void SetReconnectDelay(IClientTransport transport, TimeSpan delay)
+        {
+            // SUPER ugly, alternative is adding an overload to the create host function, adding a member to the
+            // IClientTransport object or using Reflection.  Adding a member to IClientTransport isn't horrible
+            // but we want to avoid making a breaking change... Therefore this is the least of the evils.
+            if (transport is ServerSentEventsTransport)
+            {
+                (transport as ServerSentEventsTransport).ReconnectDelay = delay;
+            }
+            else if (transport is LongPollingTransport)
+            {
+                (transport as LongPollingTransport).ReconnectDelay = delay;
+            }
+            else if (transport is WebSocketTransport)
+            {
+                (transport as WebSocketTransport).ReconnectDelay = delay;
+            }
+        }
+
         protected void EnableTracing()
         {
             string testName = GetTestName() + "." + Interlocked.Increment(ref _id);


### PR DESCRIPTION
- Also added a test to verify that this scenario is covered.
#2528
