### PR TITLE
.Net 3.5 client support

### DIFF
--- a/Microsoft.AspNet.SignalR.sln
+++ b/Microsoft.AspNet.SignalR.sln
@@ -110,6 +110,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.SignalR.Cl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.SignalR.Redis.Tests", "tests\Microsoft.AspNet.SignalR.Redis.Tests\Microsoft.AspNet.SignalR.Redis.Tests.csproj", "{C281927C-2082-4E2A-A1DB-9CD7225F5CED}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.AspNet.SignalR.Client35", "src\Microsoft.AspNet.SignalR.Client35\Microsoft.AspNet.SignalR.Client35.csproj", "{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -694,6 +696,20 @@ Global
 		{C281927C-2082-4E2A-A1DB-9CD7225F5CED}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{C281927C-2082-4E2A-A1DB-9CD7225F5CED}.Release|x64.ActiveCfg = Release|Any CPU
 		{C281927C-2082-4E2A-A1DB-9CD7225F5CED}.Release|x86.ActiveCfg = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|ARM.ActiveCfg = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|x64.ActiveCfg = Release|Any CPU
+		{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Common/CommonAssemblyInfo.cs
+++ b/src/Common/CommonAssemblyInfo.cs
@@ -11,7 +11,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCompany("Microsoft Open Technologies, Inc.")]
 [assembly: AssemblyCopyright("© Microsoft Open Technologies, Inc. All rights reserved.")]
 [assembly: AssemblyProduct("Microsoft ASP.NET SignalR")]
+#if !NET35
 [assembly: AssemblyMetadata("Serviceable", "True")]
+#endif
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: AssemblyConfiguration("")]
@@ -23,7 +25,7 @@ using System.Runtime.InteropServices;
 [assembly: NeutralResourcesLanguage("en-US")]
 
 
-#if NET4 || PORTABLE
+#if NET4 || PORTABLE || NET35
 namespace System.Reflection
 {
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]

