### PR TITLE
Send ACKs to the connection waiting on the ACK not the acker itself

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/Connection.cs
@@ -321,7 +321,10 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
                     // just trip it
                     if (!connection._ackHandler.TriggerAck(message.CommandId))
                     {
-                        connection._bus.Ack(connection._connectionId, message.CommandId).Catch(connection._traceSource);
+                        connection._bus.Ack(
+                            acker: connection._connectionId,
+                            waiter: message.Source,
+                            commandId: message.CommandId).Catch(connection._traceSource);
                     }
                 }
             }

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/MessageBusExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/MessageBusExtensions.cs
@@ -31,10 +31,10 @@ namespace Microsoft.AspNet.SignalR.Messaging
             return bus.Publish(new Message(source, key, value));
         }
 
-        internal static Task Ack(this IMessageBus bus, string connectionId, string commandId)
+        internal static Task Ack(this IMessageBus bus, string acker, string waiter, string commandId)
         {
             // Prepare the ack
-            var message = new Message(connectionId, PrefixHelper.GetAck(connectionId), null);
+            var message = new Message(acker, PrefixHelper.GetAck(waiter), null);
             message.CommandId = commandId;
             message.IsAck = true;
             return bus.Publish(message);

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNet.SignalR.Client.Http;
 using Microsoft.AspNet.SignalR.Client.Transports;
 using Microsoft.AspNet.SignalR.Configuration;
 using Microsoft.AspNet.SignalR.Hosting.Memory;
+using Microsoft.AspNet.SignalR.Messaging;
+using Microsoft.AspNet.SignalR.Tests.Common;
 using Microsoft.AspNet.SignalR.Tests.Common.Infrastructure;
 using Microsoft.Owin;
 using Owin;
@@ -116,6 +118,76 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                         await connection.Start(host);
 
                         Assert.Equal(connection.State, ConnectionState.Connected);
+                    }
+                }
+            }
+
+            [Fact]
+            public async Task ConnectionCanAddAnotherConnectionOnAnotherHostToAGroup()
+            {
+                using (var host1 = new MemoryHost())
+                using (var host2 = new MemoryHost())
+                {
+                    var sharedBus = new DefaultDependencyResolver().Resolve<IMessageBus>();
+                    host1.Configure(app =>
+                    {
+                        var resolver = new DefaultDependencyResolver();
+                        var ackHandler = new SignalR.Infrastructure.AckHandler(
+                            completeAcksOnTimeout: true,
+                            ackThreshold: TimeSpan.FromSeconds(10),
+                            ackInterval: TimeSpan.FromSeconds(1));
+
+                        resolver.Register(typeof(SignalR.Infrastructure.IAckHandler), () => ackHandler);
+                        resolver.Register(typeof(IMessageBus), () => sharedBus);
+
+                        app.MapSignalR<MyGroupConnection>("/groups", new ConnectionConfiguration
+                        {
+                            Resolver = resolver
+                        });
+                    });
+                    host2.Configure(app =>
+                    {
+                        var resolver = new DefaultDependencyResolver();
+
+                        resolver.Register(typeof(IMessageBus), () => sharedBus);
+
+                        app.MapSignalR<MyGroupConnection>("/groups", new ConnectionConfiguration
+                        {
+                            Resolver = resolver
+                        });
+                    });
+
+                    using (var connection1 = new Connection("http://foo/groups"))
+                    using (var connection2 = new Connection("http://foo/groups"))
+                    {
+                        var messageTcs = new TaskCompletionSource<string>();
+
+                        connection2.Received += message =>
+                        {
+                            messageTcs.SetResult(message);
+                        };
+
+                        await connection1.Start(host1);
+                        await connection2.Start(host2);
+
+                        await connection1.Send(new
+                        {
+                            // Add to group
+                            type = 1,
+                            group = "testGroup",
+                            connectionId = connection2.ConnectionId
+                        });
+
+                        await connection1.Send(new
+                        {
+                            // Send to group
+                            type = 3,
+                            group = "testGroup",
+                            message = "testMessage"
+                        });
+
+                        Assert.True(messageTcs.Task.Wait(TimeSpan.FromSeconds(10)));
+                        Assert.Equal("testMessage", messageTcs.Task.Result);
                     }
                 }
             }

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Connections/MyGroupConnection.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Connections/MyGroupConnection.cs
@@ -14,14 +14,15 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
             JObject operation = JObject.Parse(data);
             int type = operation.Value<int>("type");
             string group = operation.Value<string>("group");
