### PR TITLE
Prevent buffering in the JS client from duplicating messages

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -791,9 +791,7 @@
             /// <returns type="signalR" />
             var connection = this;
             $(connection).bind(events.onReceived, function (e, data) {
-                if (!connection._.connectingMessageBuffer.tryBuffer(data)) {
-                    callback.call(connection, data);
-                }
+                callback.call(connection, data);
             });
             return connection;
         },

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
@@ -279,7 +279,7 @@
                                 return;
                             }
 
-                            $(connection).triggerHandler(events.onReceived, [res]);
+                            transportLogic.triggerReceived(connection, res);
                         }
                     },
                     error: function (error, textStatus) {
@@ -331,15 +331,20 @@
             }
         },
 
+        triggerReceived: function (connection, data) {
+            if (!connection._.connectingMessageBuffer.tryBuffer(data)) {
+                $(connection).triggerHandler(events.onReceived, [data]);
+            }
+        },
+
         processMessages: function (connection, minData, onInitialized) {
-            var data,
-                $connection = $(connection);
+            var data;
 
             // Update the last message time stamp
             transportLogic.markLastMessage(connection);
 
             if (minData) {
-                data = this.maximizePersistentResponse(minData);
+                data = transportLogic.maximizePersistentResponse(minData);
 
                 if (data.Disconnect) {
                     connection.log("Disconnect command received from server.");
@@ -349,7 +354,7 @@
                     return;
                 }
 
-                this.updateGroups(connection, data.GroupsToken);
+                transportLogic.updateGroups(connection, data.GroupsToken);
 
                 if (data.MessageId) {
                     connection.messageId = data.MessageId;
@@ -357,7 +362,7 @@
 
                 if (data.Messages) {
                     $.each(data.Messages, function (index, message) {
-                        $connection.triggerHandler(events.onReceived, [message]);
+                        transportLogic.triggerReceived(connection, message);
                     });
 
                     transportLogic.tryInitialize(data, onInitialized);
@@ -450,8 +455,7 @@
         },
 
         reconnect: function (connection, transportName) {
-            var transport = signalR.transports[transportName],
-                that = this;
+            var transport = signalR.transports[transportName];
 
             // We should only set a reconnectTimeout if we are currently connected
             // and a reconnectTimeout isn't already set.
@@ -468,7 +472,7 @@
 
                     transport.stop(connection);
 
-                    if (that.ensureReconnectingState(connection)) {
+                    if (transportLogic.ensureReconnectingState(connection)) {
                         connection.log(transportName + " reconnecting.");
                         transport.start(connection);
                     }

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.webSockets.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.webSockets.js
@@ -88,8 +88,7 @@
                 };
 
                 connection.socket.onmessage = function (event) {
-                    var data,
-                        $connection = $(connection);
+                    var data;
 
                     try {
                         data = connection._parseResponse(event.data);
@@ -106,7 +105,7 @@
                         } else {
                             // For websockets we need to trigger onReceived
                             // for callbacks to outgoing hub calls.
-                            $connection.triggerHandler(events.onReceived, [data]);
+                            transportLogic.triggerReceived(connection, data);
                         }
                     }
                 };

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubProxyFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubProxyFacts.js
@@ -40,6 +40,9 @@ testUtilities.runWithAllTransports(function (transport) {
             assert.equal(connection.state, $.signalR.connectionState.connected, "Buffer me triggers after the connection is in the connected state.");
         };
 
+        // Issue #2595
+        connection.received(function () { });
+
         connection.start({ transport: transport }).done(function () {
             assert.equal(bufferMeCalls, 2, "After start's deferred completes the buffer has already been drained.");
 
@@ -50,7 +53,6 @@ testUtilities.runWithAllTransports(function (transport) {
             connection.stop();
         };
     });
-
 
     QUnit.asyncTimeoutTest(transport + " hub connection clears invocation callbacks after successful invocation.", testUtilities.defaultTestTimeout, function (end, assert, testName) {
         var connection = testUtilities.createHubConnection(end, assert, testName),


### PR DESCRIPTION
- This fixes an issue where if a message was received while in the
  connecting state, it would be duplicated for each received handler.
#2595
