### PR TITLE
Restore the latest value to Redis Key on ConnectionRestored event

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/IRedisConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/IRedisConnection.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNet.SignalR.Redis
 
         Task ScriptEvaluateAsync(int database, string script, string key, byte[] messageArguments);
 
+        Task RestoreLatestValueForKey(int database, string key);
+
         void Dispose();
 
         event Action<Exception> ConnectionFailed;

--- a/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
@@ -136,8 +136,10 @@ namespace Microsoft.AspNet.SignalR.Redis
             _trace.TraceError("OnConnectionError - " + ex.Message);
         }
 
-        private void OnConnectionRestored(Exception ex)
+        private async void OnConnectionRestored(Exception ex)
         {
+            await _connection.RestoreLatestValueForKey(_db, _key);
+
             _trace.TraceInformation("Connection restored");
 
             Interlocked.Exchange(ref _state, State.Connected);

--- a/tests/Microsoft.AspNet.SignalR.Redis.Tests/RedisMessageBusFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Redis.Tests/RedisMessageBusFacts.cs
@@ -88,6 +88,27 @@ namespace Microsoft.AspNet.SignalR.Redis.Tests
             Assert.Equal(RedisMessageBus.State.Closed, redisMessageBus.ConnectionState);
         }
 
+        [Fact]
+        public void RestoreLatestValueForKeyCalledOnConnectionRestored()
+        {
+            bool restoreLatestValueForKey = false;
+
+            var redisConnection = GetMockRedisConnection();
+
+            redisConnection.Setup(m => m.RestoreLatestValueForKey(It.IsAny<int>(), It.IsAny<string>())).Returns(() =>
+            {
+                restoreLatestValueForKey = true;
+                return TaskAsyncHelper.Empty;
+            });
+
+            var redisMessageBus = new RedisMessageBus(GetDependencyResolver(), new RedisScaleoutConfiguration(String.Empty, String.Empty),
+            redisConnection.Object, true);
+
+            redisConnection.Raise(mock => mock.ConnectionRestored += null, new Exception());
+
+            Assert.True(restoreLatestValueForKey, "RestoreLatestValueForKey not invoked");
+        }
+
         private Mock<IRedisConnection> GetMockRedisConnection()
         {
             var redisConnection = new Mock<IRedisConnection>();


### PR DESCRIPTION
For Redis restart scenario, since Redis is in-memory key-value data store, it only saves the data to disk periodically, after Redis restart, it actually will get old data from disk instead of the latest data most of the times.

In this case, so far SignalR Redis scale-out just get the old data for message.Id after Redis restart, then for the existing connections ( which started before Redis server restarted) the new cursor doesn’t match and the connections miss the messages until the message.Id match to the “latest” data which is before Redis restart, e.g.
 Let’s say, SignalR Redis scale-out uses Key “SignalRSamples” for eventKey, before the Redis restart, the Key “SignalRSamples” latest value was "7799425", after the Redis restart, the Key “SignalRSamples” value become "7799200", then the existing connection will miss 225 messages until the Key “SignalRSamples” value increases to "7799425”.

To avoid missing messages in the existing connections in this case, here are changes :
 1). Save the latest value for the eventKey in RedisConnection
 2). When Redis restart, in ConnectionRestored event set /restore the latest value to the eventKey in Redis

Verified:
 1). With the change, the existing connections don't miss messages after Redis restart
 2). Works for 2 web apps using the Redis scale-out
 3). Existing tests and new tests passed
#3091
