### PR TITLE
Adding support for WP81 and WPA81 targets to the client NuGet package.

### DIFF
--- a/build/Build.proj
+++ b/build/Build.proj
@@ -81,7 +81,7 @@
     <!-- Only build the following clients if the SDK is installed -->
     <Projects Include="$(ProjectRoot)\src\Microsoft.AspNet.SignalR.Client.Portable\Microsoft.AspNet.SignalR.Client.Portable.csproj">
       <Build Condition="!$(WP8SDKInstalled)">false</Build>
-      <Platform>portable-net45+sl5+netcore45+wp8</Platform>
+      <Platform>portable-net45+sl5+netcore45+wp8+wp81+wpa81</Platform>
       <!-- HttpClient causes issues with running FxCop on the SL5 and WP8 clients -->
       <RunFxCop>false</RunFxCop>
     </Projects>
@@ -426,6 +426,10 @@
       <NuspecTransform Include="@(Nuspecs)">
         <Find>__SIGNALR_COPYRIGHT_NOTICE__</Find>
         <ReplaceWith>Copyright (c) Microsoft Open Technologies, Inc.  All rights reserved.</ReplaceWith>
+      </NuspecTransform>
+      <NuspecTransform Include="@(Nuspecs)">
+        <Find>__SIGNALR_CLIENT_LICENSE_URL__</Find>
+        <ReplaceWith>http://www.microsoft.com/web/webpi/eula/signalr_client_enu.htm</ReplaceWith>
       </NuspecTransform>
     </ItemGroup>
 

--- a/nuspecs/Microsoft.AspNet.SignalR.Client.nuspec
+++ b/nuspecs/Microsoft.AspNet.SignalR.Client.nuspec
@@ -25,6 +25,10 @@
         <dependency id="Newtonsoft.Json" version="5.0.0" />
         <dependency id="Microsoft.Net.Http" version="2.1.10" />
       </group>
+      <group targetFramework="portable-wp81+wpa81">
+        <dependency id="Newtonsoft.Json" version="6.0.2" />
+        <dependency id="Microsoft.Net.Http" version="2.2.19" />
+      </group>
     </dependencies>
   </metadata>
   <files>
@@ -32,7 +36,7 @@
     <file src="Net40\Microsoft.AspNet.SignalR.Client.xml" target="lib\net40" />
     <file src="Net45\Microsoft.AspNet.SignalR.Client.dll" target="lib\net45" />
     <file src="Net45\Microsoft.AspNet.SignalR.Client.xml" target="lib\net45" />
-    <file src="portable-net45+sl5+netcore45+wp8\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-net45+sl5+netcore45+wp8" />
-    <file src="portable-net45+sl5+netcore45+wp8\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-net45+sl5+netcore45+wp8" />
+    <file src="portable-net45+sl5+netcore45+wp8+wp81+wpa81\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-net45+sl5+netcore45+wp8+wp81+wpa81" />
+    <file src="portable-net45+sl5+netcore45+wp8+wp81+wpa81\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-net45+sl5+netcore45+wp8+wp81+wpa81" />
   </files>
 </package>


### PR DESCRIPTION
Adding support for WP81 and WPA81 targets to the client NuGet package.

Verification: Created Windows Phone 8.1 WinRT and Silverlight and made sure they could send and receive messages. 

Note: this will probably require installing Windows 8.1 SDK on the CI 
