### PR TITLE
Prevent MessageBus from hanging forever in the second call to Dispose

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/MessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/MessageBus.cs
@@ -302,13 +302,13 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _gcRunning != GCState.Disposed)
             {
                 // Stop the broker from doing any work
                 _broker.Dispose();
 
                 // Spin while we wait for the timer to finish if it's currently running
-                while (Interlocked.Exchange(ref _gcRunning, 1) == 1)
+                while (Interlocked.CompareExchange(ref _gcRunning, GCState.Disposed, GCState.Idle) == GCState.Running)
                 {
                     Thread.Sleep(250);
                 }
@@ -330,7 +330,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
         internal void GarbageCollectTopics()
         {
-            if (Interlocked.Exchange(ref _gcRunning, 1) == 1)
+            if (Interlocked.CompareExchange(ref _gcRunning, GCState.Running, GCState.Idle) != GCState.Idle)
             {
                 return;
             }
@@ -386,7 +386,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 }
             }
 
-            Interlocked.Exchange(ref _gcRunning, 0);
+            Interlocked.CompareExchange(ref _gcRunning, GCState.Idle, GCState.Running);
         }
 
         private void DestroyTopic(string key, Topic topic)
@@ -567,6 +567,13 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 Initialized = new ManualResetEventSlim();
                 Subscriber = subscriber;
             }
+        }
+
+        private static class GCState
+        {
+            public const int Idle = 0;
+            public const int Running = 1;
+            public const int Disposed = 2;
         }
     }
 }

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/MessageBusFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/MessageBusFacts.cs
@@ -589,6 +589,15 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             }
         }
 
+        [Fact]
+        public void MessageBusCanBeDisposedTwiceWithoutHanging()
+        {
+            var bus = new MessageBus(new DefaultDependencyResolver());
+
+            bus.Dispose();
+            Assert.True(Task.Run(() => bus.Dispose()).Wait(TimeSpan.FromSeconds(10)));
+        }
+
         private class TestMessageBus : MessageBus
         {
             public TestMessageBus(IDependencyResolver resolver)


### PR DESCRIPTION
It really should be [safe to dispose twice](http://msdn.microsoft.com/en-us/library/system.idisposable.dispose.aspx). Autofac was even forced to [work around this issue](https://code.google.com/p/autofac/wiki/SignalRIntegrationReleaseNotes).
#1088
