### PR TITLE
Issue #3426 UnobservedTaskException

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/WebSockets/WebSocketHandler.cs
@@ -257,9 +257,16 @@ namespace Microsoft.AspNet.SignalR.WebSockets
 
         private static bool IsClosedOrClosedSent(WebSocket webSocket)
         {
-            return webSocket.State == WebSocketState.Closed ||
-                   webSocket.State == WebSocketState.CloseSent ||
-                   webSocket.State == WebSocketState.Aborted;
+            try
+            {
+                return webSocket.State == WebSocketState.Closed ||
+                       webSocket.State == WebSocketState.CloseSent ||
+                       webSocket.State == WebSocketState.Aborted;
+            }
+            catch (ObjectDisposedException)
+            {
+                return true;
+            }
         }
 
         private class CloseContext


### PR DESCRIPTION
This is a fix for the unobserved task exceptions that we are seeing in our logs when an attempt is made to get WebSocket.State after said web socket is disposed and after the close timeout is reached (due to using WhenAny).  We've tested this change in production.