### PR TITLE
Disable blanket.js for IE8

### DIFF
--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/default.html
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/default.html
@@ -58,7 +58,9 @@
         <script src="Build/test.config.js"></script>
         <script src="Scripts/test.utilities.js"></script>
         <script src="Build/disableCrossDomain.js"></script>
+        <!--[if gt IE 8]><!-->
         <!-- ##COVERAGE## --><script src="Scripts/blanket-1.1.5.min.js"></script><!-- ##COVERAGE## -->
+        <!--<![endif]-->
 
         <!-- Javascript is dynamically added to this panel.  First all javascript from SignalR.Client.JS is added,
              then all javascript from the Tests directory is added.  This is so that all the unit tests within the 


### PR DESCRIPTION
JS tests failed on IE8 with error JScript object expected in http://test01.signalr.net/58b71c707d0336ce37c92afa3b0b0b5c0e917750/Scripts/blanket-1.1.5.min.js on line 1   character 67353, so we disable blanket.js for IE8.
