### PR TITLE
move UWP Client JSON.Net dep back to 6.0.4

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.UWP/project.json
+++ b/src/Microsoft.AspNet.SignalR.Client.UWP/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.0.0",
-    "Newtonsoft.Json": "7.0.1"
+    "Newtonsoft.Json": "6.0.4"
   },
   "frameworks": {
     "uap10.0": {}


### PR DESCRIPTION
Fixes #3736 

Verified locally that this works with the UWP client

/cc @muratg @BrennanConroy @moozzyk 