### PR TITLE
Removed await from RedisMessageBus.Send

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/RedisConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisConnection.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.SignalR.Redis
             }
         }
 
-        public async Task ScriptEvaluateAsync(int database, string script, string key, byte[] messageArguments)
+        public Task ScriptEvaluateAsync(int database, string script, string key, byte[] messageArguments)
         {
             if (_connection == null)
             {
@@ -72,7 +72,7 @@ namespace Microsoft.AspNet.SignalR.Redis
 
             var arguments = new RedisValue[] { messageArguments };
 
-            await _connection.GetDatabase(database).ScriptEvaluateAsync(script,
+            return _connection.GetDatabase(database).ScriptEvaluateAsync(script,
                 keys,
                 arguments);
         }

--- a/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
@@ -71,16 +71,14 @@ namespace Microsoft.AspNet.SignalR.Redis
 
         protected override Task Send(int streamIndex, IList<Message> messages)
         {
-            var redisTask = _connection.ScriptEvaluateAsync(_db,
-                                @"local newId = redis.call('INCR', KEYS[1])
-                              local payload = newId .. ' ' .. ARGV[1]
-                              redis.call('PUBLISH', KEYS[1], payload)
-                              return {newId, ARGV[1], payload}  
-                            ",
+            return _connection.ScriptEvaluateAsync(
+                _db,
+                @"local newId = redis.call('INCR', KEYS[1])
+                  local payload = newId .. ' ' .. ARGV[1]
+                  redis.call('PUBLISH', KEYS[1], payload)
+                  return {newId, ARGV[1], payload}",
                 _key,
                 RedisMessage.ToBytes(messages));
-
-            return redisTask;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
- The await would cause an unnecessary SyncContext.Post that would prevent
  the returned Task from completing if there was a thread blocked on the
  returned Task while holding the SyncConetext.
#3240
