### PR TITLE
use default Redis Database from ConnectionString

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/Microsoft.AspNet.SignalR.Redis.csproj
+++ b/src/Microsoft.AspNet.SignalR.Redis/Microsoft.AspNet.SignalR.Redis.csproj
@@ -37,8 +37,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StackExchange.Redis.StrongName">
-      <HintPath>..\..\packages\StackExchange.Redis.StrongName.1.0.320\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+    <Reference Include="StackExchange.Redis.StrongName, Version=1.1.0.0, Culture=neutral, PublicKeyToken=c219ff1ca8c2ce46, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.StrongName.1.1.603\lib\net45\StackExchange.Redis.StrongName.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -80,7 +81,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\Common\Microsoft.AspNet.SignalR.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Microsoft.AspNet.SignalR.Redis/RedisScaleoutConfiguration.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisScaleoutConfiguration.cs
@@ -30,6 +30,8 @@ namespace Microsoft.AspNet.SignalR
             }
 
             ConnectionString = connectionString;
+            var options = ConfigurationOptions.Parse(connectionString);
+            Database = options.DefaultDatabase.GetValueOrDefault(0);
             EventKey = eventKey;
         }
 

--- a/src/Microsoft.AspNet.SignalR.Redis/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Redis/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StackExchange.Redis.StrongName" version="1.0.320" targetFramework="net45" />
+  <package id="StackExchange.Redis.StrongName" version="1.1.603" targetFramework="net45" />
 </packages>

--- a/tests/Microsoft.AspNet.SignalR.Redis.Tests/RedisMessageBusFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Redis.Tests/RedisMessageBusFacts.cs
@@ -109,6 +109,13 @@ namespace Microsoft.AspNet.SignalR.Redis.Tests
             Assert.True(restoreLatestValueForKey, "RestoreLatestValueForKey not invoked");
         }
 
+        [Fact]
+        public void DatabaseFromConnectionstringIsUsed()
+        {
+            var configuration = new RedisScaleoutConfiguration("localhost,defaultDatabase=5", String.Empty);
+            Assert.Equal(configuration.Database, 5);
+        }
+
         private Mock<IRedisConnection> GetMockRedisConnection()
         {
             var redisConnection = new Mock<IRedisConnection>();


### PR DESCRIPTION
- update StackExchange.Redis to 1.1.603 (to include [c7be31](https://github.com/StackExchange/StackExchange.Redis/commit/c7be31107e8e684ba805253b1fdd66a6017f725b))
- parse defaultDatabase from connectionstring
#3714
