### PR TITLE
TheFirstPlaceLoser - removing unnecessary calls to `TransportFailed`

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportInitializationHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportInitializationHandler.cs
@@ -55,7 +55,9 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             OnFailure = () => { };
 
             // We want to fail if the disconnect token is tripped while we're waiting on initialization
-            _tokenCleanup = disconnectToken.SafeRegister(_ => Fail(), state: null);
+            _tokenCleanup = disconnectToken.SafeRegister(
+                _ => Fail(new OperationCanceledException(Resources.Error_ConnectionCancelled, disconnectToken)),
+                state: null);
 
             TaskAsyncHelper.Delay(connection.TotalTransportConnectTimeout)
                 .Then(() =>

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/LongPollingTransport.cs
@@ -17,7 +17,6 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         private int _running;
         private readonly object _stopLock = new object();
         private ThreadSafeInvoker _reconnectInvoker;
-        private CancellationToken _disconnectToken;
         private IDisposable _disconnectRegistration;
 
         /// <summary>
@@ -55,11 +54,8 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
         protected override void OnStart(IConnection connection, string connectionData, CancellationToken disconnectToken)
         {
-            _disconnectToken = disconnectToken;
             _disconnectRegistration = disconnectToken.SafeRegister(state =>
             {
-                TransportFailed(new OperationCanceledException(Resources.Error_ConnectionCancelled, _disconnectToken));
-
                 // _reconnectInvoker can be null if disconnectToken is tripped before the polling loop is started
                 if (_reconnectInvoker != null)
                 {

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -108,11 +108,6 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
                 // This will no-op if the request is already finished.
                 ((IRequest)state).Abort();
-
-                if (!reconnecting)
-                {
-                    TransportFailed(new OperationCanceledException(Resources.Error_ConnectionCancelled, disconnectToken));
-                }
             }, _request);
             
             getTask.ContinueWith(task =>

--- a/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Transports/WebSocketTransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Store.Tests/Transports/WebSocketTransportFacts.cs
@@ -116,8 +116,8 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             });
 
             Assert.Equal(
-                ResourceUtil.GetResource("Error_TransportFailedToConnect"),
-                (await Assert.ThrowsAsync<InvalidOperationException>(
+                ResourceUtil.GetResource("Error_ConnectionCancelled"),
+                (await Assert.ThrowsAsync<OperationCanceledException>(
                     async () => await fakeWebSocketTransport.Start(fakeConnection, null, cancellationTokenSource.Token))).Message);
 
             Assert.Equal(1, fakeWebSocketTransport.GetInvocations("OnStartFailed").Count());


### PR DESCRIPTION
`ServerSentEventsTransport` and `LongPollingTransport` registered callbacks to let the `TransportInitializationHandler` know that the transport failed (by calling the `TransportFailed` method) when the `disconnectToken` is tripped . This was unnecessary since the `TransportInitializationHandler` registered first its own callback for the same reason which would call `TransportInitializationHandler.Fail()`. Because we use the `SafeThreadInvoker` for invoking the `Fail()` method the calls from the transport implementations were no-ops because they would have happened after the call from the `TransportInitializationHandler` which in turn would make `SafeThreadInvoker` ignore any further calls.
