### PR TITLE
BetterThreadSafeThanSorry - fixing UrlBuilder threading issue

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportAbortHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportAbortHandler.cs
@@ -26,8 +26,6 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
         private bool _disposed;
         // Used to make checking _disposed and calling _abortResetEvent.Set() thread safe
         private readonly object _disposeLock = new object();
-
-        private readonly UrlBuilder _urlBuilder = new UrlBuilder();
         
         public TransportAbortHandler(IHttpClient httpClient, string transportName)
         {
@@ -64,7 +62,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 {
                     _startedAbort = true;
 
-                    var url = _urlBuilder.BuildAbort(connection, _transportName, connectionData);
+                    var url = UrlBuilder.BuildAbort(connection, _transportName, connectionData);
 
                     _httpClient.Post(url, connection.PrepareRequest, isLongRunning: false).Catch((ex, state) =>
                     {

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/HttpBasedTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/HttpBasedTransport.cs
@@ -13,8 +13,6 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 {
     public abstract class HttpBasedTransport : ClientTransportBase
     {
-        internal readonly UrlBuilder _urlBuilder = new UrlBuilder();
-
         protected HttpBasedTransport(IHttpClient httpClient, string transportName)
             : base(httpClient, transportName)
         { }
@@ -45,7 +43,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 throw new ArgumentNullException("connection");
             }
 
-            string url = _urlBuilder.BuildSend(connection, Name, connectionData);
+            string url = UrlBuilder.BuildSend(connection, Name, connectionData);
 
             var postData = new Dictionary<string, string> {
                 { "data", data }

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/LongPollingTransport.cs
@@ -114,17 +114,17 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
                 if (connection.MessageId == null)
                 {
-                    url = _urlBuilder.BuildConnect(connection, Name, data);
+                    url = UrlBuilder.BuildConnect(connection, Name, data);
                     connection.Trace(TraceLevels.Events, "LP Connect: {0}", url);
                 }
                 else if (IsReconnecting(connection))
                 {
-                    url = _urlBuilder.BuildReconnect(connection, Name, data);
+                    url = UrlBuilder.BuildReconnect(connection, Name, data);
                     connection.Trace(TraceLevels.Events, "LP Reconnect: {0}", url);
                 }
                 else
                 {
-                    url = _urlBuilder.BuildPoll(connection, Name, data);
+                    url = UrlBuilder.BuildPoll(connection, Name, data);
                     connection.Trace(TraceLevels.Events, "LP Poll: {0}", url);
                 }
 

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -113,8 +113,8 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             };
 
             var url = reconnecting
-                ? _urlBuilder.BuildReconnect(connection, Name, data)
-                : _urlBuilder.BuildConnect(connection, Name, data);
+                ? UrlBuilder.BuildReconnect(connection, Name, data)
+                : UrlBuilder.BuildConnect(connection, Name, data);
 
             connection.Trace(TraceLevels.Events, "SSE: GET {0}", url);
 

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 throw new ArgumentNullException("connection");
             }
 
-            var negotiateUrl = new UrlBuilder().BuildNegotiate(connection, connectionData);
+            var negotiateUrl = UrlBuilder.BuildNegotiate(connection, connectionData);
 
             httpClient.Initialize(connection);
 
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 throw new ArgumentNullException("connection");
             }
 
-            var startUrl = new UrlBuilder().BuildStart(connection, transport, connectionData);
+            var startUrl = UrlBuilder.BuildStart(connection, transport, connectionData);
 
             httpClient.Initialize(connection);
 

--- a/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
@@ -97,11 +97,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
         private async Task PerformConnect(bool reconnecting)
         {
-            var urlBuilder = new UrlBuilder();
-
             var url = reconnecting
-                ? urlBuilder.BuildReconnect(_connectionInfo.Connection, Name, _connectionInfo.Data)
-                : urlBuilder.BuildConnect(_connectionInfo.Connection, Name, _connectionInfo.Data);
+                ? UrlBuilder.BuildReconnect(_connectionInfo.Connection, Name, _connectionInfo.Data)
+                : UrlBuilder.BuildConnect(_connectionInfo.Connection, Name, _connectionInfo.Data);
 
             var builder = new UriBuilder(url);
             builder.Scheme = builder.Scheme == "https" ? "wss" : "ws";

--- a/tests/Microsoft.AspNet.SignalR.Client.Portable.Tests/Client/Infrastructure/UrlBuilderFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Portable.Tests/Client/Infrastructure/UrlBuilderFacts.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
         public void BuildNegotiateAppendsNoCacheToUrl(string connectionData, string expected)
         {
             Assert.True(
-                Regex.Match(new UrlBuilder().BuildNegotiate(CreateConnection(), connectionData), 
+                Regex.Match(UrlBuilder.BuildNegotiate(CreateConnection(), connectionData), 
                 "^http://fakeurl/negotiate\\?clientProtocol=1.42" + expected + "&connectionToken=My%20Conn%20Token&noCache=[a-zA-Z0-9-]{36}$")
                     .Success);        
         }
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             Mock.Get(connection).Setup(c => c.MessageId).Returns(messageId);
 
             Assert.True(
-                Regex.Match(new UrlBuilder().BuildConnect(connection, "webPolling", null),
+                Regex.Match(UrlBuilder.BuildConnect(connection, "webPolling", null),
                     "^http://fakeurl/connect\\?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected + "&noCache=[a-zA-Z0-9-]{36}$")
                     .Success);
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             Mock.Get(connection).Setup(c => c.MessageId).Returns(messageId);
 
             Assert.True(
-                Regex.Match(new UrlBuilder().BuildReconnect(connection, "webPolling", null),
+                Regex.Match(UrlBuilder.BuildReconnect(connection, "webPolling", null),
                     "^http://fakeurl/reconnect\\?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected + "&noCache=[a-zA-Z0-9-]{36}$")
                     .Success);
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             Mock.Get(connection).Setup(c => c.GroupsToken).Returns(groupsToken);
 
             Assert.True(
-                Regex.Match(new UrlBuilder().BuildPoll(connection, "webPolling", null),
+                Regex.Match(UrlBuilder.BuildPoll(connection, "webPolling", null),
                     "^http://fakeurl/poll\\?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected + "&noCache=[a-zA-Z0-9-]{36}$")
                     .Success);

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/UrlBuilderFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/UrlBuilderFacts.cs
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/negotiate?clientProtocol=1.42" + expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildNegotiate(CreateConnection(), connectionData));
+                    UrlBuilder.BuildNegotiate(CreateConnection(), connectionData));
             }
 
             [Theory]
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             public void BuildNegotiateReturnsValidUrlWithCustomQueryString(string qs, string expected)
             {
                 Assert.Equal("http://fakeurl/negotiate?clientProtocol=1.42&connectionToken=My%20Conn%20Token" + expected,
-                    new UrlBuilder().BuildNegotiate(CreateConnection(qs), null));
+                    UrlBuilder.BuildNegotiate(CreateConnection(qs), null));
             }
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/start?clientProtocol=1.42&transport=webPolling" + expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildStart(CreateConnection(), "webPolling", connectionData));
+                    UrlBuilder.BuildStart(CreateConnection(), "webPolling", connectionData));
             }
 
             [Theory]
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/start?clientProtocol=1.42&transport=webPolling&connectionData=CustomConnectionData&connectionToken=My%20Conn%20Token" + expected,
-                    new UrlBuilder().BuildStart(CreateConnection(qs), "webPolling", "CustomConnectionData"));
+                    UrlBuilder.BuildStart(CreateConnection(qs), "webPolling", "CustomConnectionData"));
             }
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/abort?clientProtocol=1.42&transport=webPolling" + expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildAbort(CreateConnection(), "webPolling", connectionData));
+                    UrlBuilder.BuildAbort(CreateConnection(), "webPolling", connectionData));
             }
 
             [Theory]
@@ -94,7 +94,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/abort?clientProtocol=1.42&transport=webPolling&connectionData=CustomConnectionData&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildAbort(CreateConnection(qs), "webPolling", "CustomConnectionData"));
+                    UrlBuilder.BuildAbort(CreateConnection(qs), "webPolling", "CustomConnectionData"));
             }
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/connect?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildConnect(connection, "webPolling", null));
+                    UrlBuilder.BuildConnect(connection, "webPolling", null));
             }
 
             [Theory]
