### PR TITLE
Allow HubConnections to be used in Crank

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Crank/DefaultConnectionFactory.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/DefaultConnectionFactory.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Client;
+
+namespace Microsoft.AspNet.SignalR.Crank
+{
+	class DefaultConnectionFactory : IConnectionFactory
+	{
+		public Connection CreateConnection(string url)
+		{
+			return new Connection(url);
+		}
+	}
+}

--- a/src/Microsoft.AspNet.SignalR.Crank/IConnectionFactory.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/IConnectionFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Client;
+
+namespace Microsoft.AspNet.SignalR.Crank
+{
+	public interface IConnectionFactory
+	{
+		Connection CreateConnection(string url);
+	}
+}

--- a/src/Microsoft.AspNet.SignalR.Crank/Microsoft.AspNet.SignalR.Crank.csproj
+++ b/src/Microsoft.AspNet.SignalR.Crank/Microsoft.AspNet.SignalR.Crank.csproj
@@ -67,6 +67,8 @@
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.Composition.Registration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -82,6 +84,8 @@
     <Compile Include="ControllerHub.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="CrankArguments.cs" />
+    <Compile Include="DefaultConnectionFactory.cs" />
+    <Compile Include="IConnectionFactory.cs" />
     <Compile Include="PerformanceCounters.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Created IConnectionFactory as injection point for developers to
  customize how a Connection is created
- Created DefaultConnectionFactory to retain behavior of creating a
  regular Connection
- Modified Crank client to compose the IConnectionFactory dependency
  using MEF. If no candidate is supplied by an external assembly, the
  client will automatically use the DefaultConnectionFactory
#3000