+            string groupConnectionId = operation.Value<string>("connectionId") ?? connectionId;
 
             if (type == 1)
             {
-                return Groups.Add(connectionId, group);
+                return Groups.Add(groupConnectionId, group);
             }
             else if (type == 2)
             {
-                return Groups.Remove(connectionId, group);
+                return Groups.Remove(groupConnectionId, group);
             }
             else if (type == 3)
             {

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/ConnectionFacts.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Infrastructure;
-using Xunit;
 using Microsoft.AspNet.SignalR.Json;
 using Microsoft.AspNet.SignalR.Messaging;
 using Microsoft.AspNet.SignalR.Tracing;
-using Newtonsoft.Json;
+using Moq;
+using Xunit;
 
 namespace Microsoft.AspNet.SignalR.Tests.Server
 {
@@ -49,6 +50,101 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             var command = serializer.Parse<Command>(message.Value, message.Encoding);
             Assert.Equal(CommandType.AddToGroup, command.CommandType);
             Assert.Equal("foo", command.Value);
+        }
+
+        [Fact]
+        public void AcksAreSentToCommandSource()
+        {
+            // Arrange
+            var waitCommand = new Command { WaitForAck = true };
+            var ackerId = "acker";
+            var waiterId = "waiter";
+            var messageId = "messageId";
+            var maxMessages = 1;
+
+            var ackHandler = new Mock<IAckHandler>();
+            ackHandler.Setup(m => m.TriggerAck(waitCommand.Id)).Returns(false);
+
+            var messageBus = new Mock<IMessageBus>();
+            Message waitMessage = null;
+            Message ackMessage = null;
+            messageBus.Setup(m => m.Publish(It.IsAny<Message>())).Returns<Message>(m =>
+            {
+                if (m.WaitForAck)
+                {
+                    waitMessage = m;
+                }
+                else if (m.IsAck)
+                {
+                    ackMessage = m;
+                }
+
+                return TaskAsyncHelper.Empty;
+            });
+
+            var counters = new PerformanceCounterManager();
+
+            var serializer = JsonUtility.CreateDefaultSerializer();
+            var traceManager = new Mock<ITraceManager>();
+            var waiterConnection = new Connection(messageBus.Object,
+                                                  serializer,
+                                                  "signal",
+                                                  waiterId,
+                                                  new string[] { },
+                                                  new string[] { },
+                                                  traceManager.Object,
+                                                  ackHandler.Object,
+                                                  counters,
+                                                  new Mock<IProtectedData>().Object);
+
+            // Act
+            waiterConnection.Send(ackerId, waitCommand);
+
+            // Assert
+            Assert.NotNull(waitMessage);
+            Assert.Equal(waiterId, waitMessage.Source);
+            Assert.Equal(PrefixHelper.GetConnectionId(ackerId), waitMessage.Key);
+
+            // Arrange some more now that we have a waitMessage
+            var messages = new List<ArraySegment<Message>>()
+            {
+                new ArraySegment<Message>(new[] { waitMessage })
+            };
+            var messageResult = new MessageResult(messages, 1);
+
+            var ackerConnection = new Connection(messageBus.Object,
+                                                 serializer,
+                                                 "signal",
+                                                 ackerId,
+                                                 new string[] { },
+                                                 new string[] { },
+                                                 traceManager.Object,
+                                                 ackHandler.Object,
+                                                 counters,
+                                                 new Mock<IProtectedData>().Object);
+            ackerConnection.WriteCursor = _ => { };
+
+            messageBus.Setup(m => m.Subscribe(ackerConnection,
+                                              messageId,
+                                              It.IsAny<Func<MessageResult, object, Task<bool>>>(),
+                                              maxMessages,
+                                              It.IsAny<object>()))
+                .Callback<ISubscriber,
+                          string,
+                          Func<MessageResult, object, Task<bool>>,
+                          int,
+                          object>((subsciber, cursor, callback, max, state) =>
+                {
+                    callback(messageResult, state);
+                });
+
+            // Act
+            ackerConnection.Receive(messageId, (_, __) => TaskAsyncHelper.False, maxMessages, null);
+
+            // Assert
+            Assert.NotNull(ackMessage);
+            Assert.Equal(ackerId, ackMessage.Source);
+            Assert.Equal(PrefixHelper.GetAck(waiterId), ackMessage.Key);
         }
     }
 }


### PR DESCRIPTION
- These ACKs are used to verify that commands published to the
  bus have been received and processed (e.g. group commands).
- Previously, ACKs only succeeded if the waiter and acker were on
  the same machine and/or the acker happened to be the waiter.
#3037
