### PR TITLE
Update ServiceBus config documentation

### DIFF
--- a/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusScaleoutConfiguration.cs
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusScaleoutConfiguration.cs
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.SignalR
         /// <summary>
         /// The number of topics to send messages over. Using more topics reduces contention and may increase throughput.
         /// This must be consistent between all nodes in the web farm.
-        /// Defaults to 1.
+        /// Defaults to 5.
         /// </summary>
         public int TopicCount
         {


### PR DESCRIPTION
With `Line 32` setting `TopicCount` to 5 (within the constructor), should the documentation on the `TopicCount` property indicate that the default is 5 rather than 1?
