### PR TITLE
HuckingFunctionalTests - adding functional tests for WebSockets

### DIFF
--- a/Microsoft.AspNet.SignalR.sln
+++ b/Microsoft.AspNet.SignalR.sln
@@ -106,6 +106,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.SignalR.Cl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.SignalR.Client.Portable.Tests", "tests\Microsoft.AspNet.SignalR.Client.Portable.Tests\Microsoft.AspNet.SignalR.Client.Portable.Tests.csproj", "{27015CCF-9FCA-4490-A8D5-9D2B82B1369E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.SignalR.Client.Store.TestHost", "tests\Microsoft.AspNet.SignalR.Client.Store.TestHost\Microsoft.AspNet.SignalR.Client.Store.TestHost.csproj", "{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -662,6 +664,20 @@ Global
 		{27015CCF-9FCA-4490-A8D5-9D2B82B1369E}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{27015CCF-9FCA-4490-A8D5-9D2B82B1369E}.Release|x64.ActiveCfg = Release|Any CPU
 		{27015CCF-9FCA-4490-A8D5-9D2B82B1369E}.Release|x86.ActiveCfg = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|x64.ActiveCfg = Release|Any CPU
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -686,5 +702,6 @@ Global
 		{44FFD296-2FC1-4159-80AC-4F6C8AE9887C} = {7E3D992A-8F37-4C5D-AD42-E052522816C5}
 		{D728E0A1-A7F8-4FA3-9B17-2C3B9031311C} = {505538C3-B34D-4B43-BDE6-C6E974AB03A6}
 		{27015CCF-9FCA-4490-A8D5-9D2B82B1369E} = {505538C3-B34D-4B43-BDE6-C6E974AB03A6}
+		{F0697521-4A41-4A2A-BA64-D9A97CAA62A1} = {505538C3-B34D-4B43-BDE6-C6E974AB03A6}
 	EndGlobalSection
 EndGlobal

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -161,6 +161,7 @@
     <UnitTestProjects Include="$(ProjectRoot)\tests\Microsoft.AspNet.SignalR.Tests\Microsoft.AspNet.SignalR.Tests.csproj"></UnitTestProjects>
     <UnitTestProjects Include="$(ProjectRoot)\tests\Microsoft.AspNet.SignalR.Client.Tests\Microsoft.AspNet.SignalR.Client.Tests.csproj"></UnitTestProjects>
     <UnitTestProjects Include="$(ProjectRoot)\tests\Microsoft.AspNet.SignalR.SqlServer.Tests\Microsoft.AspNet.SignalR.SqlServer.Tests.csproj"></UnitTestProjects>
+    <UnitTestProjects Include="$(ProjectRoot)\tests\Microsoft.AspNet.SignalR.Client.Store.TestHost\Microsoft.AspNet.SignalR.Client.Store.TestHost.csproj"></UnitTestProjects>
     <UnitTestProjects Include="$(ProjectRoot)\tests\Microsoft.AspNet.SignalR.Client.Store.Tests\Microsoft.AspNet.SignalR.Client.Store.Tests.csproj"></UnitTestProjects>
     <UnitTestProjects Include="$(ProjectRoot)\tests\Microsoft.AspNet.SignalR.Client.Portable.Tests\Microsoft.AspNet.SignalR.Client.Portable.Tests.csproj"></UnitTestProjects>
   </ItemGroup>
@@ -247,6 +248,7 @@
   </Target>
 
   <Target Name="RunUnitTests" DependsOnTargets="BuildNetUnitTests">
+
     <MSBuild Projects="%(JsTestProjects.Identity)"
          Targets="pipelinePreDeployCopyAllFilesToOneFolder"
          Properties="Configuration=$(Configuration);ArtifactsDir=$(ProjectArtifactsDir);SolutionDir=$(ProjectRoot)\;$(ExtraProperties);_PackageTempDir=$(JSTestsPath);AutoParameterizationWebConfigConnectionStrings=false;MSBuildCommunityTasksPath=$(MSBuildCommunityTasksPath)"
@@ -266,6 +268,7 @@
 
     <Exec Command="&quot;$(ChutzpahExePath)&quot; &quot;$(JSTester)&quot; /showFailureReport /silent /timeoutMilliseconds 30000" Condition=" '$(OS)' == 'Windows_NT'" />
 
+
     <xunit Assemblies="$(ProjectArtifactsDir)\Microsoft.AspNet.SignalR.Tests\Microsoft.AspNet.SignalR.Tests.dll"
            Xml="$(TestResultsPath)\Microsoft.AspNet.SignalR.Tests.XunitResults.xml"
            Verbose="true" />
@@ -278,9 +281,14 @@
            Xml="$(TestResultsPath)\Microsoft.AspNet.SignalR.SqlServer.Tests.XunitResults.xml"
            Verbose="true" />
 
+    <!-- Microsoft.AspNet.SignalR.Client.Store.TestHost.exe is a host required to run some functional Store tests -->   
+    <ExecAsync Executable="$(ProjectArtifactsDir)\Microsoft.AspNet.SignalR.Client.Store.TestHost\Microsoft.AspNet.SignalR.Client.Store.TestHost.exe" Arguments="600000" />
+    
     <xunit Assemblies="$(ProjectArtifactsDir)\Microsoft.AspNet.SignalR.Client.Store.Tests\Microsoft.AspNet.SignalR.Client.Store.Tests.dll"
            Xml="$(TestResultsPath)\Microsoft.AspNet.SignalR.Client.Store.Tests.XunitResults.xml"
            Verbose="true" />
+           
+    <Exec Command="taskkill /IM Microsoft.AspNet.SignalR.Client.Store.TestHost.exe /F" ContinueOnError="true" />
 
     <xunit Assemblies="$(ProjectArtifactsDir)\Microsoft.AspNet.SignalR.Client.Portable.Tests\Microsoft.AspNet.SignalR.Client.Portable.Tests.dll"
            Xml="$(TestResultsPath)\Microsoft.AspNet.SignalR.Client.Portable.Tests.XunitResults.xml"
@@ -308,7 +316,7 @@
     <Exec Command="taskkill /IM iisexpress.exe /F" ContinueOnError="true" />
     <CallTarget Targets="ClearAspNetTempFolder" />
   </Target>
-
+  
   <Target Name="ClearAspNetTempFolder">
     <RemoveDir Directories="C:\Windows\Microsoft.NET\Framework\v4.0.30319\Temporary ASP.NET Files\root" ContinueOnError="true" />
     <RemoveDir Directories="C:\Windows\Microsoft.NET\Framework64\v4.0.30319\Temporary ASP.NET Files\root" ContinueOnError="true" />
@@ -484,4 +492,26 @@
 
     <Exec Command='mono $(XamarinDir)\xamarin-component\xamarin-component.exe package "$(XamarinDir)\SignalRPackage\component"' ContinueOnError="true" />
   </Target>
+  
+  <UsingTask TaskName="ExecAsync" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <Executable ParameterType="System.String" Required="true" />
+      <Arguments ParameterType="System.String" Required="false" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Diagnostics" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[
+        Log.LogMessage("Executable {0}...", Executable);
+        var name = System.IO.Path.GetFileNameWithoutExtension(Executable);
+        Log.LogMessage("Starting {0}...", name);
+        var processStartInfo = new ProcessStartInfo(Executable, Arguments) { UseShellExecute = true  };
+        Process.Start(processStartInfo);
+        Log.LogMessage("Finished running process {0}.", name);
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+    
 </Project>

--- a/src/Microsoft.AspNet.SignalR.Client.Store/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client.Store/Transports/WebSocketTransport.cs
@@ -186,6 +186,12 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 try
                 {
                     await StartWebSocket(connection, reconnectUrl);
+
+                    if (connection.ChangeState(ConnectionState.Reconnecting, ConnectionState.Connected))
+                    {
+                        connection.OnReconnected();
+                    }
+
                     break;
                 }
                 catch (OperationCanceledException)

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/App.config
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/App.config
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/Microsoft.AspNet.SignalR.Client.Store.TestHost.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/Microsoft.AspNet.SignalR.Client.Store.TestHost.csproj
@@ -1,0 +1,88 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F0697521-4A41-4A2A-BA64-D9A97CAA62A1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.AspNet.SignalR.Client.Store.TestHost</RootNamespace>
+    <AssemblyName>Microsoft.AspNet.SignalR.Client.Store.TestHost</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin">
+      <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.2.1.0\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting">
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.2.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Owin">
+      <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="StoreWebSocketTestHub.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.AspNet.SignalR.Core\Microsoft.AspNet.SignalR.Core.csproj">
+      <Project>{1b9a82c4-bca1-4834-a33e-226f17be070b}</Project>
+      <Name>Microsoft.AspNet.SignalR.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="..\..\src\Common\Microsoft.AspNet.SignalR.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/Program.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/Program.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading;
+using Microsoft.Owin.Hosting;
+using Owin;
+
+namespace Microsoft.AspNet.SignalR.Client.Store.TestHost
+{
+    // Used for running End-to-End tests for Store WebSockets transport.
+    public class Program
+    {
+        static void Main(string[] args)
+        {
+            const string url = "http://localhost:42424";
+            using (WebApp.Start(url))
+            {
+                Console.WriteLine("SignalR host for E2E Store Client tests running on {0}", url);
+                Thread.Sleep(args.Length > 0 ? int.Parse(args[0]) : Timeout.Infinite);
+            }
+        }
+    }
+
+    public class Startup
+    {
+        public void Configuration(IAppBuilder app)
+        {
+            app.MapSignalR();
+        }
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/Properties/AssemblyInfo.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Microsoft.AspNet.SignalR.Client.Store.TestHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Microsoft.AspNet.SignalR.Client.Store.TestHost")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1d5667e0-3554-467d-b626-80b6f2de0495")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/StoreWebSocketTestHub.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/StoreWebSocketTestHub.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System;
+
+namespace Microsoft.AspNet.SignalR.Client.Store.TestHost
+{
+    public class StoreWebSocketTestHub : Hub
+    {
+        public void Echo(string message)
+        {
+            Clients.All.echo(message);
+        }
+
+        public IEnumerable<int> ForceReconnect()
+        {
+            yield return 1;
+            // throwing here will close the websocket which should trigger reconnect
+            throw new Exception();
+        }
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/packages.config
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.TestHost/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="2.1.0" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
+</packages>

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Fakes/FakeConnection.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Fakes/FakeConnection.cs
@@ -144,7 +144,7 @@ namespace Microsoft.AspNet.SignalR.Client.Store.Tests.Fakes
 
         public void OnReconnected()
         {
-            throw new NotImplementedException();
+            _invocationManager.AddInvocation("OnReconnected");
         }
 
         public void OnConnectionSlow()

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/FunctionalTests/EndToEndTests.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/FunctionalTests/EndToEndTests.cs
@@ -1,0 +1,108 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.ServiceModel.Channels;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Client.Transports;
+using Xunit;
+
+namespace Microsoft.AspNet.SignalR.Client.Store.Tests
+{
+    // To run these tests you need to start Microsoft.AspNet.SignalR.Client.Store.TestHost first
+    public class EndToEndTests
+    {
+        private const string HubUrl = "http://localhost:42424";
+
+        [Fact]
+        public async Task WebSocketSendReceiveTest()
+        {
+            const int MessageCount = 3;
+            var sentMessages = new List<string>();
+            var receivedMessages = new List<string>();
+
+            using (var hubConnection = new HubConnection(HubUrl))
+            {
+                var wh = new ManualResetEventSlim();
+
+                var proxy = hubConnection.CreateHubProxy("StoreWebSocketTestHub");
+                proxy.On<string>("echo", m =>
+                {
+                    receivedMessages.Add(m);
+                    if (receivedMessages.Count == MessageCount)
+                    {
+                        wh.Set();
+                    }
+                });
+
+                await hubConnection.Start(new WebSocketTransport());
+
+                for (var i = 0; i < MessageCount; i++)
+                {
+                    var message = "MyMessage" + i;
+                    await proxy.Invoke("Echo", message);
+                    sentMessages.Add(message);
+                }
+
+                await Task.Run(() => wh.Wait(5000));
+            }
+
+            Assert.Equal(sentMessages, receivedMessages);
+        }
+
+        [Fact]
+        public async Task WebSocketReconnects()
+        {
+            var receivedMessage = (string)null;
+            var reconnectingInvoked = false;
+            var stateChanges = new List<KeyValuePair<ConnectionState, ConnectionState>>();
+
+            using (var hubConnection = new HubConnection(HubUrl))
+            {
+                var messageReceivedWh = new ManualResetEventSlim();
+                var proxy = hubConnection.CreateHubProxy("StoreWebSocketTestHub");
+                proxy.On<string>("echo", m =>
+                {
+                    receivedMessage = m;
+                    messageReceivedWh.Set();
+                });
+
+                hubConnection.StateChanged += stateChanged => stateChanges.Add(
+                    new KeyValuePair<ConnectionState, ConnectionState>(stateChanged.OldState, stateChanged.NewState));
+
+                hubConnection.Reconnecting += () => reconnectingInvoked = true;
+                var wh = new ManualResetEventSlim();
+                hubConnection.Reconnected += wh.Set;
+
+                await hubConnection.Start(new WebSocketTransport { ReconnectDelay = new TimeSpan(0, 0, 0, 500)});
+
+                try
+                {
+                    await proxy.Invoke("ForceReconnect");
+                }
+                catch (InvalidOperationException)
+                {
+                }
+
+                Assert.True(await Task.Run(() => wh.Wait(5000)));
+                Assert.True(reconnectingInvoked);
+                Assert.Equal(ConnectionState.Connected, hubConnection.State);
+
+                await proxy.Invoke("Echo", "MyMessage");
+                await Task.Run(() => wh.Wait(5000));
+                Assert.Equal("MyMessage", receivedMessage);
+            }
+
+            Assert.Equal(
+                new[]
+                {
+                    new KeyValuePair<ConnectionState, ConnectionState>(ConnectionState.Disconnected, ConnectionState.Connecting),
+                    new KeyValuePair<ConnectionState, ConnectionState>(ConnectionState.Connecting, ConnectionState.Connected),
+                    new KeyValuePair<ConnectionState, ConnectionState>(ConnectionState.Connected, ConnectionState.Reconnecting),
+                    new KeyValuePair<ConnectionState, ConnectionState>(ConnectionState.Reconnecting, ConnectionState.Connected),
+                    new KeyValuePair<ConnectionState, ConnectionState>(ConnectionState.Connected, ConnectionState.Disconnected),
+                },
+                stateChanges);
+        }
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Microsoft.AspNet.SignalR.Client.Store.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Microsoft.AspNet.SignalR.Client.Store.Tests.csproj
@@ -117,6 +117,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClientResources.cs" />
+    <Compile Include="FunctionalTests\EndToEndTests.cs" />
     <Compile Include="Fakes\FakeConnection.cs" />
     <Compile Include="Fakes\FakeDataReader.cs" />
     <Compile Include="Fakes\FakeInvocationManager.cs" />

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Transports/WebSocketTransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Transports/WebSocketTransportFacts.cs
@@ -232,6 +232,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             Assert.Equal(1, openWebSocketInvocations.Length);
             Assert.StartsWith("ws://fakeserver/reconnect?", ((Uri)openWebSocketInvocations[0][1]).AbsoluteUri);
             Assert.Contains("&connectionData=abc&", ((Uri)openWebSocketInvocations[0][1]).AbsoluteUri);
+            Assert.Equal(1, fakeConnection.GetInvocations("OnReconnected").Count());
         }
 
         [Fact]
@@ -329,6 +330,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             var onErrorInvocations = fakeConnection.GetInvocations("OnError").ToArray();
             Assert.Equal(1, onErrorInvocations.Length);
             Assert.Same(exception, onErrorInvocations[0][0]);
+            Assert.Equal(1, fakeConnection.GetInvocations("OnReconnected").Count());
         }
 
         [Fact]


### PR DESCRIPTION
Note: it is impossible to self host SignalR within Store unit tests and it is not possible to start a new process from Store unit test projects.

Fixing a bug when Reconnected event would never be invoked for Store WebSocket transport
