### PR TITLE
YouShould(Not)AlwaysCallDispose - reverting dispoing websockets on the s...

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs
@@ -224,7 +224,9 @@ namespace Microsoft.AspNet.SignalR.WebSockets
             }
             finally
             {
+#if CLIENT_NET45
                 WebSocket.Dispose();
+#endif
                 OnClose();
             }
         }

--- a/tests/Microsoft.AspNet.SignalR.Tests/Owin/WebSocketFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Owin/WebSocketFacts.cs
@@ -60,7 +60,6 @@ namespace Microsoft.AspNet.SignalR.Tests.Owin
 
             webSocket.Setup(w => w.ReceiveAsync(It.IsAny<ArraySegment<byte>>(), CancellationToken.None))
                      .Returns(() => TaskAsyncHelper.FromResult(webSocketMessages[messageIndex++]));
-            webSocket.As<IDisposable>().Setup(w => w.Dispose());
 
             webSocketHandler.Setup(h => h.OnOpen());
             webSocketHandler.Setup(h => h.OnClose());
@@ -100,7 +99,6 @@ namespace Microsoft.AspNet.SignalR.Tests.Owin
                     state = WebSocketState.Closed;
                     return TaskAsyncHelper.Empty;
                 });
-            webSocket.As<IDisposable>().Setup(w => w.Dispose());
 
             var webSocketHandler = new Mock<WebSocketHandler>(64 * 1024) {CallBase = true};
             await webSocketHandler.Object.ProcessWebSocketRequestAsync(webSocket.Object, CancellationToken.None);


### PR DESCRIPTION
...erver

AspNetWebsocket uncoditionally throws a NotSupportedException from the Dispose() method, so #ifdefing the invocation so that we only call Dispose on the client.
