### PR TITLE
Make it possible to use Forever Frame when requested.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -77,7 +77,7 @@
             if (window.EventSource) {
                 // If the browser supports SSE, don't use Forever Frame
                 if (onFailed) {
-                    connection.log("Forever Frames is not supported for browsers with SSE support.");
+                    connection.log("Forever Frame is not supported by SignalR on browsers with SSE support.");
                     onFailed();
                 }
                 return;


### PR DESCRIPTION
This pull request resolves #1057
- Instead of failing due to window.EventSource is supported, a log message sent that better transport methods are available.

This affects when you are specifying transport methods as an option to hub.start, that failed earlier if SSE was supported.
    $.connection.hub.start({ transport: ['foreverFrame', 'longPolling'] }, function() {
        console.log('connection started!');
    });

This means that it will affects the prioritization if specified like above.