--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -21,6 +21,9 @@ using Newtonsoft.Json.Linq;
 #if (NET4 || NET45)
 using System.Security.Cryptography.X509Certificates;
 #endif
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#endif
 
 namespace Microsoft.AspNet.SignalR.Client
 {
@@ -947,7 +950,7 @@ namespace Microsoft.AspNet.SignalR.Client
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "The Version constructor can throw exceptions of many different types. Failure is indicated by returning false.")]
         private static bool TryParseVersion(string versionString, out Version version)
         {
-#if PORTABLE
+#if PORTABLE || NET35
             try
             {
                 version = new Version(versionString);

--- a/src/Microsoft.AspNet.SignalR.Client/ConnectionExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/ConnectionExtensions.cs
@@ -6,6 +6,9 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using Newtonsoft.Json;
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#endif
 
 namespace Microsoft.AspNet.SignalR.Client
 {

--- a/src/Microsoft.AspNet.SignalR.Client/Http/HttpHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/HttpHelper.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
 {
     internal static class HttpHelper
     {
-#if CLIENT_NET4
+#if CLIENT_NET4 || CLIENT_NET35
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exceptions are flowed back to the caller.")]
         public static Task<HttpWebResponse> GetHttpResponseAsync(this HttpWebRequest request)

--- a/src/Microsoft.AspNet.SignalR.Client/Http/HttpWebRequestWrapper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/HttpWebRequestWrapper.cs
@@ -19,9 +19,13 @@ namespace Microsoft.AspNet.SignalR.Client.Http
                                                                         { HttpRequestHeader.ContentLength.ToString(), (request, value) => { request.ContentLength = Int32.Parse(value, CultureInfo.CurrentCulture); } }, 
                                                                         { HttpRequestHeader.UserAgent.ToString(), (request, value) => { request.UserAgent = value; } },
                                                                         { HttpRequestHeader.Connection.ToString(), (request, value) => { request.Connection = value; } },
+#if !NET35
                                                                         { HttpRequestHeader.Date.ToString(), (request, value) => {request.Date = DateTime.Parse(value, CultureInfo.CurrentCulture); } },
+#endif
                                                                         { HttpRequestHeader.Expect.ToString(), (request, value) => {request.Expect = value;} },
+#if !NET35
                                                                         { HttpRequestHeader.Host.ToString(), (request, value) => {request.Host = value; }  },                                                                     
+#endif
                                                                         { HttpRequestHeader.IfModifiedSince.ToString(), (request, value) => {request.IfModifiedSince = DateTime.Parse(value, CultureInfo.CurrentCulture);} },
                                                                         { HttpRequestHeader.Referer.ToString(), (request, value) => { request.Referer = value; } },                                                                         
                                                                         { HttpRequestHeader.TransferEncoding.ToString(), (request, value) => { request.TransferEncoding = value; } },

--- a/src/Microsoft.AspNet.SignalR.Client/HubProxyExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/HubProxyExtensions.cs
@@ -234,7 +234,7 @@ namespace Microsoft.AspNet.SignalR.Client
             return new DisposableAction(() => subscription.Received -= handler);
         }
 
-#if !PORTABLE && !__ANDROID__ && !IOS
+#if !PORTABLE && !__ANDROID__ && !IOS && !NET35
         /// <summary>
         /// Registers for an event with the specified name and callback
         /// </summary>

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/Hubservable.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/Hubservable.cs
@@ -5,6 +5,9 @@ using Newtonsoft.Json.Linq;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Microsoft.AspNet.SignalR.Infrastructure;
 using System.Collections.Generic;
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#endif
 #if !PORTABLE
 namespace Microsoft.AspNet.SignalR.Client.Hubs
 {

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/ErrorExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/ErrorExtensions.cs
@@ -4,7 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
-#if !NET4
+#if !NET4 && !NET35
 using System.Net.Http;
 #endif
 using Microsoft.AspNet.SignalR.Infrastructure;
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.SignalR.Client
             {
                 error = GetWebExceptionError(ex);
             }
-#if !NET4
+#if !NET4 && !NET35
             else
             {
                 error = GetHttpClientException(ex);
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.SignalR.Client
             return error;
         }
 
-#if !NET4
+#if !NET4 && !NET35
         [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The IDisposable object is the return value.")]
         private static SignalRError GetHttpClientException(Exception ex)
         {

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/StreamExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/StreamExtensions.cs
@@ -41,6 +41,22 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             };
         }
 
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is a shared class.")]
+        public static void CopyTo(this Stream input, Stream output)
+        {
+#if NET35
+            byte[] buffer = new byte[16 * 1024]; // Fairly arbitrary size
+            int bytesRead;
+
+            while ((bytesRead = input.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                output.Write(buffer, 0, bytesRead);
+            }
+#else
+            input.CopyTo(output);
+#endif
+        }
+
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exceptions are flowed back to the caller.")]
         private static Task<T> FromAsync<T>(Func<AsyncCallback, IAsyncResult> begin, Func<IAsyncResult, T> end)
         {

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportAbortHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportAbortHandler.cs
@@ -130,7 +130,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                     {
                         if (!_disposed)
                         {
-                            _abortResetEvent.Dispose();
+                            ((IDisposable)_abortResetEvent).Dispose();
                             _disposed = true;
                         }
                     }

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportInitializationHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportInitializationHandler.cs
@@ -56,7 +56,11 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
 
             // We want to fail if the disconnect token is tripped while we're waiting on initialization
             _tokenCleanup = disconnectToken.SafeRegister(
+#if NET35
+                _ => Fail(new OperationCanceledException(Resources.Error_ConnectionCancelled)),
+#else
                 _ => Fail(new OperationCanceledException(Resources.Error_ConnectionCancelled, disconnectToken)),
+#endif
                 state: null);
 
             TaskAsyncHelper.Delay(connection.TotalTransportConnectTimeout)

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/UrlBuilder.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/UrlBuilder.cs
@@ -5,6 +5,11 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#else
+using StringHelper = System.String;
+#endif
 
 namespace Microsoft.AspNet.SignalR.Client.Infrastructure
 {
@@ -31,7 +36,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 throw new ArgumentNullException("connection");
             }
 
-            if (string.IsNullOrWhiteSpace(transport))
+            if (StringHelper.IsNullOrWhiteSpace(transport))
             {
                 throw new ArgumentNullException("transport");
             }
@@ -46,7 +51,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 throw new ArgumentNullException("connection");
             }
 
-            if (string.IsNullOrWhiteSpace(transport))
+            if (StringHelper.IsNullOrWhiteSpace(transport))
             {
                 throw new ArgumentNullException("transport");
             }
@@ -64,7 +69,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 throw new ArgumentNullException("connection");
             }
 
-            if (string.IsNullOrWhiteSpace(transport))
+            if (StringHelper.IsNullOrWhiteSpace(transport))
             {
                 throw new ArgumentNullException("transport");
             }
@@ -82,13 +87,13 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 throw new ArgumentNullException("connection");
             }
 
-            if (string.IsNullOrWhiteSpace(transport))
+            if (StringHelper.IsNullOrWhiteSpace(transport))
             {
                 throw new ArgumentNullException("transport");
             }
 
             Debug.Assert(connection != null, "connection is null");
-            Debug.Assert(!string.IsNullOrWhiteSpace(transport), "invalid transport");
+            Debug.Assert(!StringHelper.IsNullOrWhiteSpace(transport), "invalid transport");
 
             var urlStringBuilder = CreateBaseUrl("poll", connection, transport, connectionData);
             AppendReceiveParameters(urlStringBuilder, connection);
@@ -103,7 +108,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 throw new ArgumentNullException("connection");
             }
 
-            if (string.IsNullOrWhiteSpace(transport))
+            if (StringHelper.IsNullOrWhiteSpace(transport))
             {
                 throw new ArgumentNullException("transport");
             }
@@ -118,7 +123,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 throw new ArgumentNullException("connection");
             }
 
-            if (string.IsNullOrWhiteSpace(transport))
+            if (StringHelper.IsNullOrWhiteSpace(transport))
             {
                 throw new ArgumentNullException("transport");
             }

--- a/src/Microsoft.AspNet.SignalR.Client/ObservableConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/ObservableConnection.cs
@@ -4,6 +4,9 @@ using System;
 using System.Globalization;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Microsoft.AspNet.SignalR.Infrastructure;
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#endif
 
 namespace Microsoft.AspNet.SignalR.Client
 {

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ClientTransportBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ClientTransportBase.cs
@@ -9,6 +9,11 @@ using Microsoft.AspNet.SignalR.Client.Http;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Newtonsoft.Json.Linq;
 using System.Collections.Generic;
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#else
+using StringHelper = System.String;
+#endif
 
 namespace Microsoft.AspNet.SignalR.Client.Transports
 {
@@ -35,7 +40,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 throw new ArgumentNullException("httpClient");
             }
 
-            if (string.IsNullOrWhiteSpace(transportName))
+            if (StringHelper.IsNullOrWhiteSpace(transportName))
             {
                 throw new ArgumentNullException("transportName");
             }

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEvents/ChunkBuffer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEvents/ChunkBuffer.cs
@@ -2,6 +2,9 @@
 
 using System;
 using System.Text;
+#if NET35
+using Microsoft.AspNet.SignalR.Client.LibExtensions;
+#endif
 
 namespace Microsoft.AspNet.SignalR.Client.Transports.ServerSentEvents
 {

--- a/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/Enum.cs
+++ b/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/Enum.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace Microsoft.AspNet.SignalR.Client.LibExtensions
+{
+    static class EnumExt
+    {
+        /// <summary>
+        /// Check to see if a flags enumeration has a specific flag set.
+        /// </summary>
+        /// <param name="variable">Flags enumeration to check</param>
+        /// <param name="value">Flag to check for</param>
+        /// <returns></returns>
+        public static bool HasFlag(this Enum variable, Enum value)
+        {
+            if (variable == null)
+                return false;
+
+            if (value == null)
+                throw new ArgumentNullException("value");
+
+            // Not as good as the .NET 4 version of this function, but should be good enough
+            if (!Enum.IsDefined(variable.GetType(), value))
+            {
+                throw new ArgumentException(string.Format(
+                    "Enumeration type mismatch.  The flag is of type '{0}', was expecting '{1}'.",
+                    value.GetType(), variable.GetType()));
+            }
+
+            ulong num = Convert.ToUInt64(value);
+            return ((Convert.ToUInt64(variable) & num) == num);
+
+        }
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/IObservable.cs
+++ b/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/IObservable.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace Microsoft.AspNet.SignalR.Client.LibExtensions
+{
+    // Summary:
+    //     Defines a provider for push-based notification.
+    //
+    // Type parameters:
+    //   T:
+    //     The object that provides notification information.This type parameter is
+    //     covariant. That is, you can use either the type you specified or any type
+    //     that is more derived. For more information about covariance and contravariance,
+    //     see Covariance and Contravariance in Generics.
+    public interface IObservable<out T>
+    {
+        // Summary:
+        //     Notifies the provider that an observer is to receive notifications.
+        //
+        // Parameters:
+        //   observer:
+        //     The object that is to receive notifications.
+        //
+        // Returns:
+        //     A reference to an interface that allows observers to stop receiving notifications
+        //     before the provider has finished sending them.
+        IDisposable Subscribe(IObserver<T> observer);
+    }
+
+    // Summary:
+    //     Provides a mechanism for receiving push-based notifications.
+    //
+    // Type parameters:
+    //   T:
+    //     The object that provides notification information.This type parameter is
+    //     contravariant. That is, you can use either the type you specified or any
+    //     type that is less derived. For more information about covariance and contravariance,
+    //     see Covariance and Contravariance in Generics.
+    public interface IObserver<in T>
+    {
+        // Summary:
+        //     Notifies the observer that the provider has finished sending push-based notifications.
+        void OnCompleted();
+        //
+        // Summary:
+        //     Notifies the observer that the provider has experienced an error condition.
+        //
+        // Parameters:
+        //   error:
+        //     An object that provides additional information about the error.
+        void OnError(Exception error);
+        //
+        // Summary:
+        //     Provides the observer with new data.
+        //
+        // Parameters:
+        //   value:
+        //     The current notification information.
+        void OnNext(T value);
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/StringBuilderExt.cs
+++ b/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/StringBuilderExt.cs
@@ -1,0 +1,12 @@
+﻿using System.Text;
+
+namespace Microsoft.AspNet.SignalR.Client.LibExtensions
+{
+    static class StringBuilderExt
+    {
+        public static void Clear(this StringBuilder sb)
+        {
+            sb.Length = 0;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/StringHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client35/LibExtensions/StringHelper.cs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.AspNet.SignalR.Client.LibExtensions
+{
+    static class StringHelper
+    {
+        public static bool IsNullOrWhiteSpace(string value)
+        {
+            if (value == null) return true;
+            return string.IsNullOrEmpty(value.Trim());
+        }
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Client35/Microsoft.AspNet.SignalR.Client35.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client35/Microsoft.AspNet.SignalR.Client35.csproj
@@ -1,0 +1,283 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FA1A4952-E4B4-438F-A5F6-0CBFE71C728A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Microsoft.AspNet.SignalR.Client</RootNamespace>
+    <AssemblyName>Microsoft.AspNet.SignalR.Client</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;CLIENT_NET35;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Microsoft.AspNet.SignalR.Client.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE;CLIENT_NET35;NET35</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\Microsoft.AspNet.SignalR.Client.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="AsyncBridge.Net35">
+      <HintPath>..\..\packages\AsyncBridge.Net35.0.2.0\lib\net35-Client\AsyncBridge.Net35.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net35\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Threading">
+      <HintPath>..\..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\Common\CommonAssemblyInfo.cs">
+      <Link>Properties\CommonAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\Common\CommonVersionInfo.cs">
+      <Link>Properties\CommonVersionInfo.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Connection.cs">
+      <Link>Connection.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\ConnectionExtensions.cs">
+      <Link>ConnectionExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\ConnectionState.cs">
+      <Link>ConnectionState.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\HeaderDictionary.cs">
+      <Link>HeaderDictionary.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\HeartBeatMonitor.cs">
+      <Link>HeartBeatMonitor.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\DefaultHttpClient.cs">
+      <Link>Http\DefaultHttpClient.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\HttpHelper.cs">
+      <Link>Http\HttpHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\HttpWebRequestWrapper.cs">
+      <Link>Http\HttpWebRequestWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\HttpWebResponseWrapper.cs">
+      <Link>Http\HttpWebResponseWrapper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\IHttpClient.cs">
+      <Link>Http\IHttpClient.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\IHttpClientExtensions.cs">
+      <Link>Http\IHttpClientExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\IRequest.cs">
+      <Link>Http\IRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\IResponse.cs">
+      <Link>Http\IResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Http\IResponseExtensions.cs">
+      <Link>Http\IResponseExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\HubConnection.cs">
+      <Link>HubConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\HubException.cs">
+      <Link>HubException.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\HubProxyExtensions.cs">
+      <Link>HubProxyExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\HubInvocation.cs">
+      <Link>Hubs\HubInvocation.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\HubProgressUpdate.cs">
+      <Link>Hubs\HubProgressUpdate.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\HubProxy.cs">
+      <Link>Hubs\HubProxy.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\HubRegistrationData.cs">
+      <Link>Hubs\HubRegistrationData.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\HubResult.cs">
+      <Link>Hubs\HubResult.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\Hubservable.cs">
+      <Link>Hubs\Hubservable.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\IHubConnection.cs">
+      <Link>Hubs\IHubConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Hubs\Subscription.cs">
+      <Link>Hubs\Subscription.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\IConnection.cs">
+      <Link>IConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\IHubProxy.cs">
+      <Link>IHubProxy.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\ErrorExtensions.cs">
+      <Link>Infrastructure\ErrorExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\ITaskMonitor.cs">
+      <Link>Infrastructure\ITaskMonitor.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\SignalRError.cs">
+      <Link>Infrastructure\SignalRError.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\SlowCallbackException.cs">
+      <Link>Infrastructure\SlowCallbackException.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\StartException.cs">
+      <Link>Infrastructure\StartException.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\TaskQueueMonitor.cs">
+      <Link>Infrastructure\TaskQueueMonitor.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\TransportAbortHandler.cs">
+      <Link>Infrastructure\TransportAbortHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\TransportInitializationHandler.cs">
+      <Link>Infrastructure\TransportInitializationHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\UrlBuilder.cs">
+      <Link>Infrastructure\UrlBuilder.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\UrlEncoder.cs">
+      <Link>Infrastructure\UrlEncoder.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\KeepAliveData.cs">
+      <Link>KeepAliveData.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\TraceLevels.cs">
+      <Link>TraceLevels.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\AsyncStreamReader.cs">
+      <Link>Transports\AsyncStreamReader.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\ClientTransportBase.cs">
+      <Link>Transports\ClientTransportBase.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\CancellationTokenExtensions.cs">
+      <Link>Infrastructure\CancellationTokenExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DisposableAction.cs">
+      <Link>Infrastructure\DisposableAction.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\Disposer.cs">
+      <Link>Infrastructure\Disposer.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\ThreadSafeInvoker.cs">
+      <Link>Infrastructure\ThreadSafeInvoker.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\ExceptionHelper.cs">
+      <Link>Infrastructure\ExceptionHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Infrastructure\StreamExtensions.cs">
+      <Link>Infrastructure\StreamExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\NegotiationResponse.cs">
+      <Link>NegotiationResponse.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\ObservableConnection.cs">
+      <Link>ObservableConnection.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Resources.Designer.cs">
+      <Link>Resources.Designer.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\StateChange.cs">
+      <Link>StateChange.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\AutoTransport.cs">
+      <Link>Transports\AutoTransport.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\HttpBasedTransport.cs">
+      <Link>Transports\HttpBasedTransport.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\IClientTransport.cs">
+      <Link>Transports\IClientTransport.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\LongPollingTransport.cs">
+      <Link>Transports\LongPollingTransport.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\ServerSentEventsTransport.cs">
+      <Link>Transports\ServerSentEventsTransport.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\ServerSentEvents\ChunkBuffer.cs">
+      <Link>Transports\ServerSentEvents\ChunkBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\ServerSentEvents\EventSourceStreamReader.cs">
+      <Link>Transports\ServerSentEvents\EventSourceStreamReader.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\ServerSentEvents\EventType.cs">
+      <Link>Transports\ServerSentEvents\EventType.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\ServerSentEvents\SseEvent.cs">
+      <Link>Transports\ServerSentEvents\SseEvent.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Client\Transports\TransportHelper.cs">
+      <Link>Transports\TransportHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\ExceptionsExtensions.cs">
+      <Link>Infrastructure\ExceptionsExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\MonoUtility.cs">
+      <Link>Infrastructure\MonoUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\TaskQueue.cs">
+      <Link>Infrastructure\TaskQueue.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Owin\Infrastructure\ByteBuffer.cs">
+      <Link>Infrastructure\ByteBuffer.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAwaiterHelper.cs">
+      <Link>Infrastructure\TaskAwaiterHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
+      <Link>Infrastructure\TaskAsyncHelper.cs</Link>
+    </Compile>
+    <Compile Include="LibExtensions\Enum.cs" />
+    <Compile Include="LibExtensions\IObservable.cs" />
+    <Compile Include="LibExtensions\StringBuilderExt.cs" />
+    <Compile Include="LibExtensions\StringHelper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="..\Microsoft.AspNet.SignalR.Client\Resources.resx">
+      <Link>Resources.resx</Link>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="..\Common\Microsoft.AspNet.SignalR.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Microsoft.AspNet.SignalR.Client35/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.SignalR.Client35/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle("Microsoft.AspNet.SignalR.Client45")]
+[assembly: AssemblyDescription(".NET client for SignalR")]
+
+#if SIGNED
+[assembly: InternalsVisibleTo("Microsoft.AspNet.SignalR.Client.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
+// Moq
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
+#else
+[assembly: InternalsVisibleTo("Microsoft.AspNet.SignalR.Client.Tests")]
+// Moq
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
+#endif
+

--- a/src/Microsoft.AspNet.SignalR.Client35/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.AspNet.SignalR.Client35/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 
-[assembly: AssemblyTitle("Microsoft.AspNet.SignalR.Client45")]
+[assembly: AssemblyTitle("Microsoft.AspNet.SignalR.Client35")]
 [assembly: AssemblyDescription(".NET client for SignalR")]
 
 #if SIGNED

--- a/src/Microsoft.AspNet.SignalR.Client35/app.config
+++ b/src/Microsoft.AspNet.SignalR.Client35/app.config
@@ -1,0 +1,2 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration />

--- a/src/Microsoft.AspNet.SignalR.Client35/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Client35/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="AsyncBridge.Net35" version="0.2.0" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net35" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net35" />
+</packages>

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/TaskQueue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/TaskQueue.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
-#if CLIENT_NET45 || CLIENT_NET4 || PORTABLE || NETFX_CORE
+#if CLIENT_NET45 || CLIENT_NET4 || PORTABLE || NETFX_CORE || CLIENT_NET35
 #define CLIENT
 #endif
 


### PR DESCRIPTION
With AsyncBridge and TaskParallelLibrary, get a working 3.5 client.
Untested.  Should theoretically work though.  Project was basically a direct copy from the 4.5 project, but then just directly reference as if working off original Client project (.net 4) ie, not using websockets, and change back to the .net4 http client stuff

Why 3.5? Unity3d support, basically.  There might be an issue with the Json library's version though, as I was having issues with anything above 5.0.8. AsyncBridge and deps do work in unity though (tested with a different project)