### PR TITLE
 Add a workaround to make sure Redis connection is reconnected in ConnectionRestored event

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/RedisConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisConnection.cs
@@ -81,6 +81,12 @@ namespace Microsoft.AspNet.SignalR.Redis
         {
             try
             {
+                // Workaround for StackExchange.Redis/issues/61 that sometimes Redis connection is not connected in ConnectionRestored event 
+                while (!_connection.GetDatabase(database).IsConnected(key))
+                {
+                    await Task.Delay(200);
+                }
+
                 var redisResult = await _connection.GetDatabase(database).ScriptEvaluateAsync(
                    @"local newvalue = redis.call('GET', KEYS[1])
                     if newvalue < ARGV[1] then


### PR DESCRIPTION
I found an external issue that after Redis restart, sometimes in ConnectionRestored event the Redis connection is not reconnected yet.

This workaround basically make sure the latest value can be restored for Redis Key.
This workaround basically make sure the Rdis connection is reconnected before Open the stream, so it can reduce the chance of the issue #3093 happening which when Send() method runs into an error, the stream will never be opened again until Redis is restarted.
#3095
