### PR TITLE
Avoid crashing Safari during window unload

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -913,6 +913,8 @@
             window.clearInterval(connection._.pingIntervalId);
 
             if (connection.transport) {
+                connection.transport.stop(connection);
+
                 if (notifyServer !== false) {
                     connection.transport.abort(connection, async);
                 }
@@ -921,7 +923,6 @@
                     signalR.transports._logic.stopMonitoringKeepAlive(connection);
                 }
 
-                connection.transport.stop(connection);
                 connection.transport = null;
             }
 


### PR DESCRIPTION
Stop the active transport before making an /abort request (JS Client)
- Desktop and mobile Safari will sometimes crash if a synchronous request
  is made during unload with an ongoing WebSocket connection open
- Stopping the ongoing WebSocket connection before making the /abort
  request during unload prevents Safari from crashing
#2650
