### PR TITLE
Handling bug #2853

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
             Identity = identity;
             _callback = callback;
-            EventKeys = eventKeys;
+            EventKeys = new List<string>(eventKeys);
             MaxMessages = maxMessages;
             _counters = counters;
             _callbackState = state;

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/SubscriptionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/SubscriptionFacts.cs
@@ -160,6 +160,28 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             }
         }
 
+        [Fact]
+        public void SubscriptionShouldHaveOwnEventKeysList()
+        {
+            Func<MessageResult, object, Task<bool>> callback = async (result, state) =>
+            {
+                await TaskAsyncHelper.FromResult(true);
+                return false;
+            };
+
+            var subscription = new Mock<TestSubscription>("TestSub", new[] { "a" }, callback)
+            {
+                CallBase = true
+            };
+
+            using (subscription.Object)
+            {
+                subscription.Object.RemoveEvent("a");
+                Assert.Empty(subscription.Object.EventKeys);
+            }
+
+        }
+
         public class TestSubscription : Subscription
         {
             private readonly int _itemCount;


### PR DESCRIPTION
Subscription have to maintain its own list of event keys to be able to
modify the collection.
