### PR TITLE
Fix license link on github pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
 
 <h2>LICENSE</h2>
 
-<p><a href="https://github.com/SignalR/SignalR/blob/master/LICENSE.md">Apache 2.0 License</a></p>
+<p><a href="https://github.com/SignalR/SignalR/blob/master/LICENSE.txt">Apache 2.0 License</a></p>
 
 <h2>Building the source</h2>
 


### PR DESCRIPTION
Despite PR #3768 link to license file is still broken on signalr.net
This PR is an attempt to fix it.