### PR TITLE
TrippedOnNull - occasionall NRE in SSE transport

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ServerSentEventsTransport.cs
@@ -53,7 +53,10 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             // if the transport failed to start we want to stop it silently.
             _stop = true;
 
-            _request.Abort();
+            if (_request != null)
+            {
+                _request.Abort();
+            }
         }
 
         private void Reconnect(IConnection connection, string data, CancellationToken disconnectToken)


### PR DESCRIPTION
If the disconnectToken is tripped before any request was made the _request class variable won't be set in which case OnStartFailed would throw because it tried to call `_request.Abort()`. Adding a null check to prevent the NRE.

Fixes #3376