### PR TITLE
Fixed an issue (#1655) with null values failing to serialize.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR.Client;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
 {
@@ -97,7 +95,9 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             var tokenifiedArguments = new JToken[args.Length];
             for (int i = 0; i < tokenifiedArguments.Length; i++)
             {
-                tokenifiedArguments[i] = new JValue(args[i]);
+                tokenifiedArguments[i] = args[i] != null
+                    ? JToken.FromObject(args[i], JsonSerializer)
+                    : JValue.CreateNull();
             }
 
             var tcs = new TaskCompletionSource<TResult>();

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -97,7 +97,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
             var tokenifiedArguments = new JToken[args.Length];
             for (int i = 0; i < tokenifiedArguments.Length; i++)
             {
-                tokenifiedArguments[i] = JToken.FromObject(args[i], JsonSerializer);
+                tokenifiedArguments[i] = new JValue(args[i]);
             }
 
             var tcs = new TaskCompletionSource<TResult>();


### PR DESCRIPTION
Fixed an issue (#1655) with null values failing to serialize due to an ArgumentNullException..

JToken.FromObject() throws an argument null exception if the 'o' parameter is null.  JValue however, is a derived type of JToken that has multiple constructors that allow nulls for serialization (including Nullable<T> items).

This is useful as service calls can legitimately allow null values.