@@ -129,7 +129,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/connect?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildConnect(connection, "webPolling", null));
+                    UrlBuilder.BuildConnect(connection, "webPolling", null));
             }
 
             [Theory]
@@ -140,7 +140,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/connect?clientProtocol=1.42&transport=webPolling" + expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildConnect(CreateConnection(), "webPolling", connectionData));
+                    UrlBuilder.BuildConnect(CreateConnection(), "webPolling", connectionData));
             }
 
             [Theory]
@@ -157,7 +157,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/connect?clientProtocol=1.42&transport=webPolling&connectionData=CustomConnectionData&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildConnect(CreateConnection(qs), "webPolling", "CustomConnectionData"));
+                    UrlBuilder.BuildConnect(CreateConnection(qs), "webPolling", "CustomConnectionData"));
             }
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/reconnect?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildReconnect(connection, "webPolling", null));
+                    UrlBuilder.BuildReconnect(connection, "webPolling", null));
             }
 
             [Theory]
@@ -192,7 +192,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/reconnect?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildReconnect(connection, "webPolling", null));
+                    UrlBuilder.BuildReconnect(connection, "webPolling", null));
             }
 
             [Theory]
@@ -203,7 +203,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/reconnect?clientProtocol=1.42&transport=webPolling"+ expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildReconnect(CreateConnection(), "webPolling", connectionData));
+                    UrlBuilder.BuildReconnect(CreateConnection(), "webPolling", connectionData));
             }
 
             [Theory]
