### PR TITLE
fixed a major performance bottleneck in BufferTextWriter, attempted same for ChunkBuffer

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEvents/ChunkBuffer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEvents/ChunkBuffer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Microsoft.AspNet.SignalR.Client.Transports.ServerSentEvents
@@ -8,50 +9,45 @@ namespace Microsoft.AspNet.SignalR.Client.Transports.ServerSentEvents
     public class ChunkBuffer
     {
         private int _offset;
-        private readonly StringBuilder _buffer;
-        private readonly StringBuilder _lineBuilder;
+        private readonly List<char> _buffer;
 
         public ChunkBuffer()
         {
-            _buffer = new StringBuilder();
-            _lineBuilder = new StringBuilder();
+            _buffer = new List<char>();
         }
 
         public bool HasChunks
         {
             get
             {
-                return _offset < _buffer.Length;
+                return _offset < _buffer.Count;
             }
         }
 
         public void Add(byte[] buffer, int length)
         {
-            _buffer.Append(Encoding.UTF8.GetString(buffer, 0, length));
+            _buffer.AddRange(Encoding.UTF8.GetChars(buffer, 0, length));
         }
 
         public void Add(ArraySegment<byte> buffer)
         {
-            _buffer.Append(Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count));
+			_buffer.AddRange(Encoding.UTF8.GetChars(buffer.Array, buffer.Offset, buffer.Count));
         }
 
         public string ReadLine()
         {
             // Lock while reading so that we can make safe assuptions about the buffer indicies
-            for (int i = _offset; i < _buffer.Length; i++, _offset++)
+            for (int i = _offset; i < _buffer.Count; i++, _offset++)
             {
-                if (_buffer[i] == '\n')
+                if (_buffer[i] == '\n') // List seems to have a faster getter than StringBuilder
                 {
-                    _buffer.Remove(0, _offset + 1);
-
-                    string line = _lineBuilder.ToString().Trim();
-                    _lineBuilder.Clear();
-
-                    _offset = 0;
-                    return line;
+	                var chars = new char[_offset];
+					_buffer.CopyTo(0, chars, 0, _offset);
+                    _buffer.RemoveRange(0, _offset + 1);
+					_offset = 0;
+					
+                    return new string(chars).Trim(); // we could be smarter on that trim and do it by hand before the CopyTo; I think it's mostly a NOP
                 }
-
-                _lineBuilder.Append(_buffer[i]);
             }
 
             return null;

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -58,7 +58,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             {
                 _stop = true;
 
-                _request.Abort();
+				var req = _request;
+				if (req != null)
+					req.Abort();
             };
 
             OpenConnection(connection, connectionData, disconnectToken, initializeHandler.InitReceived, initializeHandler.Fail);
@@ -261,9 +263,10 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
         public override void LostConnection(IConnection connection)
         {
-            if (_request != null)
+	        var req = _request;
+            if (req != null)
             {
-                _request.Abort();
+                req.Abort();
             }
         }
     }

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/BinaryTextWriter.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/BinaryTextWriter.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
     /// <summary>
     /// A buffering text writer that supports writing binary directly as well
     /// </summary>
-    internal unsafe class BinaryTextWriter : BufferTextWriter, IBinaryWriter
+    internal class BinaryTextWriter : BufferTextWriter, IBinaryWriter
     {
         public BinaryTextWriter(IResponse response) :
             base((data, state) => ((IResponse)state).Write(data), response, reuseBuffers: true, bufferSize: 128)

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/BufferTextWriter.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/BufferTextWriter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
     /// we don't need to write to a long lived buffer. This saves massive amounts of memory
     /// as the number of connections grows.
     /// </summary>
-    internal abstract unsafe class BufferTextWriter : TextWriter
+    internal abstract class BufferTextWriter : TextWriter
     {
         private readonly Encoding _encoding;
 
@@ -79,7 +79,12 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             Writer.Write(value);
         }
 
-        public override void Flush()
+		public override void Write(char[] buffer, int index, int count)
+		{
+			Writer.Write(buffer, index, count);
+		}
+
+	    public override void Flush()
         {
             Writer.Flush();
         }
@@ -142,9 +147,41 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
                     sourceIndex += count;
                     length -= count;
                 }
+
+				if (_charPos == _charLen)
+				{
+					Flush(flushEncoder: false);
+				}
             }
 
-            public void Write(ArraySegment<byte> data)
+			public void Write(char[] buffer, int sourceIndex, int length)
+			{
+				while (length > 0)
+				{
+					if (_charPos == _charLen)
+					{
+						Flush(flushEncoder: false);
+					}
+
+					int count = _charLen - _charPos;
+					if (count > length)
+					{
+						count = length;
+					}
+
+					Array.Copy(buffer, sourceIndex, _charBuffer, _charPos, count);
+					_charPos += count;
+					sourceIndex += count;
+					length -= count;
+				}
+
+				if (_charPos == _charLen)
+				{
+					Flush(flushEncoder: false);
+				}
+			}
+			
+			public void Write(ArraySegment<byte> data)
             {
                 Flush();
                 _write(data, _writeState);

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/PerformanceCounterManager.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/PerformanceCounterManager.cs
@@ -381,7 +381,15 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             // and when they are thrown. 
             try
             {
-                var counter = new PerformanceCounter(categoryName, counterName, instanceName, isReadOnly);
+				if (!PerformanceCounterCategory.Exists(categoryName))
+				{
+#if !UTILS
+					_trace.TraceEvent(TraceEventType.Warning, 0, "Performance counter failed to load. The counters are not installed.");
+#endif
+					return null;
+				}
+				
+				var counter = new PerformanceCounter(categoryName, counterName, instanceName, isReadOnly);
 
                 // Initialize the counter sample
                 counter.NextSample();


### PR DESCRIPTION
`BufferTextWriter`'s most common call was the `Write(char[], int, int)` method. This method was not overridden for efficient handling. It was breaking that down into individual bytes. Overriding that method shows a 20x speed increase in my testing with 40k-long messages. Also, I don't think it was right for that method to not attempt a flush after the last character on a given write. It was waiting until the next write call came in to flush the previous data.

I also changed `ChunkBuffer` to use List instead of `StringBuilder`. That seems to have better performance on the indexer. However, `ChunkBuffer` and its unit tests seem wrong to me in general. We shouldn't have to scan the entire buffer for newline characters. The sentinel should be at the end of one of the incoming chunks. We should only have to check the last character in each of the `ChunkBuffer.Add` methods. If we could do that it would eliminate most of the time on the read call, according to my profiling. 

![image](https://cloud.githubusercontent.com/assets/1509322/5636699/e38c754c-95b1-11e4-9628-67f59508d55e.png)

![image](https://cloud.githubusercontent.com/assets/1509322/5636725/21c895c0-95b2-11e4-9c9d-52b2cc0b234a.png)

![image](https://cloud.githubusercontent.com/assets/1509322/5636746/535a99da-95b2-11e4-9cd9-8e57be239558.png)

