### PR TITLE
Backpatch fixes for Mono to 1.2

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hosting/HostDependencyResolverExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hosting/HostDependencyResolverExtensions.cs
@@ -20,8 +20,12 @@ namespace Microsoft.AspNet.SignalR.Hosting
                 throw new ArgumentNullException("instanceName");
             }
 
-            // Initialize the performance counters
-            resolver.InitializePerformanceCounters(instanceName, hostShutdownToken);
+            // Performance counters are broken on mono so just skip this step
+            if (!MonoUtility.IsRunningMono)
+            {
+                // Initialize the performance counters
+                resolver.InitializePerformanceCounters(instanceName, hostShutdownToken);
+            }
 
             // Dispose the dependency resolver on host shut down (cleanly)
             resolver.InitializeResolverDispose(hostShutdownToken);

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/MonoUtility.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/MonoUtility.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNet.SignalR.Infrastructure
+{
+    internal static class MonoUtility
+    {
+        private static readonly Lazy<bool> _isRunningMono = new Lazy<bool>(() => CheckRunningOnMono());
+
+        internal static bool IsRunningMono
+        {
+            get
+            {
+                return _isRunningMono.Value;
+            }
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "This should never fail")]
+        private static bool CheckRunningOnMono()
+        {
+            try
+            {
+                return Type.GetType("Mono.Runtime") != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
+++ b/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Infrastructure\ConnectionManager.cs" />
     <Compile Include="ConnectionMessage.cs" />
     <Compile Include="Infrastructure\DefaultProtectedData.cs" />
+    <Compile Include="Infrastructure\MonoUtility.cs" />
     <Compile Include="Infrastructure\DiffPair.cs" />
     <Compile Include="Infrastructure\DiffSet.cs" />
     <Compile Include="GlobalHost.cs" />


### PR DESCRIPTION
Please apply this workaround that David made to the 2.x code to achieve compatibility with Mono.  This will allow those of us stuck with earlier versions of Mono to be able to use SignalR on .NET 4.0.

The embedded Linux/ARMv5 system that I'm coding for has multiple issues with .NET 4.5 on Mono, so SignalR 2.x isn't a possibility on this project. However, .NET 4.0 Mono is solid and SignalR 1.2 works great with the PerformanceCounter exclusion workaround.
