### PR TITLE
Handle transport failures occurring in the connecting state

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -73,7 +73,9 @@
                 frame = createFrame(),
                 frameLoadHandler = function () {
                     connection.log("Forever frame iframe finished loading and is no longer receiving messages.");
-                    that.reconnect(connection);
+                    if (!onFailed || !onFailed()) {
+                        that.reconnect(connection);
+                    }
                 };
 
             if (window.EventSource) {
@@ -235,7 +237,7 @@
             if (changeState(connection,
                 signalR.connectionState.reconnecting,
                 signalR.connectionState.connected) === true) {
-                // If there's no onSuccess handler we assume this is a reconnect
+
                 $(connection).triggerHandler(events.onReconnect);
             }
         }

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.serverSentEvents.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.serverSentEvents.js
@@ -116,6 +116,11 @@
             }, false);
 
             connection.eventSource.addEventListener("error", function (e) {
+                var error = signalR._.transportError(
+                    signalR.resources.eventSourceError,
+                    connection.transport,
+                    e);
+
                 // Only handle an error if the error is from the current Event Source.
                 // Sometimes on disconnect the server will push down an error event
                 // to an expired Event Source.
@@ -123,11 +128,7 @@
                     return;
                 }
 
-                if (!opened) {
-                    if (onFailed) {
-                        onFailed();
-                    }
-
+                if (onFailed && onFailed(error)) {
                     return;
                 }
 
@@ -143,7 +144,7 @@
                 } else {
                     // connection error
                     connection.log("EventSource error.");
-                    $connection.triggerHandler(events.onError, [signalR._.transportError(signalR.resources.eventSourceError, connection.transport, e)]);
+                    $connection.triggerHandler(events.onError, [error]);
                 }
             }, false);
         },

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.webSockets.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.webSockets.js
@@ -73,31 +73,33 @@
                 };
 
                 connection.socket.onclose = function (event) {
+                    var error;
+
                     // Only handle a socket close if the close is from the current socket.
                     // Sometimes on disconnect the server will push down an onclose event
                     // to an expired socket.
 
                     if (this === connection.socket) {
-                        if (!opened) {
-                            if (onFailed) {
-                                onFailed();
-                            } else if (reconnecting) {
-                                that.reconnect(connection);
-                            }
-                            return;
-                        } else if (typeof event.wasClean !== "undefined" && event.wasClean === false) {
+                        if (opened && typeof event.wasClean !== "undefined" && event.wasClean === false) {
                             // Ideally this would use the websocket.onerror handler (rather than checking wasClean in onclose) but
                             // I found in some circumstances Chrome won't call onerror. This implementation seems to work on all browsers.
-                            $(connection).triggerHandler(events.onError, [signalR._.transportError(
+                            error = signalR._.transportError(
                                 signalR.resources.webSocketClosed,
                                 connection.transport,
-                                event)]);
+                                event);
+
                             connection.log("Unclean disconnect from websocket: " + event.reason || "[no reason given].");
                         } else {
                             connection.log("Websocket closed.");
                         }
 
-                        that.reconnect(connection);
+                        if (!onFailed || !onFailed(error)) {
+                            if (error) {
+                                $(connection).triggerHandler(events.onError, [error]);
+                            }
+
+                            that.reconnect(connection);
+                        }
                     }
                 };
 

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Microsoft.AspNet.SignalR.Client.JS.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Microsoft.AspNet.SignalR.Client.JS.Tests.csproj
@@ -127,6 +127,7 @@
     <Content Include="Tests\FunctionalTests\Transports\ServerSentEvents\SSEReconnectFacts.js" />
     <Content Include="Tests\FunctionalTests\Transports\WebSocketsFacts\WebSocketsFacts.js" />
     <Content Include="Tests\UnitTests\Common\AjaxFacts.js" />
+    <Content Include="Tests\UnitTests\Common\InitHandlerFacts.js" />
     <Content Include="Tests\UnitTests\Common\KeepAliveFacts.js" />
     <Content Include="Tests\UnitTests\Common\ProcessMessagesFacts.js" />
     <Content Include="Tests\UnitTests\Common\ResponseFacts.js" />

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Common/InitHandlerFacts.js
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/Tests/UnitTests/Common/InitHandlerFacts.js
@@ -1,0 +1,315 @@
+﻿QUnit.module("Transports Common - InitHandler Facts");
+
+(function (undefined) {
+    function buildFakeConnection() {
+        return {
+            log: function () { },
+            stop: function () {
+                this.stopCalled = true;
+            },
+            _: {},
+            stopCalled: false
+        };
+    }
+
+    function buildFakeTransport() {
+        return {
+            name: "fake",
+            start: function (connection, onSuccess, onFailed) {
+                this.onSuccess = onSuccess;
+                this.onFailed = onFailed;
+            },
+            stop: function () {
+                this.stopCalled = true;
+            },
+            stopCalled: false
+        };
+    }
+
+    QUnit.test("Transport cannot trigger start request after it has already failed.", function () {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            savedAjaxStart = $.signalR.transports._logic.ajaxStart,
+            ajaxStartCalled = false,
+            initOnSuccessCalled = false,
+            initOnFallbackCalled = false,
+            onFailedResult;
+
+        $.signalR.transports._logic.ajaxStart = function () {
+            ajaxStartCalled = true;
+        };
+
+        // Act
+        initHandler.start(fakeTransport, function () {
+            initOnSuccessCalled = true;
+        }, function () {
+            initOnFallbackCalled = true;
+        });
+
+        onFailedResult = fakeTransport.onFailed();
+        fakeTransport.onSuccess();
+
+        // Assert
+        QUnit.isTrue(onFailedResult, "Transport should stop. onFailed called during initialization.");
+        QUnit.isTrue(initOnFallbackCalled, "Transport failure triggered fallback.");
+        QUnit.isFalse(initOnSuccessCalled, "Initialization did not complete.");
+        QUnit.isFalse(ajaxStartCalled, "Transport failure prevented start request.");
+        QUnit.isTrue(fakeTransport.stopCalled, "Transport failure caused the transport to be stopped.");
+        QUnit.isFalse(fakeConnection.stopCalled, "Transport failure did not cause the connection to be stopped.");
+
+        // Cleanup
+        $.signalR.transports._logic.ajaxStart = savedAjaxStart;
+    });
+
+    QUnit.test("Transport failure during start request forces the connection to stop.", function () {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            savedAjaxStart = $.signalR.transports._logic.ajaxStart,
+            ajaxStartCalled = false,
+            initOnSuccessCalled = false,
+            initOnFallbackCalled = false,
+            onFailedResult;
+
+        $.signalR.transports._logic.ajaxStart = function () {
+            ajaxStartCalled = true;
+        };
+
+        // Act
+        initHandler.start(fakeTransport, function () {
+            initOnSuccessCalled = true;
+        }, function () {
+            initOnFallbackCalled = true;
+        });
+
+        fakeTransport.onSuccess();
+        onFailedResult = fakeTransport.onFailed();
+
+        // Assert
+        QUnit.isTrue(onFailedResult, "Transport should stop. onFailed called during initialization.");
+        QUnit.isFalse(initOnFallbackCalled, "Transport failure did not trigger fallback.");
+        QUnit.isFalse(initOnSuccessCalled, "Initialization did not complete.");
+        QUnit.isTrue(ajaxStartCalled, "Transport success triggered start request.");
+        QUnit.isTrue(fakeConnection.stopCalled, "Transport failure caused the connection to be stopped.");
+
+        // Cleanup
+        $.signalR.transports._logic.ajaxStart = savedAjaxStart;
+    });
+
+    QUnit.test("Transport failure after successful start request has no effect.", function () {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            savedAjaxStart = $.signalR.transports._logic.ajaxStart,
+            initOnSuccessCalled = false,
+            initOnFallbackCalled = false,
+            onFailedResult;
+
+        $.signalR.transports._logic.ajaxStart = function (connection, onSuccess) {
+            onSuccess();
+        };
+
+        // Act
+        initHandler.start(fakeTransport, function () {
+            initOnSuccessCalled = true;
+        }, function () {
+            initOnFallbackCalled = true;
+        });
+
+        fakeTransport.onSuccess();
+        onFailedResult = fakeTransport.onFailed();
+
+        // Assert
+        QUnit.isFalse(onFailedResult, "Transport should reconnect. onFailed called after initialization.");
+        QUnit.isFalse(initOnFallbackCalled, "Transport failure did not trigger fallback.");
+        QUnit.isTrue(initOnSuccessCalled, "Initialization completed.");
+        QUnit.isFalse(fakeTransport.stopCalled, "Transport failure did not cause the transport to be stopped.");
+        QUnit.isFalse(fakeConnection.stopCalled, "Transport failure did not cause the connection to be stopped.");
+
+        // Cleanup
+        $.signalR.transports._logic.ajaxStart = savedAjaxStart;
+    });
+
+    QUnit.test("Transport failure or success after connection stop has no effect.", function () {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            savedAjaxStart = $.signalR.transports._logic.ajaxStart,
+            ajaxStartCalled = false,
+            initOnSuccessCalled = false,
+            initOnFallbackCalled = false,
+            onFailedResult;
+
+        $.signalR.transports._logic.ajaxStart = function () {
+            ajaxStartCalled = true;
+        };
+
+        // Act
+        initHandler.start(fakeTransport, function () {
+            initOnSuccessCalled = true;
+        }, function () {
+            initOnFallbackCalled = true;
+        });
+
+        initHandler.stop();
+        fakeTransport.onSuccess();
+        onFailedResult = fakeTransport.onFailed();
+
+        // Assert
+        QUnit.isTrue(onFailedResult, "Transport should stop. onFailed called after connection stopped.");
+        QUnit.isFalse(initOnFallbackCalled, "Transport failure did not trigger fallback.");
+        QUnit.isFalse(initOnSuccessCalled, "Initialization did not complete.");
+        QUnit.isFalse(ajaxStartCalled, "Transport success did not trigger start request.");
+        QUnit.isFalse(fakeConnection.stopCalled, "Transport failure did not cause the transport to be stopped.");
+        QUnit.isFalse(fakeConnection.stopCalled, "Transport failure did not cause the connection to be stopped.");
+
+        // Cleanup
+        $.signalR.transports._logic.ajaxStart = savedAjaxStart;
+    });
+
+    QUnit.test("A single transport cannot trigger multiple fallbacks.", function () {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            initOnFallbackCount = 0,
+            transportShouldStop;
+
+        // Act
+        initHandler.start(fakeTransport, undefined, function () {
+            initOnFallbackCount++;
+        });
+
+        // onFailed should return true (meaning the transport should stop) each time in this test
+        transportShouldStop = fakeTransport.onFailed();
+        transportShouldStop = fakeTransport.onFailed() && transportShouldStop;
+
+        // Assert
+        QUnit.isTrue(transportShouldStop, "Transport should stop. onFailed was called during initialization each time.");
+        QUnit.equal(initOnFallbackCount, 1, "Multiple transport failures triggered fallback exactly once.");
+        QUnit.isTrue(fakeTransport.stopCalled, "Transport failure caused the transport to be stopped");
+        QUnit.isFalse(fakeConnection.stopCalled, "Transport failure did not cause the connection to be stopped.");
+    });
+
+    QUnit.test("Multiple transports can trigger multiple fallbacks.", function () {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport1 = buildFakeTransport(),
+            fakeTransport2 = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            initOnFallbackCount = 0,
+            transportShouldStop;
+
+        // Act
+        initHandler.start(fakeTransport1, undefined, function () {
+            initOnFallbackCount++;
+        });
+
+        // onFailed should return true (meaning the transport should stop) each time in this test
+        transportShouldStop = fakeTransport1.onFailed();
+
+        initHandler.start(fakeTransport2, undefined, function () {
+            initOnFallbackCount++;
+        });
+
+        transportShouldStop = fakeTransport2.onFailed() && transportShouldStop;
+
+        // Both of the following calls should be ignored
+        transportShouldStop = fakeTransport1.onFailed() && transportShouldStop;
+        transportShouldStop = fakeTransport2.onFailed() && transportShouldStop;
+
+        // Assert
+        QUnit.isTrue(transportShouldStop, "Transports should stop. onFailed was called during initialization each time.");
+        QUnit.isTrue(fakeTransport1.stopCalled, "Transport failure caused the first transport to be stopped");
+        QUnit.isTrue(fakeTransport2.stopCalled, "Transport failure caused the second transport to be stopped");
+        QUnit.equal(initOnFallbackCount, 2, "Each transport triggered fallback once.");
+        QUnit.isFalse(fakeConnection.stopCalled, "Transport failure did not cause the connection to be stopped.");
+    });
+
+    QUnit.asyncTimeoutTest("Transport timeout can stop transport and trigger fallback.", testUtilities.defaultTestTimeout, function (end, assert) {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            savedAjaxStart = $.signalR.transports._logic.ajaxStart,
+            ajaxStartCalled = false,
+            initOnSuccessCalled = false,
+            initOnFallbackCalled = false;
+
+        $.signalR.transports._logic.ajaxStart = function () {
+            ajaxStartCalled = true;
+        };
+
+        fakeConnection._.totalTransportConnectTimeout = 100;
+
+        // Act
+        initHandler.start(fakeTransport, function () {
+            initOnSuccessCalled = true;
+        }, function () {
+            initOnFallbackCalled = true;
+        });
+
+        window.setTimeout(function () {
+            fakeTransport.onSuccess();
+
+            // Assert
+            QUnit.isTrue(initOnFallbackCalled, "Timeout triggered fallback.");
+            assert.isFalse(initOnSuccessCalled, "Initialization did not complete.");
+            assert.isFalse(ajaxStartCalled, "Timeout prevented start request.");
+            assert.isTrue(fakeTransport.stopCalled, "Timeout caused the transport to be stopped.");
+            assert.isFalse(fakeConnection.stopCalled, "Timeout did not cause the connection to be stopped.");
+            end();
+        }, 200);
+
+        // Cleanup
+        return function () {
+            $.signalR.transports._logic.ajaxStart = savedAjaxStart;
+        };
+    });
+
+    QUnit.asyncTimeoutTest("Transport timeout is not triggered after the start request is initiated.", testUtilities.defaultTestTimeout, function (end, assert) {
+        // Arrange
+        var fakeConnection = buildFakeConnection(),
+            fakeTransport = buildFakeTransport(),
+            initHandler = $.signalR.transports._logic.initHandler(fakeConnection),
+            savedAjaxStart = $.signalR.transports._logic.ajaxStart,
+            ajaxStartCalled = false,
+            initOnSuccessCalled = false,
+            initOnFallbackCalled = false;
+
+        $.signalR.transports._logic.ajaxStart = function () {
+            ajaxStartCalled = true;
+        };
+
+        fakeConnection._.totalTransportConnectTimeout = 100;
+
+        // Act
+        initHandler.start(fakeTransport, function () {
+            initOnSuccessCalled = true;
+        }, function () {
+            initOnFallbackCalled = true;
+        });
+
+        fakeTransport.onSuccess();
+
+        window.setTimeout(function () {
+            // Assert
+            QUnit.isFalse(initOnFallbackCalled, "Timeout did not trigger fallback.");
+            assert.isFalse(initOnSuccessCalled, "Initialization did not complete.");
+            assert.isTrue(ajaxStartCalled, "Timeout did not prevent start request.");
+            assert.isFalse(fakeTransport.stopCalled, "Timeout did not cause the transport to be stopped.");
+            assert.isFalse(fakeConnection.stopCalled, "Timeout did not cause the connection to be stopped.");
+            end();
+        }, 200);
+
+        // Cleanup
+        return function () {
+            $.signalR.transports._logic.ajaxStart = savedAjaxStart;
+        };
+    });
+})();

--- a/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/default.html
+++ b/tests/Microsoft.AspNet.SignalR.Client.JS.Tests/default.html
@@ -92,6 +92,7 @@
         <script src="Tests/FunctionalTests/Transports/WebSocketsFacts/WebSocketsFacts.js"></script>
         <script src="Tests/UnitTests/SignalRFacts.js"></script>
         <script src="Tests/UnitTests/Common/AjaxFacts.js"></script>
+        <script src="Tests/UnitTests/Common/InitHandlerFacts.js"></script>
         <script src="Tests/UnitTests/Common/KeepAliveFacts.js"></script>
         <script src="Tests/UnitTests/Common/ProcessMessagesFacts.js"></script>
         <script src="Tests/UnitTests/Common/ResponseFacts.js"></script>


### PR DESCRIPTION
- In the event of any transport error prior to the init message,
  the transport should immediately stop and allow the connection to
  fall back to another transport.
- In the event of any transport error during the start request,
  the entire connection should immediately be stopped
#2902

This is the JS equivalent to https://github.com/SignalR/SignalR/pull/3263
