### PR TITLE
Change long polling request to use same url and Post instead of Get for ...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -100,7 +100,7 @@
         isDisconnecting = function (connection) {
             return connection.state === signalR.connectionState.disconnected;
         },
-        
+
         supportsKeepAlive = function (connection) {
             return connection._.keepAliveData.activated &&
                    connection.transport.supportsKeepAlive(connection);
@@ -403,7 +403,7 @@
 
         state: signalR.connectionState.disconnected,
 
-        clientProtocol: "1.4",
+        clientProtocol: "1.5",
 
         reconnectDelay: 2000,
 

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.common.js
@@ -206,13 +206,14 @@
             throw new Error("Query string property must be either a string or object.");
         },
 
-        getUrl: function (connection, transport, reconnecting, poll) {
+        // BUG #2953: The url needs to be same otherwise it will cause a memory leak
+        getUrl: function (connection, transport, reconnecting, poll, ajaxPost) {
             /// <summary>Gets the url for making a GET based connect request</summary>
             var baseUrl = transport === "webSockets" ? "" : connection.baseUrl,
                 url = baseUrl + connection.appRelativeUrl,
                 qs = "transport=" + transport;
 
-            if (connection.groupsToken) {
+            if (!ajaxPost && connection.groupsToken) {
                 qs += "&groupsToken=" + window.encodeURIComponent(connection.groupsToken);
             }
 
@@ -226,13 +227,17 @@
                     url += "/reconnect";
                 }
 
-                if (connection.messageId) {
+                if (!ajaxPost && connection.messageId) {
                     qs += "&messageId=" + window.encodeURIComponent(connection.messageId);
                 }
             }
             url += "?" + qs;
             url = transportLogic.prepareQueryString(connection, url);
-            url += "&tid=" + Math.floor(Math.random() * 11);
+
+            if (!ajaxPost) {
+                url += "&tid=" + Math.floor(Math.random() * 11);
+            }
+
             return url;
         },
 

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.longPolling.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.longPolling.js
@@ -90,7 +90,16 @@
                         connect = (messageId === null),
                         reconnecting = !connect,
                         polling = !raiseReconnect,
-                        url = transportLogic.getUrl(instance, that.name, reconnecting, polling);
+                        url = transportLogic.getUrl(instance, that.name, reconnecting, polling, true /* use Post for longPolling */),
+                        postData = {};
+
+                    if (instance.messageId) {
+                        postData.messageId = instance.messageId;
+                    }
+
+                    if (instance.groupsToken) {
+                        postData.groupsToken = instance.groupsToken;
+                    }
 
                     // If we've disconnected during the time we've tried to re-instantiate the poll then stop.
                     if (isDisconnecting(instance) === true) {
@@ -105,6 +114,9 @@
                             }
                         },
                         url: url,
