### PR TITLE
MomentaryLapsOfReason - fixing stupid code (I wrote)

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
@@ -100,10 +100,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         {
             var uri = UrlBuilder.ConvertToWebSocketUri(url);
 
-            var builder = new UriBuilder(url);
-            builder.Scheme = builder.Scheme == "https" ? "wss" : "ws";
-
-            _connection.Trace(TraceLevels.Events, "WS Connecting to: {0}", builder.Uri);
+            _connection.Trace(TraceLevels.Events, "WS Connecting to: {0}", uri);
  
             // TODO: Revisit thread safety of this assignment
             _webSocketTokenSource = new CancellationTokenSource();


### PR DESCRIPTION
HTTP => WS scheme conversion is supposed to be done everywhere by UrlBuilder however the net45 WebSocketTransport was using both - UrlBuilder _and_ manual conversion _in the same method_. Fixing the code to use the Uri converted by the UrlBuilder instead of doing the same conversion the second time.
