### PR TITLE
Fix for #3559 - Included LoaderExceptions property in trace.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/Lookup/ReflectedHubDescriptorProvider.cs
@@ -113,6 +113,16 @@ namespace Microsoft.AspNet.SignalR.Hubs
                                     ex.GetType().Name,
                                     ex.Message);
 
+                if (ex.LoaderExceptions != null)
+                {
+                    _trace.TraceWarning("Loader exceptions messages: ");
+
+                    foreach (var exception in ex.LoaderExceptions)
+                    {
+                        _trace.TraceWarning("{0}\r\n", exception);
+                    }
+                }
+
                 return ex.Types.Where(t => t != null);
             }
             catch (Exception ex)


### PR DESCRIPTION
ReflectedHubDescriptorProvider GetTypesSafe() method will now write trace information for LoaderExceptions property.

Merge pull request for fix of Issue #3559 