### PR TITLE
return types that had been found (even if there were some errors)

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
@@ -96,6 +96,10 @@ namespace Microsoft.AspNet.SignalR.Hubs
             {
                 return a.GetTypes();
             }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types;
+            }
             catch
             {
                 return Enumerable.Empty<Type>();


### PR DESCRIPTION
ReflectedHubDescriptorProvider.GetTypesSafe() was all or nothing getter. 
This patch permits to retrieve all the possible types from the assembly (even if an exception is raised).
