### PR TITLE
updated package name and versions

### DIFF
--- a/SignalR.Hosting.AspNet.Samples/packages.config
+++ b/SignalR.Hosting.AspNet.Samples/packages.config
@@ -3,7 +3,7 @@
   <package id="AntiXSS" version="4.0.1" />
   <package id="elmah" version="1.2.0.1" />
   <package id="elmah.corelibrary" version="1.2" />
-  <package id="EntityFramework" version="4.1.10331.0" />
+  <package id="EntityFramework" version="6.0.1" />
   <package id="jQuery" version="1.6.2" />
   <package id="jQuery.Color" version="1.0" />
   <package id="jquery.cookie" version="1.0" />
@@ -13,5 +13,5 @@
   <package id="jQuery.UI.Combined" version="1.8.13" />
   <package id="json2" version="1.0" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
-  <package id="WebActivator" version="1.5" />
+  <package id="WebActivatorEx" version="2.0.4" />
 </packages>


### PR DESCRIPTION
Had to update Entity Framework version and change package name of WebActivator to WebActivatorEx (and update version) in packages.config to successfully build the project - SignalR.Hosting.AspNet.Samples
