### PR TITLE
fire and forget style async calls can cause NullReferenceException

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNet.SignalR.Redis
 
             if (connectAutomatically)
             {
-                Task.Run(() => ConnectWithRetry());
+                Task.Run(() => ConnectWithRetry()).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
https://github.com/SignalR/SignalR/issues/3173

http://connect.microsoft.com/VisualStudio/feedback/details/745956/getting-null-reference-exception-in-asp-net-mvc-4-rc
