### PR TITLE
LoadTestHarness has incorrectly named "X-UA-Compatibility" meta tag

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/LoadGenerator.html
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/LoadGenerator.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-    <meta http-equiv="X-UA-Compatibility" content="IE=Edge" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <title>Load Generator</title>
     <style>
         body { font-family: 'Segoe UI', Arial, Helvetica; font-size: 24px; }


### PR DESCRIPTION
Renaming "X-UA-Compatibility" to "X-UA-Compatible"... Although it'd be better to send this as an HTTP response header rather than as a <meta> tag, since sites accessed on the same intranet ignore the meta tag and only respect the response header.
