### PR TITLE
Supporting newer version of WindowsAzure.ServiceBus

### DIFF
--- a/src/Microsoft.AspNet.SignalR.ServiceBus/Infrastructure/ServiceBusTaskExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/Infrastructure/ServiceBusTaskExtensions.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.md in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.ServiceBus.Messaging;
 
@@ -7,9 +10,38 @@ namespace Microsoft.AspNet.SignalR.ServiceBus.Infrastructure
 {
     public static class ServiceBusTaskExtensions
     {
-        public static Task SendAsync(this TopicClient client, BrokeredMessage message)
+        // Stephen Toub http://blogs.msdn.com/b/pfxteam/archive/2011/06/27/10179452.aspx
+        static Task<TResult> ToApm<TResult>(this Task<TResult> task, AsyncCallback callback, object state)
         {
-            return Task.Factory.FromAsync((cb, state) => client.BeginSend((BrokeredMessage)state, cb, null), client.EndSend, message);
+            var tcs = new TaskCompletionSource<TResult>(state);
+
+            task.ContinueWith(delegate
+            {
+                if (task.IsFaulted) tcs.TrySetException(task.Exception.InnerExceptions);
+                else if (task.IsCanceled) tcs.TrySetCanceled();
+                else tcs.TrySetResult(task.Result);
+
+                callback?.Invoke(tcs.Task);
+
+            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
+            return tcs.Task;
         }
+
+        public static IAsyncResult BeginReceiveBatch(this MessageReceiver mr, int messageCount,
+            TimeSpan timeSpan, AsyncCallback callback, object state)
+        {
+            return mr.ReceiveBatchAsync(messageCount, timeSpan).ToApm(callback, state);
+        }
+
+        public static IEnumerable<BrokeredMessage> EndReceiveBatch(this MessageReceiver mr, IAsyncResult asyncResult)
+        {
+            try
+            {
+                return ((Task<IEnumerable<BrokeredMessage>>)asyncResult).Result;
+            }
+            catch (AggregateException ae) { throw ae.InnerException; }
+        }
+
     }
 }

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/Microsoft.AspNet.SignalR.ServiceBus.csproj
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/Microsoft.AspNet.SignalR.ServiceBus.csproj
@@ -39,8 +39,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WindowsAzure.ServiceBus.2.1.2.0\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
+    <Reference Include="Microsoft.ServiceBus, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.ServiceBus.3.2.4\lib\net45-full\Microsoft.ServiceBus.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/ServiceBusConnection.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.ServiceBus;
 using Microsoft.ServiceBus.Messaging;
+using Microsoft.AspNet.SignalR.ServiceBus.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.ServiceBus
 {

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/packages.config
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net40" />
-  <package id="WindowsAzure.ServiceBus" version="2.1.2.0" targetFramework="net45" />
+  <package id="WindowsAzure.ServiceBus" version="3.2.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- using extension methods to backfill the missing APM methods `BeginReceiveBatch` and `EndReceiveBatch` in the latest `WindowsAzure.ServiceBus` NuGet packages
- referenced the latest `WindowsAzure.ServiceBus` NuGet Package (3.2.4 at the time of making this), but probably could rely on earlier 3.x versions if that is preferable.
- have tested this in production in Azure, all seems to be working fine.
#3548