@@ -220,7 +220,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/reconnect?clientProtocol=1.42&transport=webPolling&connectionData=CustomConnectionData&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildReconnect(CreateConnection(qs), "webPolling", "CustomConnectionData"));
+                    UrlBuilder.BuildReconnect(CreateConnection(qs), "webPolling", "CustomConnectionData"));
             }
         }
 
@@ -239,7 +239,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/poll?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildPoll(connection, "webPolling", null));
+                    UrlBuilder.BuildPoll(connection, "webPolling", null));
             }
 
             [Theory]
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/poll?clientProtocol=1.42&transport=webPolling&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildPoll(connection, "webPolling", null));
+                    UrlBuilder.BuildPoll(connection, "webPolling", null));
             }
 
             [Theory]
@@ -266,7 +266,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/poll?clientProtocol=1.42&transport=webPolling" + expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildPoll(CreateConnection(), "webPolling", connectionData));
+                    UrlBuilder.BuildPoll(CreateConnection(), "webPolling", connectionData));
             }
 
             [Theory]
@@ -283,7 +283,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/poll?clientProtocol=1.42&transport=webPolling&connectionData=CustomConnectionData&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildPoll(CreateConnection(qs), "webPolling", "CustomConnectionData"));
+                    UrlBuilder.BuildPoll(CreateConnection(qs), "webPolling", "CustomConnectionData"));
             }
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             {
                 Assert.Equal(
                     "http://fakeurl/send?clientProtocol=1.42&transport=webPolling" + expected + "&connectionToken=My%20Conn%20Token",
-                    new UrlBuilder().BuildSend(CreateConnection(), "webPolling", connectionData));
+                    UrlBuilder.BuildSend(CreateConnection(), "webPolling", connectionData));
             }
 
             [Theory]
@@ -314,7 +314,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 Assert.Equal(
                     "http://fakeurl/send?clientProtocol=1.42&transport=webPolling&connectionData=CustomConnectionData&connectionToken=My%20Conn%20Token" +
                     expected,
-                    new UrlBuilder().BuildSend(CreateConnection(qs), "webPolling", "CustomConnectionData"));
+                    UrlBuilder.BuildSend(CreateConnection(qs), "webPolling", "CustomConnectionData"));
             }
         }
 


### PR DESCRIPTION
The same instance of UrlBuilder could be used by multiple threads which could corrupt the internal state of the StringBuilder instance used by the UrlBuilder which results in weird exceptions. This manifested as random CI build failures. The fix is to create a new instance each time instead of having a re-usable class variable.
