### PR TITLE
YouFailedToFail.JS - complete "connect" request if websocket closed

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.webSockets.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.webSockets.js
@@ -95,6 +95,14 @@
                             connection.log("Unclean disconnect from websocket: " + event.reason || "[no reason given].");
                         } else {
                             connection.log("Websocket closed.");
+
+                            if (!reconnecting) {
+                                if (onFailed) {
+                                    onFailed();
+                                }
+
+                                return;
+                            }
                         }
 
                         that.reconnect(connection);


### PR DESCRIPTION
If the server closed the websocket while the client was waiting for a response to the "connect" request the client would not notice this and would wait until the connect request timed out. The fix is to explicitly finish the initialization phase if it is in progress and the websocket is closed.

Fixes #2902 

I don't think creating a test for this is feasible. Tested manually using a repro from the bug #2902 where we set an incorrect connection string for Sql scale out, set total connect timeout to 60 secs on the server and disable a backgroud thread - not a scenario we would like to have in our tests. 
