### PR TITLE
Transport!YouAreFinished! - generalizing AbortSent flag

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.Store/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client.Store/Transports/WebSocketTransport.cs
@@ -160,8 +160,8 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             DisposeSocket();
 
-            // abort has been sent - do not reconnect
-            if (AbortSent)
+            // either abort has been sent or transport has been disposed - do not reconnect
+            if (Finished)
             {
                 return;
             }

--- a/src/Microsoft.AspNet.SignalR.Client.WinRT/Resources.resw
+++ b/src/Microsoft.AspNet.SignalR.Client.WinRT/Resources.resw
@@ -177,4 +177,7 @@
   <data name="Error_InvalidUriScheme" xml:space="preserve">
     <value>Uri scheme '{0}' is not valid. The only valid uri schemes are 'http' and 'https'.</value>
   </data>
+  <data name="Error_TransportCannotBeReused">
+    <value>The transport instance passed to the Negotiate method has already been used. Use a new transport instance each time you start a new connection.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNet.SignalR.Client {
     using System;
     using System.Reflection;
     
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -197,6 +198,15 @@ namespace Microsoft.AspNet.SignalR.Client {
         internal static string Error_TaskCancelledException {
             get {
                 return ResourceManager.GetString("Error_TaskCancelledException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The transport instance passed to the Negotiate method has already been used. Use a new transport instance each time you start a new connection..
+        /// </summary>
+        internal static string Error_TransportCannotBeReused {
+            get {
+                return ResourceManager.GetString("Error_TransportCannotBeReused", resourceCulture);
             }
         }
         

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -177,4 +177,7 @@
   <data name="Error_InvalidUriScheme" xml:space="preserve">
     <value>Uri scheme '{0}' is not valid. The only valid uri schemes are 'http' and 'https'.</value>
   </data>
+  <data name="Error_TransportCannotBeReused">
+    <value>The transport instance passed to the Negotiate method has already been used. Use a new transport instance each time you start a new connection.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/LongPollingTransport.cs
@@ -184,7 +184,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             _requestHandler.OnAfterPoll = exception =>
             {
-                if (AbortSent)
+                if (Finished)
                 {
                     // Abort() was called, so don't reconnect
                     _requestHandler.Stop();

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -210,7 +210,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                         esCancellationRegistration.Dispose();
                         response.Dispose();
 
-                        if (!_stop && !AbortSent)
+                        if (!_stop && !Finished)
                         {
                             Reconnect(connection, data, disconnectToken);
                         }

--- a/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
@@ -157,7 +157,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         {
             _connection.Trace(TraceLevels.Events, "WS: OnClose()");
 
-            if (_disconnectToken.IsCancellationRequested || AbortSent)
+            if (_disconnectToken.IsCancellationRequested || Finished)
             {
                 return;
             }


### PR DESCRIPTION
The transport is not in a usable state if either the abort request is sent or the transport was disposed. When in this state the transport should no longer be used. Before it was guarded by the AbortSent flag but the abort request does not necessarily have to be sent so the AbortSent was replaced with a new Finished flag which is set to true if either the Abort method was called or the transport was disposed.
