### PR TITLE
20x speedup for BufferTextWriter

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR.Client;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
 {
@@ -97,7 +95,9 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             var tokenifiedArguments = new JToken[args.Length];
             for (int i = 0; i < tokenifiedArguments.Length; i++)
             {
-                tokenifiedArguments[i] = JToken.FromObject(args[i], JsonSerializer);
+                tokenifiedArguments[i] = args[i] != null
+                    ? JToken.FromObject(args[i], JsonSerializer)
+                    : JValue.CreateNull();
             }
 
             var tcs = new TaskCompletionSource<TResult>();

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEvents/ChunkBuffer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEvents/ChunkBuffer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Text;
 
 namespace Microsoft.AspNet.SignalR.Client.Transports.ServerSentEvents
@@ -8,50 +9,45 @@ namespace Microsoft.AspNet.SignalR.Client.Transports.ServerSentEvents
     public class ChunkBuffer
     {
         private int _offset;
-        private readonly StringBuilder _buffer;
-        private readonly StringBuilder _lineBuilder;
+        private readonly List<char> _buffer;
 
         public ChunkBuffer()
         {
-            _buffer = new StringBuilder();
-            _lineBuilder = new StringBuilder();
+            _buffer = new List<char>();
         }
 
         public bool HasChunks
         {
             get
             {
-                return _offset < _buffer.Length;
+                return _offset < _buffer.Count;
             }
         }
 
         public void Add(byte[] buffer, int length)
         {
-            _buffer.Append(Encoding.UTF8.GetString(buffer, 0, length));
+            _buffer.AddRange(Encoding.UTF8.GetChars(buffer, 0, length));
         }
 
         public void Add(ArraySegment<byte> buffer)
         {
-            _buffer.Append(Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count));
+            _buffer.AddRange(Encoding.UTF8.GetChars(buffer.Array, buffer.Offset, buffer.Count));
         }
 
         public string ReadLine()
         {
             // Lock while reading so that we can make safe assuptions about the buffer indicies
-            for (int i = _offset; i < _buffer.Length; i++, _offset++)
+            for (int i = _offset; i < _buffer.Count; i++, _offset++)
             {
-                if (_buffer[i] == '\n')
+                if (_buffer[i] == '\n') // List seems to have a faster getter than StringBuilder
                 {
-                    _buffer.Remove(0, _offset + 1);
-
-                    string line = _lineBuilder.ToString().Trim();
-                    _lineBuilder.Clear();
-
+                    var chars = new char[_offset];
+                    _buffer.CopyTo(0, chars, 0, _offset);
+                    _buffer.RemoveRange(0, _offset + 1);
                     _offset = 0;
-                    return line;
-                }
 
-                _lineBuilder.Append(_buffer[i]);
+                    return new string(chars).Trim(); // we could be smarter on that trim and do it by hand before the CopyTo; I think it's mostly a NOP
+                }
             }
 
             return null;

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -53,7 +53,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             // if the transport failed to start we want to stop it silently.
             _stop = true;
 
-            _request.Abort();
+            var request = _request;
+            if (request != null)
+                request.Abort();
         }
 
         private void Reconnect(IConnection connection, string data, CancellationToken disconnectToken)
@@ -95,10 +97,10 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             var getTask = HttpClient.Get(url, req =>
             {
+                req.Accept = "text/event-stream";
                 _request = req;
-                _request.Accept = "text/event-stream";
 
-                connection.PrepareRequest(_request);
+                connection.PrepareRequest(req);
 
             }, isLongRunning: true);
 
@@ -107,7 +109,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 _stop = true;
 
                 // This will no-op if the request is already finished.
-                ((IRequest)state).Abort();
+                var request = state as IRequest;
+                if (request != null)
+                    request.Abort();
             }, _request);
             
             getTask.ContinueWith(task =>
@@ -200,10 +204,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
         public override void LostConnection(IConnection connection)
         {
-            if (_request != null)
-            {
-                _request.Abort();
-            }
+            var request = _request;
+            if (request != null)
+                request.Abort();
         }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -55,7 +55,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             var request = _request;
             if (request != null)
+            {
                 request.Abort();
+            }
         }
 
         private void Reconnect(IConnection connection, string data, CancellationToken disconnectToken)
