### PR TITLE
OutOfBodyExperience - removing IFrame from body

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -95,8 +95,8 @@
             url = transportLogic.getUrl(connection, this.name);
             url += "&frameId=" + frameId;
 
-            // Set body prior to setting URL to avoid caching issues.
-            window.document.body.appendChild(frame);
+            // add frame to the document prior to setting URL to avoid caching issues.
+            window.document.documentElement.appendChild(frame);
 
             connection.log("Binding to iframe's load event.");
 

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Transports/ForeverFrameFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Transports/ForeverFrameFacts.js
@@ -45,3 +45,22 @@ QUnit.test("Messages are not run through connection JSON parser if it's not set.
 
     QUnit.equal(responseType, "object", "Forever Frame does not use JSON parser if it's not configured for the connection.");
 });
+
+QUnit.test("IFrame is created outside body.", function () {
+
+    if (window.EventSource) {
+        QUnit.ok(true, "test skipped - Forever Frame is not supported browsers with SSE support.");
+        return;
+    }
+
+    var connection = $.connection("");
+
+    $.connection.transports.foreverFrame.start(connection);
+
+    var frame = $("body")[0].nextSibling;
+    QUnit.equal(frame && frame.tagName, 'IFRAME');
+
+    if (frame) {
+        frame.parentNode.removeChild(frame);
+    };
+});


### PR DESCRIPTION
For foreverFrame transport SignalR appended the iframe as the last child of the body node. However some libraries (e.g. jQuery UI) move nodes inside the body which causes the iframe to reload which results in sending a "connect" request even though the transport has already been started. Because we cleaned up some things after sending the original "connect" request the second "connect" request may cause "Object expected" exceptions. The fix is to move the iframe outside the document body node so it is less likely to be touched/moved by the user's code.
