### PR TITLE
Issue #3481 - Ability to create partitioned Topics for ServiceBus backplane

### DIFF
--- a/src/Microsoft.AspNet.SignalR.ServiceBus/Microsoft.AspNet.SignalR.ServiceBus.csproj
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/Microsoft.AspNet.SignalR.ServiceBus.csproj
@@ -39,8 +39,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.ServiceBus.2.1.2.0\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.ServiceBus, Version=2.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\WindowsAzure.ServiceBus.2.6.7\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -87,6 +88,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="..\Common\Microsoft.AspNet.SignalR.targets" />

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusConnection.cs
@@ -94,10 +94,9 @@ namespace Microsoft.AspNet.SignalR.ServiceBus
                     {
                         _trace.TraceInformation("Creating a new topic {0} in the service bus...", topicName);
 
-                        _namespaceManager.CreateTopic(topicName);
+                        _namespaceManager.CreateTopic(new TopicDescription(topicName) { EnablePartitioning = _configuration.EnablePartitioning });
 
                         _trace.TraceInformation("Creation of a new topic {0} in the service bus completed successfully.", topicName);
-
                     }
                     catch (MessagingEntityAlreadyExistsException)
                     {

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusScaleoutConfiguration.cs
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusScaleoutConfiguration.cs
@@ -34,6 +34,7 @@ namespace Microsoft.AspNet.SignalR
             TimeToLive = TimeSpan.FromMinutes(1);
             MaximumMessageSize = 256 * 1024;
             OperationTimeout = null;
+            EnablePartitioning = false;
         }
 
         /// <summary>
@@ -120,5 +121,12 @@ namespace Microsoft.AspNet.SignalR
         /// Default value is RetryExponential.Default
         /// </summary>
         public RetryPolicy RetryPolicy { get; set; }
+
+        /// <summary>
+        /// Gets or Sets the value to use for enabling ServiceBus Entity Partitioning while creating backplane Topics.  
+        /// Partitioning allows multiple brokers and multiple message stores to be used for an Entity, increasing performance and reliability.
+        /// see https://msdn.microsoft.com/en-us/library/azure/dn520246.aspx
+        /// </summary>
+        public bool EnablePartitioning { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/packages.config
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net40" />
-  <package id="WindowsAzure.ServiceBus" version="2.1.2.0" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="2.6.7" targetFramework="net45" />
 </packages>

--- a/tests/Microsoft.AspNet.SignalR.Client.Portable.Tests/Microsoft.AspNet.SignalR.Client.Portable.Tests.csproj
+++ b/tests/Microsoft.AspNet.SignalR.Client.Portable.Tests/Microsoft.AspNet.SignalR.Client.Portable.Tests.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>89047a57</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>fe8dcdaf</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,6 +39,15 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -71,6 +80,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -85,7 +95,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\packages\xunit.core.2.0.0-beta4-build2738\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.core.2.0.0-beta4-build2738\build\portable-net45+win+wpa81+wp80+monotouch+monoandroid\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tests/Microsoft.AspNet.SignalR.Client.Portable.Tests/packages.config
+++ b/tests/Microsoft.AspNet.SignalR.Client.Portable.Tests/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.28" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="xunit" version="2.0.0-beta4-build2738" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0-beta4-build2738" targetFramework="net45" />


### PR DESCRIPTION
Add ability to configure the usage of partitioned topics for ServiceBus backplane.
 - Updated WindowsAzure.ServiceBus dependency to 2.6 (partitioning available as of 2.2)
 - Added option for partitioning to ServiceBusScaleoutConfiguration
 - Use partitioning option to create topics if they don't already exist.  You canot convert existing ServiceBus entities to use partitioning, they must be created that way.

#3481 