### PR TITLE
Fixed the Hub Auth portion of the Sample project

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.Samples/App_Start/Startup.cs
+++ b/samples/Microsoft.AspNet.SignalR.Samples/App_Start/Startup.cs
@@ -27,13 +27,6 @@ namespace Microsoft.AspNet.SignalR.Samples
 
             ConfigureSignalR(GlobalHost.DependencyResolver, GlobalHost.HubPipeline);
 
-            var config = new HubConfiguration()
-            {
-                EnableDetailedErrors = true
-            };
-
-            app.MapSignalR(config);
-
             app.Map("/cors", map =>
             {
                 map.UseCors(CorsOptions.AllowAll);
@@ -76,6 +69,13 @@ namespace Microsoft.AspNet.SignalR.Samples
                 map.MapSignalR<AuthenticatedEchoConnection>("/echo");
                 map.MapSignalR();
             });
+
+            var config = new HubConfiguration()
+            {
+                EnableDetailedErrors = true
+            };
+
+            app.MapSignalR(config);
 
             BackgroundThread.Start();
         }


### PR DESCRIPTION
- By calling MapSignalR later we can ensure SignalR runs after auth
  middleware and HttpApplication.AuthenticateRequest.
#3152
