### PR TITLE
Updated app domain restart JS test to pass reliably with long polling

### DIFF
--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubGroupFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/FunctionalTests/Hubs/HubGroupFacts.js
@@ -112,6 +112,15 @@ testUtilities.runWithAllTransports(function (transport) {
             groupChat = connection.createHubProxies().groupChat,
             groupName = "group$&+,/:;=?@[]1";
 
+        groupChat.client.joinedGroup = function (g) {
+            assert.equal(g, groupName);
+
+            // Ensure that the app domain restart doesn't occur between poll requests.
+            window.setTimeout(function () {
+                groupChat.server.triggerAppDomainRestart();
+            }, 30);
+        };
+
         groupChat.client.send = function (value) {
             assert.ok(value === "hello", "Successful received message from group after reconnected");
             end();
@@ -124,7 +133,7 @@ testUtilities.runWithAllTransports(function (transport) {
         connection.reconnected(function () {
             assert.ok(true, "Successfuly raised reconnected event ");
 
-            // Workaround for bug#2642 on webSockets that requires to call server method after a short timeout in reconnected event   
+            // Workaround for bug#2642 on webSockets that requires to call server method after a short timeout in reconnected event
             window.setTimeout(function () {
                 groupChat.server.send(groupName, "hello").done(function () {
                     assert.ok(true, "Successful send to group");
@@ -135,9 +144,7 @@ testUtilities.runWithAllTransports(function (transport) {
         connection.start({ transport: transport }).done(function () {
             assert.ok(true, "Connected");
 
-            groupChat.server.join(groupName).done(function () {
-                groupChat.server.triggerAppDomainRestart();
-            });
+            groupChat.server.join(groupName);
         });
 
         // Cleanup
@@ -145,6 +152,5 @@ testUtilities.runWithAllTransports(function (transport) {
             connection.stop();
         };
     });
-
 });
 

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Hubs/ChatWithGroups.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Hubs/ChatWithGroups.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNet.SignalR.Hubs;
 
@@ -12,9 +13,10 @@ namespace Microsoft.AspNet.SignalR.Tests.Common.Hubs
             Clients.Group(group).send(message);
         }
 
-        public void Join(string group)
+        public async Task Join(string group)
         {
-            Groups.Add(Context.ConnectionId, group);
+            await Groups.Add(Context.ConnectionId, group);
+            await Clients.Caller.joinedGroup(group);
         }
 
         public void Leave(string group)


### PR DESCRIPTION
The issue was that the server restarted between polls so the reconnecting and
reconnected events were never fired on the client. We could possibly do more to
raise the reconnect events in this situation, but for now, I think this is by
design.

The test was fixed by ensuring that the app domain restart is not triggered
between polls.
