### PR TITLE
FalseStart - client becomes unsuable if transport fails during start request

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ClientTransportBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ClientTransportBase.cs
@@ -103,7 +103,8 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         
         protected abstract void OnStartFailed();
 
-        protected void TransportFailed(Exception ex)
+        // internal for testing
+        protected internal void TransportFailed(Exception ex)
         {
             // will be no-op if handler already finished (either succeeded or failed)
             if (ex == null)

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TransportInitializationHandlerFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TransportInitializationHandlerFacts.cs
@@ -1,0 +1,201 @@
+﻿
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Client.Http;
+using Microsoft.AspNet.SignalR.Client.Transports;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.AspNet.SignalR.Client.Infrastructure
+{
+    public class TransportInitializationHandlerFacts
+    {
+        [Fact]
+        public void StartRequestNotCalledIfTransportAlreadyFailed()
+        {
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(c => c.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(1));
+
+            var mockTransportHelper = new Mock<TransportHelper>();
+            var failureInvokedMre = new ManualResetEvent(false);
+
+            var initHandler = new TransportInitializationHandler(Mock.Of<IHttpClient>(), mockConnection.Object,
+                string.Empty, "fakeTransport", CancellationToken.None, mockTransportHelper.Object);
+
+            initHandler.OnFailure += () => failureInvokedMre.Set();
+
+            initHandler.Fail();
+
+            Assert.True(failureInvokedMre.WaitOne(1000));
+
+            initHandler.InitReceived();
+
+            mockTransportHelper.Verify(
+                h => h.GetStartResponse(It.IsAny<IHttpClient>(), It.IsAny<IConnection>(), 
+                    It.IsAny<string>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public void InitTaskIsFailedIfFailureOccursAfterStartRequestStarted()
+        {
+            var mockTransportHelper = new Mock<TransportHelper>();
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(p => p.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(0.5));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            var initHandler = new TransportInitializationHandler(Mock.Of<IHttpClient>(), mockConnection.Object,
+                string.Empty, "fakeTransport", CancellationToken.None, mockTransportHelper.Object);
+
+            var onFailureInvoked = false;
+            initHandler.OnFailure += () => onFailureInvoked = true;
+
+            var exception = new Exception("test exception");
+
+            mockTransportHelper.Setup(
+                h => h.GetStartResponse(It.IsAny<IHttpClient>(), It.IsAny<IConnection>(),
+                    It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<IHttpClient, IConnection, string, string>(
+                    (httpClient, connection, connectionData, transport) =>
+                    {
+                        initHandler.Fail(exception);
+                        return Task.FromResult("{ \"Response\" : \"started\" }");
+                    });
+
+            initHandler.InitReceived();
+
+            var startException = 
+                Assert.Throws<AggregateException>(
+                    () => Assert.True(initHandler.Task.Wait(TimeSpan.FromSeconds(1)))).InnerException;
+
+            Assert.IsType<StartException>(startException);
+            Assert.Same(exception, startException.InnerException);
+
+            Assert.True(onFailureInvoked);
+        }
+
+        [Fact]
+        public async Task TimeoutDoesNotFailTheTaskAfterInitReceived()
+        {
+            var mockTransportHelper = new Mock<TransportHelper>();
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(p => p.TotalTransportConnectTimeout).Returns(TimeSpan.FromMilliseconds(200));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            mockTransportHelper.Setup(
+                h => h.GetStartResponse(It.IsAny<IHttpClient>(), It.IsAny<IConnection>(),
+                    It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<IHttpClient, IConnection, string, string>(
+                    (httpClient, connection, connectionData, transport) =>
+                        // wait for the timeout to fire
+                        Task.Delay(250).ContinueWith(t => "{ \"Response\" : \"started\" }"));
+
+            var initHandler = new TransportInitializationHandler(Mock.Of<IHttpClient>(), mockConnection.Object,
+                string.Empty, "fakeTransport", CancellationToken.None, mockTransportHelper.Object);
+            var onFailureInvoked = false;  
+            initHandler.OnFailure += () => onFailureInvoked = true;
+
+            initHandler.InitReceived();
+
+            await initHandler.Task;
+            Assert.False(onFailureInvoked);
+        }
+
+        [Fact]
+        public void InitTaskThrowsStartFailedExceptionIfStartRequestThrows()
+        {
+            var mockTransportHelper = new Mock<TransportHelper>();
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(p => p.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(5));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            var initHandler = new TransportInitializationHandler(Mock.Of<IHttpClient>(), mockConnection.Object,
+                string.Empty, "fakeTransport", CancellationToken.None, mockTransportHelper.Object);
+
+            var onFailureInvoked = false;
+            initHandler.OnFailure += () => onFailureInvoked = true;
+
+            var exception = new Exception("test exception");
+
+            mockTransportHelper.Setup(
+                h => h.GetStartResponse(It.IsAny<IHttpClient>(), It.IsAny<IConnection>(),
+                    It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<IHttpClient, IConnection, string, string>(
+                    (httpClient, connection, connectionData, transport) =>
+                    {
+                        var tcs = new TaskCompletionSource<string>();
+                        tcs.SetException(exception);
+                        return tcs.Task;
+                    });
+
+            initHandler.InitReceived();
+
+            var startException =
+                Assert.Throws<AggregateException>(
+                    () => Assert.True(initHandler.Task.Wait(TimeSpan.FromSeconds(1)))).InnerException;
+
+            Assert.IsType<StartException>(startException);
+            // startException.InnerException is an AggregateException
+            Assert.Same(exception, startException.InnerException.InnerException);
+            Assert.True(onFailureInvoked);
+        }
+
+        [Fact]
+        public void InitTaskThrowsStartFailedExceptionIfStartRequestReturnsIncorrectResult()
+        {
+            var mockTransportHelper = new Mock<TransportHelper>();
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(p => p.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(5));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            var initHandler = new TransportInitializationHandler(Mock.Of<IHttpClient>(), mockConnection.Object,
+                string.Empty, "fakeTransport", CancellationToken.None, mockTransportHelper.Object);
+
+            var onFailureInvoked = false;
+            initHandler.OnFailure += () => onFailureInvoked = true;
+
+            mockTransportHelper.Setup(
+                h => h.GetStartResponse(It.IsAny<IHttpClient>(), It.IsAny<IConnection>(),
+                    It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<IHttpClient, IConnection, string, string>(
+                    (httpClient, connection, connectionData, transport) 
+                        => Task.FromResult("{ \"foo\" : \"bar\" }"));
+
+            initHandler.InitReceived();
+
+            Assert.IsType<StartException>(
+                Assert.Throws<AggregateException>(
+                    () => Assert.True(initHandler.Task.Wait(TimeSpan.FromSeconds(1)))).InnerException);
+
+            Assert.True(onFailureInvoked);
+        }
+
+        [Fact]
+        public async Task FailIsNoOpAfterStartCompletedSuccessfully()
+        {
+            var mockTransportHelper = new Mock<TransportHelper>();
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(p => p.TotalTransportConnectTimeout).Returns(TimeSpan.FromMilliseconds(200));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            var initHandler = new TransportInitializationHandler(Mock.Of<IHttpClient>(), mockConnection.Object,
+                string.Empty, "fakeTransport", CancellationToken.None, mockTransportHelper.Object);
+
+            var onFailureInvoked = false;
+            initHandler.OnFailure += () => onFailureInvoked = true;
+
+            mockTransportHelper.Setup(
+                h => h.GetStartResponse(It.IsAny<IHttpClient>(), It.IsAny<IConnection>(),
+                    It.IsAny<string>(), It.IsAny<string>()))
+                .Returns<IHttpClient, IConnection, string, string>(
+                    (httpClient, connection, connectionData, transport) => Task.FromResult("{ \"Response\" : \"started\" }"));
+
+            initHandler.InitReceived();
+            initHandler.Fail();
+
+            await initHandler.Task;
+            Assert.False(onFailureInvoked);
+        }
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Transports/AutoTransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/Transports/AutoTransportFacts.cs
@@ -1,0 +1,115 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.AspNet.SignalR.Client.Http;
+using Microsoft.AspNet.SignalR.Client.Infrastructure;
+using Moq;
+using System.Threading.Tasks;
+using Moq.Protected;
+using Xunit;
+using Newtonsoft.Json;
+
+namespace Microsoft.AspNet.SignalR.Client.Transports
+{
+    public class AutoTransportFacts
+    {
+        [Fact]
+        public void AutoTransportDoesNotTryAnotherTransportIfTransportFailsDuringStartRequest()
+        {
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(c => c.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(5));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            var mockHttpClient = new Mock<IHttpClient>();
+
+            var mockFailingTransport = new Mock<ClientTransportBase>(mockHttpClient.Object, "fakeTransport") {CallBase = true};
+            mockFailingTransport.Protected()
+                .Setup("OnStart", ItExpr.IsAny<IConnection>(), ItExpr.IsAny<string>(), ItExpr.IsAny<CancellationToken>())
+                .Callback<IConnection, string, CancellationToken>((c, d, t) =>
+                {
+                    mockFailingTransport.Object.ProcessResponse(c,
+                        "{\"C\":\"d-C6243495-A,0|B,0|C,1|D,0\",\"S\":1,\"M\":[]}");
+                });
+
+            var exception = new Exception("test exception");
+            mockHttpClient
+                .Setup(c => c.Get(It.IsAny<string>(), It.IsAny<Action<IRequest>>(), It.IsAny<bool>()))
+                .Returns<string, Action<IRequest>, bool>((url, prepareRequest, isLongRunning) =>
+                {
+                    mockFailingTransport.Object.TransportFailed(exception);
+
+                    return Task.FromResult(Mock.Of<IResponse>());
+                });
+
+            var mockTransport = new Mock<IClientTransport>();
+            mockTransport.Setup(t => t.Start(It.IsAny<IConnection>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<object>(null));
+
+            var autoTransport = new AutoTransport(mockHttpClient.Object,
+                new List<IClientTransport> {mockFailingTransport.Object, mockTransport.Object});
+
+            var startException =
+                Assert.Throws<AggregateException>(() =>
+                    autoTransport.Start(mockConnection.Object, string.Empty, CancellationToken.None)
+                        .Wait(TimeSpan.FromSeconds(1))).InnerException;
+
+            Assert.IsType<StartException>(startException);
+            Assert.Same(exception, startException.InnerException);
+
+            mockTransport.Verify(
+                t => t.Start(It.IsAny<IConnection>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never());
+        }
+
+        [Fact]
+        public void AutoTransportDoesNotTryAnotherTransportIfStartRequestFails()
+        {
+            var mockConnection = new Mock<IConnection>();
+            mockConnection.Setup(c => c.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(5));
+            mockConnection.Setup(c => c.JsonSerializer).Returns(JsonSerializer.CreateDefault());
+
+            var mockHttpClient = new Mock<IHttpClient>();
+
+            var mockFailingTransport = new Mock<ClientTransportBase>(mockHttpClient.Object, "fakeTransport") { CallBase = true };
+            mockFailingTransport.Protected()
+                .Setup("OnStart", ItExpr.IsAny<IConnection>(), ItExpr.IsAny<string>(), ItExpr.IsAny<CancellationToken>())
+                .Callback<IConnection, string, CancellationToken>((c, d, t) =>
+                {
+                    mockFailingTransport.Object.ProcessResponse(c,
+                        "{\"C\":\"d-C6243495-A,0|B,0|C,1|D,0\",\"S\":1,\"M\":[]}");
+                });
+
+            var exception = new Exception("test exception");
+            mockHttpClient
+                .Setup(c => c.Get(It.IsAny<string>(), It.IsAny<Action<IRequest>>(), It.IsAny<bool>()))
+                .Returns<string, Action<IRequest>, bool>((url, prepareRequest, isLongRunning) =>
+                {
+                    var tcs = new TaskCompletionSource<IResponse>();
+                    tcs.SetException(exception);
+                    return tcs.Task;
+                });
+
+            var mockTransport = new Mock<IClientTransport>();
+            mockTransport.Setup(t => t.Start(It.IsAny<IConnection>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<object>(null));
+
+            var autoTransport = new AutoTransport(mockHttpClient.Object,
+                new List<IClientTransport> { mockFailingTransport.Object, mockTransport.Object });
+
+            var startException =
+                Assert.Throws<AggregateException>(() =>
+                    autoTransport.Start(mockConnection.Object, string.Empty, CancellationToken.None)
+                        .Wait(TimeSpan.FromSeconds(1))).InnerException;
+
+            Assert.IsType<StartException>(startException);
+            // startException.InnerException is an AggregateException
+            Assert.Same(exception, startException.InnerException.InnerException);
+
+            mockTransport.Verify(
+                t => t.Start(It.IsAny<IConnection>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                Times.Never());
+        }
+
+    }
+}

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Microsoft.AspNet.SignalR.Client.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Microsoft.AspNet.SignalR.Client.Tests.csproj
@@ -63,8 +63,10 @@
     <Compile Include="Client\HeartbeatMonitorFacts.cs" />
     <Compile Include="Client\Http\DefaultHttpClientFacts.cs" />
     <Compile Include="Client\HubProxyFacts.cs" />
+    <Compile Include="Client\Infrastructure\TransportInitializationHandlerFacts.cs" />
     <Compile Include="Client\Infrastructure\UrlBuilderFacts.cs" />
     <Compile Include="Client\KeepAliveFacts.cs" />
+    <Compile Include="Client\Transports\AutoTransportFacts.cs" />
     <Compile Include="Client\Transports\ClientTransportBaseFacts.cs" />
     <Compile Include="Client\Transports\TransportFacts.cs" />
     <Compile Include="Client\Transports\WebSockets\ClientWebSocketHandlerFacts.cs" />

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Client/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Client/ConnectionFacts.cs
@@ -439,9 +439,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                                 connectionTimeout: 2,
                                 disconnectTimeout: 6);
 
-                var connection = CreateConnection(host, "/force-lp-reconnect/examine-reconnect");
-
-                using (connection)
+                using (var connection = CreateConnection(host, "/force-lp-reconnect/examine-reconnect"))
                 {
                     connection.Received += reconnectEndsPath =>
                     {

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
@@ -641,9 +641,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                                     disconnectTimeout: 8, // 8s because the default heartbeat time span is 5s
                                     messageBusType: messageBusType);
 
-                    var connection = CreateHubConnection(host, "/force-lp-reconnect");
-
-                    using (connection)
+                    using (var connection = CreateHubConnection(host, "/force-lp-reconnect"))
                     {
                         var reconnectingWh = new AsyncManualResetEvent();
                         var reconnectedWh = new AsyncManualResetEvent();


### PR DESCRIPTION
If a transport failed during the start request or if the start request failed we would not fail the transport or throw an exception leaving the transport in kind of a zombie state. The reason for this was that we used `SafeThreadInvoker` to start the start request which invalidated any further `Fail` calls. When AutoTransport was being used we would always try the next transport even though the correct behavior was to throw from the `Start` method if the connect request completed successfully and a failure occured during start request. The fix is to not to use SafeThreadInvoker to start the start request. In addition we have to track the state of the initialization phase to prevent failing the transport due to timeout once the connect request completed successfully and to throw the StartException after connect request completed successfully to let the AutoTransport know to not try the next available transport but to re-throw the exception.
