### PR TITLE
ReflectedHubDescriptorProvider now also finds internal (and private) hubs

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
@@ -86,9 +86,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
             try
             {
                 return typeof(IHub).IsAssignableFrom(type) &&
-                       !type.IsAbstract &&
-                       (type.Attributes.HasFlag(TypeAttributes.Public) ||
-                        type.Attributes.HasFlag(TypeAttributes.NestedPublic));
+                       !type.IsAbstract;
             }
             catch
             {

--- a/tests/Microsoft.AspNet.SignalR.Tests/DefaultHubResolverFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/DefaultHubResolverFacts.cs
@@ -78,6 +78,19 @@ namespace Microsoft.AspNet.SignalR.Tests
             Assert.Equal(hub.NameSpecified, false);
         }
 
+        [Fact]
+        public void ShouldDiscoverInternalHub()
+        {
+            var resolver = new DefaultDependencyResolver();
+            var manager = new DefaultHubManager(resolver);
+
+            var hub = manager.GetHub("internalHub");
+
+            Assert.NotNull(hub);
+            Assert.Equal(hub.Name, "InternalHub");
+            Assert.Equal(hub.NameSpecified, false);
+        }
+
         [HubName("NameFromAttribute")]
         public class HubWithAttribute : Hub
         {
@@ -86,5 +99,12 @@ namespace Microsoft.AspNet.SignalR.Tests
         public class HubWithoutAttribute : Hub
         {
         }
+
+
+    }
+
+    internal class InternalHub : Hub
+    {
+
     }
 }


### PR DESCRIPTION
I'm working on a project that builds a webapplication out of multiple (discrete) components. We'll ILMerge all internal dependencies into these components. 

SignalR doesn't lend itself well to ILMerging, because the hubs needed to be public. In my mind, that's not needed. If you create a hub, you're doing so to be called from javascript. Regardless if the hub itself is public or private. 

This change allows the hubs to be private as well. 

Note, I do have a workaround: 
http://www.erwinvandervalk.net/2015/01/making-signalr-hubs-internal.html 
