### PR TITLE
2693 - Ensured that failed ajaxSends have their invocation callbacks cleared.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -813,8 +813,10 @@
             /// <param name="callback" type="Function">A callback function to execute when an error occurs on the connection</param>
             /// <returns type="signalR" />
             var connection = this;
-            $(connection).bind(events.onError, function (e, data) {
-                callback.call(connection, data);
+            $(connection).bind(events.onError, function (e, a, b) {
+                // In practice 'a' is the SignalR built error object.
+                // In practice 'b' is undefined for all error events except those triggered by ajaxSend.  For ajaxSend 'b' is the original send payload.
+                callback.call(connection, a, b);
             });
             return connection;
         },

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.hubs.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.hubs.js
@@ -291,7 +291,7 @@
         });
 
         connection.error(function (errData, origData) {
-            var data, callbackId, callback;
+            var callbackId, callback;
 
             if (connection.transport && connection.transport.name === "webSockets") {
                 // WebSockets connections have all callbacks removed on reconnect instead
@@ -304,26 +304,18 @@
                 return;
             }
 
-            try {
-                data = window.JSON.parse(origData);
-                if (!data.I) {
-                    // The original data doesn't have a callback ID so not a send error
-                    return;
-                }
-            } catch (e) {
-                // The original data is not a JSON payload so this is not a send error
-                return;
-            }
-            
-            callbackId = data.I;
+            callbackId = origData.I;
             callback = connection._.invocationCallbacks[callbackId];
 
-            // Invoke the callback with an error to reject the promise
-            callback.method.call(callback.scope, { E: errData });
+            // Verify that there is a callback bound (could have been cleared)
+            if (callback) {
+                // Delete the callback
+                connection._.invocationCallbacks[callbackId] = null;
+                delete connection._.invocationCallbacks[callbackId];
 
-            // Delete the callback
-            connection._.invocationCallbacks[callbackId] = null;
-            delete connection._.invocationCallbacks[callbackId];
+                // Invoke the callback with an error to reject the promise
+                callback.method.call(callback.scope, { E: errData });
+            }
         });
 
         connection.reconnecting(function () {

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubProxyFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubProxyFacts.js
@@ -75,6 +75,39 @@ testUtilities.runWithAllTransports(function (transport) {
         };
     });
 
+    QUnit.asyncTimeoutTest(transport + " hub connection clears invocation callbacks after failed invocation.", testUtilities.defaultTestTimeout * 3, function (end, assert, testName) {
+        var connection = testUtilities.createHubConnection(end, assert, testName),
+            demo = connection.createHubProxies().demo,
+            url = connection.url;
+
+        connection.start({ transport: transport }).done(function () {
+            assert.isNotSet(connection._.invocationCallbacks["0"], "Callback list should be empty before invocation.");
+
+            // Provide faulty url so the ajaxSend fails.
+            connection.url = "http://foo";
+            var invokePromise = demo.server.synchronousException();
+            // Reset back to original url so background network tasks function properly.
+            connection.url = url;
+
+            assert.isSet(connection._.invocationCallbacks["0"], "Callback should be in the callback list.");
+
+            invokePromise.done(function (result) {
+                assert.fail("Invocation succeeded.");
+                end();
+            }).fail(function () {
+                assert.isNotSet(connection._.invocationCallbacks["0"], "Callback should be cleared.");
+                end();
+            });
+        });
+
+        // Cleanup
+        return function () {
+            // Replace url with a valid url so stop completes successfully.
+            connection.url = url;
+            connection.stop();
+        };
+    });
+
     QUnit.asyncTimeoutTest(transport + " hub connection clears all invocation callbacks on stop.", testUtilities.defaultTestTimeout, function (end, assert, testName) {
         var connection = testUtilities.createHubConnection(end, assert, testName),
             demo = connection.createHubProxies().demo,


### PR DESCRIPTION
- Involved having two parameters for our error callback binder.
- This code path wasn't run for a while due to never receiving the origData in the callback, therefore had to remove some legacy functionality.
- Also added a test to ensure that failed sends clear invocation callbacks.
#2693
