### PR TITLE
YouFailedToFail.Net - complete "connect" request if websocket closed

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client45/Transports/WebSocketTransport.cs
@@ -167,6 +167,11 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 return;
             }
 
+            if (_connection.State == ConnectionState.Connecting)
+            {
+                _initializeHandler.Fail();
+            }
+
             DoReconnect();
         }
 

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Transports/WebSocketTransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Transports/WebSocketTransportFacts.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNet.SignalR.Client.Transports
+{
+    public class WebSocketTransportFacts
+    {
+        [Fact]
+        public void TransportInitializationHandlerStoppedIfWebsocketClosedWhenConnecting()
+        {
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(c => c.State).Returns(ConnectionState.Connecting);
+            mockConnection.Setup(c => c.TotalTransportConnectTimeout).Returns(new TimeSpan(0, 0, 5));
+
+            var mockWebSocketTransport = new Mock<WebSocketTransport> { CallBase = true };
+            var webSocketTransport = mockWebSocketTransport.Object;
+
+            mockWebSocketTransport.Setup(t => t.PerformConnect())
+                .Callback(webSocketTransport.OnClose)
+                .Returns(Task.FromResult(0));
+
+            var ex = Assert.Throws<AggregateException>(
+                () => webSocketTransport.Start(mockConnection.Object, "test", new CancellationToken()).Wait());
+
+            Assert.Equal(Resources.Error_TransportFailedToConnect, ex.InnerException.Message);
+        }
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Microsoft.AspNet.SignalR.Client.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Microsoft.AspNet.SignalR.Client.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Client\Transports\ClientTransportBaseFacts.cs" />
     <Compile Include="Client\Transports\TransportFacts.cs" />
     <Compile Include="Client\Transports\WebSockets\ClientWebSocketHandlerFacts.cs" />
+    <Compile Include="Client\Transports\WebSocketTransportFacts.cs" />
     <Compile Include="EventSourceStreamReaderFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Client\TransportFacts.cs" />


### PR DESCRIPTION
If the server closed the websocket while the client was waiting for a response to the "connect" request the client would not notice this and would wait until the connect request timed out. The fix is to explicitly finish the initialization phase if it is in progress and the websocket is closed.

Fixes #2903
