### PR TITLE
DefineGenericParameters for type parameters

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/TypedClientBuilder.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/TypedClientBuilder.cs
@@ -123,6 +123,11 @@ namespace Microsoft.AspNet.SignalR.Hubs
 
             methodBuilder.SetReturnType(interfaceMethodInfo.ReturnType);
             methodBuilder.SetParameters(paramTypes);
+            // Sets the number of generic type parameters
+            foreach (var generic in paramTypes.Where(param => param.IsGenericParameter))
+            {
+                methodBuilder.DefineGenericParameters(generic.Name);
+            }
 
             ILGenerator generator = methodBuilder.GetILGenerator();
 


### PR DESCRIPTION
This is fix for the issue of #3594.

The `TypeLoadException` is thrown while executing `TypeBuilder.CreateType()` in `TypedClientBuilder.GenerateInterfaceImplementation` method.

https://github.com/SignalR/SignalR/blob/3a219c101587333d562f04f30903d50ad9773e1c/src/Microsoft.AspNet.SignalR.Core/Hubs/TypedClientBuilder.cs#L63

I have added `MethodBuilder.DefineGenericParameters` call in BuildMethod method.