### PR TITLE
SleepWell - adding a workaround for a race condition in WebSockets

### DIFF
--- a/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/FunctionalTests/EndToEndTests.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/FunctionalTests/EndToEndTests.cs
@@ -88,6 +88,10 @@ namespace Microsoft.AspNet.SignalR.Client.Store.Tests
                 Assert.True(reconnectingInvoked);
                 Assert.Equal(ConnectionState.Connected, hubConnection.State);
 
+                // TODO: this is a workaround to a race condition in WebSocket. 
+                // Should be removed once the race in WebSockets is fixed
+                await Task.Delay(200);
+
                 await proxy.Invoke("Echo", "MyMessage");
 
                 await Task.Run(() => messageReceivedWh.Wait(5000));
@@ -147,6 +151,10 @@ namespace Microsoft.AspNet.SignalR.Client.Store.Tests
                 );
 
                 Assert.True(await Task.Run(() => reconnectedWh.Wait(5000)));
+
+                // TODO: this is a workaround to a race condition in WebSocket. 
+                // Should be removed once the race in WebSockets is fixed
+                await Task.Delay(200);
 
                 await proxy.Invoke("Echo", "MyMessage");
 


### PR DESCRIPTION
There seems to be a race condition in WebSockets which may result in a deadlock/livelock which in turn causes a failure to the EndToEndTests. Adding a delay seems to fix the issue so we can use it as a workaround until the issue in the WebSocket implementation is fixed.

Note: I don't have any scientific explanation why this "fixes" the issue.