@@ -111,7 +113,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 // This will no-op if the request is already finished.
                 var request = state as IRequest;
                 if (request != null)
+                {
                     request.Abort();
+                }
             }, _request);
             
             getTask.ContinueWith(task =>
@@ -206,7 +210,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         {
             var request = _request;
             if (request != null)
+            {
                 request.Abort();
+            }
         }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubRequestParser.cs
@@ -24,7 +24,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             request.Method = deserializedData.Method;
             request.Id = deserializedData.Id;
             request.State = GetState(deserializedData);
-            request.ParameterValues = (deserializedData.Args != null) ? deserializedData.Args.Select(value => new JRawValue(value)).ToArray() : _emptyArgs;
+            request.ParameterValues = (deserializedData.Args != null) ? deserializedData.Args.Select(value => new JRawValue(value, serializer)).ToArray() : _emptyArgs;
 
             return request;
         }

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
@@ -113,6 +113,16 @@ namespace Microsoft.AspNet.SignalR.Hubs
                                     ex.GetType().Name,
                                     ex.Message);
 
+                if (ex.LoaderExceptions != null)
+                {
+                    _trace.TraceWarning("Loader exceptions messages: ");
+
+                    foreach (var exception in ex.LoaderExceptions)
+                    {
+                        _trace.TraceWarning("{0}\r\n", exception);
+                    }
+                }
+
                 return ex.Types.Where(t => t != null);
             }
             catch (Exception ex)

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
@@ -109,7 +109,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
                                     "Original exception type: {2}\r\n" +
                                     "Original exception message: {3}\r\n",
                                     a.FullName,
-                                    a.Location,
+                                    a.IsDynamic ? "na" : a.Location,
                                     ex.GetType().Name,
                                     ex.Message);
 
@@ -131,7 +131,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
                                     "Original exception type: {2}\r\n" +
                                     "Original exception message: {3}\r\n",
                                     a.FullName,
-                                    a.Location,
+                                    a.IsDynamic ? "na" : a.Location,
                                     ex.GetType().Name,
                                     ex.Message);
 

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/TypedClientBuilder.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/TypedClientBuilder.cs
@@ -123,6 +123,11 @@ namespace Microsoft.AspNet.SignalR.Hubs
 
             methodBuilder.SetReturnType(interfaceMethodInfo.ReturnType);
             methodBuilder.SetParameters(paramTypes);
+            // Sets the number of generic type parameters
+            foreach (var generic in paramTypes.Where(param => param.IsGenericParameter))
+            {
+                methodBuilder.DefineGenericParameters(generic.Name);
+            }
 
             ILGenerator generator = methodBuilder.GetILGenerator();
 

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/BinaryTextWriter.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/BinaryTextWriter.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
     /// <summary>
     /// A buffering text writer that supports writing binary directly as well
     /// </summary>
