### PR TITLE
DontPublicizeInternalAffairs - changing visibility of OnReconnecting fro...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -812,7 +812,12 @@ namespace Microsoft.AspNet.SignalR.Client
             OnError(error);
         }
 
-        public virtual void OnReconnecting()
+        void IConnection.OnReconnecting()
+        {
+            OnReconnecting();
+        }
+
+        internal virtual void OnReconnecting()
         {
             // Only allow the client to attempt to reconnect for a _disconnectTimout TimeSpan which is set by
             // the server during negotiation.

--- a/src/Microsoft.AspNet.SignalR.Client/HubConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/HubConnection.cs
@@ -82,7 +82,7 @@ namespace Microsoft.AspNet.SignalR.Client
         {
         }
 
-        public override void OnReconnecting()
+        internal override void OnReconnecting()
         {
             ClearInvocationCallbacks(Resources.Message_Reconnecting);
             base.OnReconnecting();

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/ConnectionFacts.cs
@@ -382,5 +382,28 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                 Assert.True(errorCalledResetEvent.Wait(1000), "OnError not called");
             }
         }
+        
+        [Fact]
+        public void OnReconnectingExplicitImplementationCallsIntoProtectedOnReconnecting()
+        {
+            var connectionFake = new HubConnectionFake();
+            ((IConnection)connectionFake).OnReconnecting();
+            Assert.True(connectionFake.OnReconnectingInvoked);
+        }
+
+        private class HubConnectionFake : HubConnection
+        {
+            public HubConnectionFake()
+                : base("http://fakeurl")
+            {
+            }
+
+            public bool OnReconnectingInvoked { get; private set; }
+
+            internal override void OnReconnecting()
+            {
+                OnReconnectingInvoked = true;
+            }
+        }
     }
 }


### PR DESCRIPTION
...m public to internal (fixes #3005)

OnReconnecting is not meant to be used by end users and therefore should not be public.
