### PR TITLE
HopeIsTheOnlyStrategy - fixing hangs when creating Perf Counters

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNet.SignalR.Tracing;
 using Microsoft.Owin.Infrastructure;
 using Microsoft.Owin.Security.DataProtection;
 using Microsoft.Owin.Extensions;
+using System.Globalization;
 
 namespace Owin
 {
@@ -161,6 +162,7 @@ namespace Owin
         [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling", Justification = "This class wires up new dependencies from the host")]
         private static IAppBuilder UseSignalRMiddleware<T>(this IAppBuilder builder, params object[] args)
         {
+            EnsureValidCulture();
             ConnectionConfiguration configuration = null;
 
             // Ensure we have the conversions for MS.Owin so that
@@ -243,6 +245,27 @@ namespace Owin
             builder.UseStageMarker(PipelineStage.PostAuthorize);
 
             return builder;
+        }
+
+        private static void EnsureValidCulture()
+        {
+            // The CultureInfo may leak across app domains which may cause hangs. The most prominent
+            // case in SignalR are MapSignalR hangs when creating Performance Counters (#3414).
+            // See https://github.com/SignalR/SignalR/issues/3414#issuecomment-152733194 for more details.
+            var culture = CultureInfo.CurrentCulture;
+            while (!culture.Equals(CultureInfo.InvariantCulture))
+            {
+                culture = culture.Parent;
+            }
+
+            if (ReferenceEquals(culture, CultureInfo.InvariantCulture))
+            {
+                return;
+            }
+
+            var thread = Thread.CurrentThread;
+            thread.CurrentCulture = CultureInfo.GetCultureInfo(thread.CurrentCulture.Name);
+            thread.CurrentUICulture = CultureInfo.GetCultureInfo(thread.CurrentUICulture.Name);
         }
     }
 }


### PR DESCRIPTION
The theory is that tha hangs are caused by a CultureInfo that leaked
from a different AppDomain (see this blog post for more details:
(http://www.zpqrtbnk.net/posts/appdomains-threads-cultureinfos-and-paracetamol).
Unfortunately, I was not however able to reproduce the issue (tried both English
and non-English Windows) but hope it will fix #3414 as indicated in the discussion
and the above blog post.