### PR TITLE
HostIlE - IE11 connects to a wrong host in cross domain scenarios when a...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -485,7 +485,7 @@
             parser.href = connection.url;
             if (!parser.protocol || parser.protocol === ":") {
                 connection.protocol = window.document.location.protocol;
-                connection.host = !parser.host || parser.host === "" ? window.document.location.host : parser.host;
+                connection.host = parser.host || window.document.location.host;
             } else {
                 connection.protocol = parser.protocol;
                 connection.host = parser.host;


### PR DESCRIPTION
... relative connection url is used (fixes #2959)

When parsing a relatinve uri with <a> (anchor) IE11 does not provide the protocol so we fall back to using `window.document.location` to resolve connection details. However if the host could be read from the url provided by the user we should use it instead of the one from the `window.document.location`. The fix is to use the host from the url provided by the user if possible and fall back to using the host from the `window.document.location` if the host could not be read from the user's url.
