### PR TITLE
Update SqlReceiver.cs

### DIFF
--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlReceiver.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlReceiver.cs
@@ -84,7 +84,8 @@ namespace Microsoft.AspNet.SignalR.SqlServer
 
                 try
                 {
-                    _lastPayloadId = (long?)lastPayloadIdOperation.ExecuteScalar();
+                    var lastPayloadId = (long?)lastPayloadIdOperation.ExecuteScalar();
+                    _lastPayloadId = lastPayloadId.HasValue ? lastPayloadId : 0;
                     Queried();
 
                     // Complete the StartReceiving task as we've successfully initialized the payload ID


### PR DESCRIPTION
A little patch to prevent an crash because of uncaught exception if the Messages_0_Id table is empty for any reason :

System.InvalidOperationException: Nullable object must have a value.
   at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
   at Microsoft.AspNet.SignalR.SqlServer.SqlReceiver.Receive(Object state)

I think there is room for optimization, but this is just a suggestion.
After all, the table should never be empty.
