### PR TITLE
OutOfBodyExperience - removing IFrame from body

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.transports.foreverFrame.js
@@ -212,8 +212,8 @@
                 }
 
                 // Ensure the iframe is where we left it
-                if (connection.frame.parentNode === window.document.body) {
-                    window.document.body.removeChild(connection.frame);
+                if (connection.frame.parentNode === window.document.documentElement) {
+                    window.document.documentElement.removeChild(connection.frame);
                 }
 
                 delete transportLogic.foreverFrame.connections[connection.frameId];


### PR DESCRIPTION
See commit c9200820823395b1b31d3b800938568e496ca2c5 by moozzyk on Aug 13, 2014

foreverFrame was moved to documentElement however stop was still looking for it in the body.  End result was connection was disposed but frame survived causing null reference errors to be thrown.

Fixes #2795