### PR TITLE
Async call back from proxy.On<>(...) to fix a dead-lock issue

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.Client40.Samples/Client.cs
+++ b/samples/Microsoft.AspNet.SignalR.Client40.Samples/Client.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNet.SignalR.Client40.Samples
         {
             try
             {
-                RunHubConnectionAPI(url);
+                RunLockStepDemo(url);
             }
             catch (Exception exception)
             {
@@ -54,6 +54,31 @@ namespace Microsoft.AspNet.SignalR.Client40.Samples
             hubProxy.Invoke("DisplayMessageGroup", "CommonClientGroup", "Hello Group Members! (caller should not see this message)").Wait();
 
             hubProxy.Invoke("DisplayMessageCaller", "Hello Caller again!").Wait();
+        }
+
+        private void RunLockStepDemo(string url)
+        {
+            var hubConnection = new HubConnection(url);
+
+            var hubProxy = hubConnection.CreateHubProxy("demo");
+            hubProxy.On<int>("invoke", (i) =>
+            {
+                var task = hubProxy.Invoke("PlainTask");
+                // See Microsoft.AspNet.SignalR.Client/HubProxyExtensions.cs:417
+                //     without the `new Task(action).Start();` the `task.Wait();` call
+                //     below never returns.
+                // Justification: 
+                //     sending calls back synchronously is desirable in some situations,
+                //     and should not create a dead-lock in any case.           
+                task.Wait();
+                Console.WriteLine("Completed synchronous call-back");
+            });
+
+            hubConnection.Start().Wait();
+            hubConnection.TraceWriter.WriteLine("transport.Name={0}", hubConnection.Transport.Name);
+
+            Console.WriteLine("Starting calls...");
+            hubProxy.Invoke("multipleCalls").Wait();
         }
 
         private void RunDemo(string url)

--- a/src/Microsoft.AspNet.SignalR.Client/HubProxyExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/HubProxyExtensions.cs
@@ -4,13 +4,14 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.AspNet.SignalR.Client.Hubs;
-using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Microsoft.AspNet.SignalR.Infrastructure;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Threading.Tasks;
 
 namespace Microsoft.AspNet.SignalR.Client
 {
+
     /// <summary>
     /// Extensions to the <see cref="IHubProxy"/>.
     /// </summary>
@@ -411,7 +412,7 @@ namespace Microsoft.AspNet.SignalR.Client
 
             try
             {
-                action();
+                new Task(action).Start();
             }
             catch (JsonReaderException ex)
             {

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/HubProxyFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/HubProxyFacts.cs
@@ -113,6 +113,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             });
 
             hubProxy.InvokeEvent("foo", new JToken[] { });
+            Thread.Sleep(100);
             Assert.True(eventRaised);
         }
 
@@ -132,6 +133,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             });
 
             hubProxy.InvokeEvent("foo", new[] { JToken.FromObject(1) });
+            Thread.Sleep(100);
             Assert.True(eventRaised);
         }
 


### PR DESCRIPTION
Hi.

As mentioned in #2153, there is a case of potential deadlock. A potential 1-line fix is here in `HubProxyExtensions.cs`.

I tried add an appropriate unit test, but using mocks I couldn't reproduce; using real connections ended up with an unreadable tangle of a test.

I've added an example in `samples/Microsoft.AspNet.SignalR.Client40.Samples/Client.cs` that dead-locks without the change, and runs smoothly without.

A disadvantage is that two of the `HubProxyFacts.cs` tests are no longer single-threaded and require a small sleep to pass.

Thanks,
Iain B.
