### PR TITLE
TrickedOutCherryPicker - fixing a build break in release1.x

### DIFF
--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlMessageBus.cs
@@ -144,8 +144,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
                     // Try again in a little bit
                     Thread.Sleep(2000);
                     StartReceiving(streamIndex);
-                },
-                _trace);
+                });
         }
     }
 }


### PR DESCRIPTION
A fix was ported from the dev branch to the release1.x branch however the method used in dev branch does not exist in the release1.x so compilation fails. Removing the extraneous parameter fixes the problem.
