### PR TITLE
ForYouTheStoreIsClosed

### DIFF
--- a/build/Build.proj
+++ b/build/Build.proj
@@ -81,7 +81,7 @@
     <!-- Only build the following clients if the SDK is installed -->
     <Projects Include="$(ProjectRoot)\src\Microsoft.AspNet.SignalR.Client.Portable\Microsoft.AspNet.SignalR.Client.Portable.csproj">
       <Build Condition="!$(WP8SDKInstalled)">false</Build>
-      <Platform>portable-net45+sl5+netcore45+wp8+wp81</Platform>
+      <Platform>portable-net45+sl50+win+wpa81+wp80</Platform>
     </Projects>
     <Projects Include="$(ProjectRoot)\src\Microsoft.AspNet.SignalR.Client.Portable\Microsoft.AspNet.SignalR.Client.Portable.csproj">
       <!--

--- a/nuspecs/Microsoft.AspNet.SignalR.Client.nuspec
+++ b/nuspecs/Microsoft.AspNet.SignalR.Client.nuspec
@@ -36,8 +36,8 @@
     <file src="Net40\Microsoft.AspNet.SignalR.Client.xml" target="lib\net40" />
     <file src="Net45\Microsoft.AspNet.SignalR.Client.dll" target="lib\net45" />
     <file src="Net45\Microsoft.AspNet.SignalR.Client.xml" target="lib\net45" />
-    <file src="portable-net45+sl5+netcore45+wp8+wp81\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-net45+sl5+netcore45+wp8+wp81" />
-    <file src="portable-net45+sl5+netcore45+wp8+wp81\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-net45+sl5+netcore45+wp8+wp81" />
+    <file src="portable-net45+sl50+win+wpa81+wp80\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-net45+sl50+win+wpa81+wp80" />
+    <file src="portable-net45+sl50+win+wpa81+wp80\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-net45+sl50+win+wpa81+wp80" />
     <file src="portable-win81+wpa81\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-win81+wpa81" />
     <file src="portable-win81+wpa81\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-win81+wpa81" />
     <file src="portable-win81+wpa81\Microsoft.AspNet.SignalR.Client.Store.dll" target="lib\portable-win81+wpa81" />


### PR DESCRIPTION
When a project targeted both net45 and wpa81 or win8 we did not have a subset that could satisfy this. The store websocket transport can only be used if an app/lib targets wpa81 and/or win8 since it is using WinRT APIs. If the app/lib targets any other platform in addition to wpa81/win8 the store websocket cannot be used and therefore we must not install it. Adding wpa81/win8 platforms to the folder containing just the portable version of Microsoft.AspNet.SignalR.Client.dll will do the trick - this folder will be selected if the application targets any other platform in addition to wpa81/win8

Fixes #3393