-    internal unsafe class BinaryTextWriter : BufferTextWriter, IBinaryWriter
+    internal class BinaryTextWriter : BufferTextWriter, IBinaryWriter
     {
         public BinaryTextWriter(IResponse response) :
             base((data, state) => ((IResponse)state).Write(data), response, reuseBuffers: true, bufferSize: 128)

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/PerformanceCounterManager.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/PerformanceCounterManager.cs
@@ -438,6 +438,14 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             // and when they are thrown. 
             try
             {
+                if (!PerformanceCounterCategory.Exists(categoryName))
+                {
+#if !UTILS
+                    _trace.TraceEvent(TraceEventType.Warning, 0, "Performance counter failed to load. The counters are not installed.");
+#endif
+                    return null;
+                }
+
                 var counter = new PerformanceCounter(categoryName, counterName, instanceName, isReadOnly);
 
                 // Initialize the counter sample

--- a/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Json/JRawValue.cs
@@ -13,10 +13,12 @@ namespace Microsoft.AspNet.SignalR.Json
     internal class JRawValue : IJsonValue
     {
         private readonly string _value;
+        private readonly JsonSerializer _serializer;
 
-        public JRawValue(JRaw value)
+        public JRawValue(JRaw value, JsonSerializer serializer)
         {
             _value = value.ToString();
+            _serializer = serializer;
         }
 
         public object ConvertTo(Type type)
@@ -24,8 +26,7 @@ namespace Microsoft.AspNet.SignalR.Json
             // A non generic implementation of ToObject<T> on JToken
             using (var jsonReader = new StringReader(_value))
             {
-                var serializer = JsonUtility.CreateDefaultSerializer();
-                return serializer.Deserialize(jsonReader, type);
+                return _serializer.Deserialize(jsonReader, type);
             }
         }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/DefaultWebSocketHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/DefaultWebSocketHandler.cs
@@ -12,6 +12,9 @@ namespace Microsoft.AspNet.SignalR.WebSockets
         private readonly IWebSocket _webSocket;
         private volatile bool _closed;
 
+        private Action _onClose;
+        private Action<Exception> _onError;
+
         internal ArraySegment<byte> NextMessageToSend { get; private set; }
 
         public DefaultWebSocketHandler(int? maxIncomingMessageSize)
@@ -49,14 +52,22 @@ namespace Microsoft.AspNet.SignalR.WebSockets
 
         Action IWebSocket.OnClose
         {
-            get;
-            set;
+            get { return _onClose; }
+            set
+            {
+                _onClose = value;
+                if (_onClose != null && _closed) _onClose();
+            }
         }
 
         Action<Exception> IWebSocket.OnError
         {
-            get;
-            set;
+            get { return _onError; }
+            set
+            {
+                _onError = value;
+                if (_onError != null && Error != null) _onError(Error);
+            }
         }
 
         Task IWebSocket.Send(string value)

--- a/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.SignalR.WebSockets
 
         internal virtual Task SendAsync(ArraySegment<byte> message, WebSocketMessageType messageType, bool endOfMessage = true)
         {
-            if (WebSocket.State != WebSocketState.Open)
+            if (GetWebSocketState(WebSocket) != WebSocketState.Open)
             {
                 return TaskAsyncHelper.Empty;
             }
@@ -68,7 +68,7 @@ namespace Microsoft.AspNet.SignalR.WebSockets
             {
                 var context = (SendContext)state;
 
-                if (context.Handler.WebSocket.State != WebSocketState.Open)
+                if (GetWebSocketState(context.Handler.WebSocket) != WebSocketState.Open)
                 {
                     return;
                 }
@@ -212,8 +212,9 @@ namespace Microsoft.AspNet.SignalR.WebSockets
             try
             {
 #if CLIENT_NET45
-                if (WebSocket.State == WebSocketState.Closed ||
-                    WebSocket.State == WebSocketState.Aborted)
+                var webSocketState = GetWebSocketState(WebSocket);
+                if (webSocketState == WebSocketState.Closed ||
+                    webSocketState == WebSocketState.Aborted)
                 {
                     // No-op if the socket is already closed or aborted
                 }
@@ -257,9 +258,23 @@ namespace Microsoft.AspNet.SignalR.WebSockets
 
         private static bool IsClosedOrClosedSent(WebSocket webSocket)
         {
-            return webSocket.State == WebSocketState.Closed ||
-                   webSocket.State == WebSocketState.CloseSent ||
-                   webSocket.State == WebSocketState.Aborted;
+            var webSocketState = GetWebSocketState(webSocket);
+
+            return webSocketState == WebSocketState.Closed ||
+                   webSocketState == WebSocketState.CloseSent ||
+                   webSocketState == WebSocketState.Aborted;
+        }
+
+        private static WebSocketState GetWebSocketState(WebSocket webSocket)
+        {
+            try
+            {
+                return webSocket.State;
+            }
+            catch (ObjectDisposedException)
+            {
+                return WebSocketState.Closed;
+            }
         }
 
         private class CloseContext


### PR DESCRIPTION
I posted this pull request once before, but I've now updated it for 2.2 and fixed the spacing. The JSON serializer uses the TextWriter's `Write(char[], int, int)` overload.
