### PR TITLE
AccidentalRefactoring - removing an unneeded public method

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -90,14 +90,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             });
         }
 
-        public void OpenConnection(IConnection connection, Action<Exception> errorCallback)
-        {
-            OpenConnection(connection, null, CancellationToken.None, () => { }, errorCallback);
-        }
-
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "We will refactor later.")]
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "We will refactor later.")]
-        private void OpenConnection(IConnection connection,
+        internal void OpenConnection(IConnection connection,
                                     string data,
                                     CancellationToken disconnectToken,
                                     Action initializeCallback,

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/TransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/TransportFacts.cs
@@ -71,10 +71,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             connection.SetupGet(c => c.ConnectionToken).Returns("foo");
 
             var sse = new ServerSentEventsTransport(httpClient.Object);
-            sse.OpenConnection(connection.Object, (ex) =>
-            {
-                wh.TrySetResult(ex);
-            });
+            sse.OpenConnection(connection.Object, null, CancellationToken.None, () => { }, ex => wh.TrySetResult(ex));
 
             Assert.True(wh.Task.Wait(TimeSpan.FromSeconds(5)));
             Assert.IsType(typeof(OperationCanceledException), wh.Task.Result);


### PR DESCRIPTION
One of the methods was made public for testing purposes but since we now have InternalsVisibleTo it can be removed.
