### PR TITLE
Made TraceSource return param

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Tracing/TraceSourceExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Tracing/TraceSourceExtensions.cs
@@ -7,46 +7,54 @@ namespace System.Diagnostics
     public static class TraceSourceExtensions
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "msg")]
-        public static void TraceVerbose(this TraceSource traceSource, string msg)
+        public static TraceSource TraceVerbose(this TraceSource traceSource, string msg)
         {
             Trace(traceSource, TraceEventType.Verbose, msg);
+            return traceSource;
         }
 
-        public static void TraceVerbose(this TraceSource traceSource, string format, params object[] args)
+        public static TraceSource TraceVerbose(this TraceSource traceSource, string format, params object[] args)
         {
             Trace(traceSource, TraceEventType.Verbose, format, args);
+            return traceSource;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "msg")]
-        public static void TraceWarning(this TraceSource traceSource, string msg)
+        public static TraceSource TraceWarning(this TraceSource traceSource, string msg)
         {
             Trace(traceSource, TraceEventType.Warning, msg);
+            return traceSource;
         }
 
-        public static void TraceWarning(this TraceSource traceSource, string format, params object[] args)
+        public static TraceSource TraceWarning(this TraceSource traceSource, string format, params object[] args)
         {
             Trace(traceSource, TraceEventType.Warning, format, args);
+            return traceSource;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "msg")]
-        public static void TraceError(this TraceSource traceSource, string msg)
+        public static TraceSource TraceError(this TraceSource traceSource, string msg)
         {
             Trace(traceSource, TraceEventType.Error, msg);
+            return traceSource;
         }
 
-        public static void TraceError(this TraceSource traceSource, string format, params object[] args)
+        public static TraceSource TraceError(this TraceSource traceSource, string format, params object[] args)
         {
             Trace(traceSource, TraceEventType.Error, format, args);
+            return traceSource;
         }
 
-        private static void Trace(TraceSource traceSource, TraceEventType eventType, string msg)
+        private static TraceSource Trace(TraceSource traceSource, TraceEventType eventType, string msg)
         {
             traceSource.TraceEvent(eventType, 0, msg);
+            return traceSource;
         }
 
-        private static void Trace(TraceSource traceSource, TraceEventType eventType, string format, params object[] args)
+        private static TraceSource Trace(TraceSource traceSource, TraceEventType eventType, string format, params object[] args)
         {
             traceSource.TraceEvent(eventType, 0, format, args);
+            return traceSource;
         }
     }
 }


### PR DESCRIPTION
To allow TraceInformation("Before bad").TraceError("Bad").Flush();

My tests show that "return" instead of void does not adds performance overhead if return object not used and method not inlined. I can be wrong, but made tests https://github.com/OpenSharp/NStopwatch/blob/master/src/Invocation.Tests/InvocationsTests.cs to have some guaranty.