+                        type: "POST",
+                        contentType: signalR._.defaultContentType,
+                        data: postData,
                         success: function (result) {
                             var minData,
                                 delay = 0,

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/ProtocolResolver.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/ProtocolResolver.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
         private readonly Version _minimumDelayedStartVersion = new Version(1, 4);
 
         public ProtocolResolver() :
-            this(new Version(1, 2), new Version(1, 4))
+            this(new Version(1, 2), new Version(1, 5))
         {
         }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ITransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ITransport.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Infrastructure;
+using Microsoft.AspNet.SignalR.Hosting;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.AspNet.SignalR.Transports
 {
@@ -36,6 +38,13 @@ namespace Microsoft.AspNet.SignalR.Transports
         /// Gets or sets the connection id for the transport.
         /// </summary>
         string ConnectionId { get; set; }
+
+        /// <summary>
+        /// Get groupsToken in request over the transport.
+        /// </summary>
+        /// <returns>groupsToken in request</returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is for async.")]
+        Task<string> GetGroupsToken();
 
         /// <summary>
         /// Processes the specified <see cref="ITransportConnection"/> for this transport.

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/TransportDisconnectBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/TransportDisconnectBase.cs
@@ -26,6 +26,9 @@ namespace Microsoft.AspNet.SignalR.Transports
         private int _ended;
         private TransportConnectionStates _state;
 
+        [SuppressMessage("Microsoft.Design", "CA1051:DoNotDeclareVisibleInstanceFields", Justification = "It can be set in any derived class.")]
+        protected string _lastMessageId;
+
         internal static readonly Func<Task> _emptyTaskFunc = () => TaskAsyncHelper.Empty;
 
         // The TCS that completes when the task returned by PersistentConnection.OnConnected does.
@@ -90,6 +93,26 @@ namespace Microsoft.AspNet.SignalR.Transports
             set;
         }
 
+        protected string LastMessageId
+        {
+            get
+            {
+                return _lastMessageId;
+            }
+        }
+
+        protected virtual Task InitializeMessageId()
+        {
+            _lastMessageId = Context.Request.QueryString["messageId"];
+            return TaskAsyncHelper.Empty;
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is for async.")]
+        public virtual Task<string> GetGroupsToken()
+        {
+            return TaskAsyncHelper.FromResult(Context.Request.QueryString["groupsToken"]);
+        }
+
         public virtual TextWriter OutputWriter
         {
             get
@@ -126,7 +149,7 @@ namespace Microsoft.AspNet.SignalR.Transports
             {
                 // If the CTS is tripped or the request has ended then the connection isn't alive
                 return !(
-                    CancellationToken.IsCancellationRequested || 
+                    CancellationToken.IsCancellationRequested ||
                     (_requestLifeTime != null && _requestLifeTime.Task.IsCompleted) ||
                     _lastWriteTask.IsCanceled ||
                     _lastWriteTask.IsFaulted
@@ -357,7 +380,7 @@ namespace Microsoft.AspNet.SignalR.Transports
             return writeTask;
         }
 
-        protected virtual void InitializePersistentState()
+        protected virtual async Task InitializePersistentState()
         {
             _hostShutdownToken = _context.Environment.GetShutdownToken();
 
@@ -383,6 +406,8 @@ namespace Microsoft.AspNet.SignalR.Transports
                 ((HttpRequestLifeTime)state).Complete();
             },
             _requestLifeTime);
+
+            await InitializeMessageId().PreserveCulture();
         }
 
         private static void OnDisconnectError(AggregateException ex, object state)

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubGroupFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubGroupFacts.js
@@ -87,7 +87,7 @@ testUtilities.runWithAllTransports(function (transport) {
 
             if (++pingCount === 2) {
                 assert.comment("Pinged twice.");
-                
+
                 // Let sleep for 1 second to let any dups flow in (so we can fail)
                 window.setTimeout(function () {
                     end();
@@ -99,6 +99,45 @@ testUtilities.runWithAllTransports(function (transport) {
 
         connection.start({ transport: transport }).done(function () {
             groupJoiningHub.server.pingGroup();
+        });
+
+        // Cleanup
+        return function () {
+            connection.stop();
+        };
+    });
+
+    QUnit.asyncTimeoutTest(transport + ": group works after app domain restart when groupsToken just from client.", testUtilities.defaultTestTimeout * 3, function (end, assert, testName) {
+        var connection = testUtilities.createHubConnection(end, assert, testName),
+            groupChat = connection.createHubProxies().groupChat,
+            groupName = "group$&+,/:;=?@[]1";
+
+        groupChat.client.send = function (value) {
+            assert.ok(value === "hello", "Successful received message from group after reconnected");
+            end();
+        };
+
+        connection.reconnecting(function () {
+            assert.ok(true, "Connection is now attempting to reconnect");
+        });
+
+        connection.reconnected(function () {
+            assert.ok(true, "Successfuly raised reconnected event ");
+
+            // Workaround for bug#2642 on webSockets that requires to call server method after a short timeout in reconnected event   
+            window.setTimeout(function () {
+                groupChat.server.send(groupName, "hello").done(function () {
+                    assert.ok(true, "Successful send to group");
+                });
+            }, 30);
+        });
+
+        connection.start({ transport: transport }).done(function () {
+            assert.ok(true, "Connected");
+
+            groupChat.server.join(groupName).done(function () {
+                groupChat.server.triggerAppDomainRestart();
+            });
         });
 
         // Cleanup

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Common/UrlFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Common/UrlFacts.js
@@ -8,7 +8,7 @@ QUnit.test("getUrl handles groupsToken correctly.", function () {
     // Every unsafe character group name.
     connection.groupsToken = '$&+,/:;=?@ "<>#%{}|\^[]`';
 
-    $.each(testUtilities.transportNames, function () {
+    $.each(["webSocket", "serverSentEvents", "foreverFrame"], function () {
         var transport = this.toString();
 
         url = $.signalR.transports._logic.getUrl(connection, transport, true);
@@ -115,7 +115,7 @@ QUnit.test("getUrl handles messageId correctly", function () {
     // Every unsafe character name.
     connection.messageId = '$&+,/:;=?@ "<>#%{}|\^[]`';
 
-    $.each(testUtilities.transportNames, function () {
+    $.each(["webSocket", "serverSentEvents", "foreverFrame"], function () {
         var transport = this.toString();
 
         url = $.signalR.transports._logic.getUrl(connection, transport, true);

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Hubs/ChatWithGroups.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Hubs/ChatWithGroups.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNet.SignalR.Hubs;
 
 namespace Microsoft.AspNet.SignalR.Tests.Common.Hubs
@@ -23,6 +20,11 @@ namespace Microsoft.AspNet.SignalR.Tests.Common.Hubs
         public void Leave(string group)
         {
             Groups.Remove(Context.ConnectionId, group);
+        }
+
+        public void TriggerAppDomainRestart()
+        {
+            HttpRuntime.UnloadAppDomain();
         }
     }
 }

--- a/tests/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNet.SignalR.Infrastructure;
 using Microsoft.AspNet.SignalR.Tests.Common.Infrastructure;
 using Moq;
 using Xunit;
+using Microsoft.AspNet.SignalR.Tests.Utilities;
 
 namespace Microsoft.AspNet.SignalR.Tests
 {
@@ -18,14 +19,22 @@ namespace Microsoft.AspNet.SignalR.Tests
             public void NullContextThrows()
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
-                Assert.Throws<ArgumentNullException>(() => connection.Object.ProcessRequest((HostContext)null));
+
+                TestUtilities.AssertUnwrappedException<ArgumentNullException>(() =>
+                {
+                    connection.Object.ProcessRequest((HostContext)null).Wait();
+                });
             }
 
             [Fact]
             public void UninitializedThrows()
             {
                 var connection = new Mock<PersistentConnection>() { CallBase = true };
-                Assert.Throws<InvalidOperationException>(() => connection.Object.ProcessRequest(new HostContext(null, null)));
+
+                TestUtilities.AssertUnwrappedException<InvalidOperationException>(() =>
+                {
+                    connection.Object.ProcessRequest(new HostContext(null, null)).Wait();
+                });
             }
 
             [Fact]
@@ -137,7 +146,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 var context = new HostContext(req.Object, null);
                 connection.Object.Initialize(dr);
 
-                return connection.Object.VerifyGroups(context, connectionId);
+                return connection.Object.VerifyGroups(connectionId, groupsToken);
             }
         }
 

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/Transports/LongPollingTransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/Transports/LongPollingTransportFacts.cs
@@ -82,6 +82,8 @@ namespace Microsoft.AspNet.SignalR.Tests.Server.Transports
             {
                 var request = new Mock<IRequest>();
                 request.Setup(m => m.QueryString).Returns(new NameValueCollectionWrapper());
+                request.Setup(m => m.ReadForm())
+                    .Returns(TaskAsyncHelper.FromResult((INameValueCollection)new NameValueCollectionWrapper()));
                 request.Setup(m => m.LocalPath).Returns(requestPath);
 
                 var response = new Mock<IResponse>();


### PR DESCRIPTION
...workaround to handle memory leaking on browser

We found that memory leaks on IE/Chrome when long polling url is different every time, however memory doesn’t leak on IE/Chrome when long polling url is same every time, so here we do some workaround for SignalR:
1. Change long polling request to use same url and Post instead of Get 
2. Move messageId from queryString to request body
3. Move groupsToken from queryString to request body

Verified:
1. With the change, all transports work, longPolling doesn't have memory leaking on IE/Chrome anymore.
2. Old version JS clients all transports work with the new server.
3. Tests passed on CI machine.
4. Run Stress.exe for SimpleEchoHub, it is faster than the code from dev branch without the change on same machine.
5. Run stress tests on local machine for 10+ hours, no new issue found.
6. In JS tests we have functional tests, so messageId get automatically verified.
7. In JS tests we also have functional tests for groupsToken and new test added to verify groupsTokens  after app domain restart .
#2953
