### PR TITLE
Added EXE support (for OWIN self-hosted SignalR hubs)

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Utils/Commands/GenerateHubProxyCommand.cs
+++ b/src/Microsoft.AspNet.SignalR.Utils/Commands/GenerateHubProxyCommand.cs
@@ -38,8 +38,9 @@ namespace Microsoft.AspNet.SignalR.Utils
             string path = null;
             string outputPath = null;
             string url = null;
+            var includeExecutables = false;
 
-            ParseArguments(args, out url, out path, out outputPath);
+            ParseArguments(args, out url, out path, out outputPath, out includeExecutables);
 
             if (String.IsNullOrEmpty(outputPath))
             {
@@ -53,15 +54,20 @@ namespace Microsoft.AspNet.SignalR.Utils
                 outputPath = Path.Combine(outputPath, "server.js");
             }
 
-            OutputHubs(path, url, outputPath);
+            OutputHubs(path, url, outputPath, includeExecutables);
         }
 
-        private void OutputHubs(string path, string url, string outputPath)
+        private void OutputHubs(string path, string url, string outputPath, bool includeExecutables)
         {
             path = path ?? Directory.GetCurrentDirectory();
             url = url ?? "/signalr";
 
-            var assemblies = Directory.GetFiles(path, "*.dll", SearchOption.AllDirectories);
+            var assemblies = Directory.GetFiles(path, "*.dll", SearchOption.AllDirectories).ToList();
+            if (includeExecutables)
+            {
+                assemblies.InsertRange(0, Directory.GetFiles(path, "*.exe", SearchOption.AllDirectories));
+            }
+
             var tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             Info(String.Format(CultureInfo.CurrentCulture, Resources.Notify_CreatingTempDirectory, tempPath));
@@ -85,7 +91,7 @@ namespace Microsoft.AspNet.SignalR.Utils
 
             var generator = (JavaScriptGenerator)domain.CreateInstanceAndUnwrap(typeof(Program).Assembly.FullName,
                                                                                 typeof(JavaScriptGenerator).FullName);
-            var js = generator.GenerateProxy(path, url, Warning);
+            var js = generator.GenerateProxy(path, url, Warning, includeExecutables);
 
             Generate(outputPath, js);
         }
@@ -102,11 +108,12 @@ namespace Microsoft.AspNet.SignalR.Utils
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1307:SpecifyStringComparison", MessageId = "System.String.StartsWith(System.String)", Justification = "All starts with methods are SignalR/networking terms.  Will not change via localization.")]
-        private static void ParseArguments(string[] args, out string url, out string path, out string outputPath)
+        private static void ParseArguments(string[] args, out string url, out string path, out string outputPath, out bool includeExecutables)
         {
             path = null;
             url = null;
             outputPath = null;
+            includeExecutables = false;
 
             foreach (var a in args)
             {
@@ -126,6 +133,9 @@ namespace Microsoft.AspNet.SignalR.Utils
                         break;
                     case "o":
                         outputPath = arg.Value;
+                        break;
+                    case "exe":
+                        includeExecutables = true;
                         break;
                 }
             }
@@ -148,9 +158,15 @@ namespace Microsoft.AspNet.SignalR.Utils
         public class JavaScriptGenerator : MarshalByRefObject
         {
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Called from non-static.")]
-            public string GenerateProxy(string path, string url, Action<string> warning)
+            public string GenerateProxy(string path, string url, Action<string> warning, bool includeExecutables)
             {
-                foreach (var assemblyPath in Directory.GetFiles(path, "*.dll", SearchOption.AllDirectories))
+                var assemblies = Directory.GetFiles(path, "*.dll", SearchOption.AllDirectories).ToList();
+                if (includeExecutables)
+                {
+                    assemblies.InsertRange(0, Directory.GetFiles(path, "*.exe", SearchOption.AllDirectories));
+                }
+
+                foreach (var assemblyPath in assemblies)
                 {
                     try
                     {


### PR DESCRIPTION
The Signalr.exe utility only scanned for DLL's.  In the case of a self-hosted OWIN process, the hubs are generally part of the EXE.  Added a /exe flag that will search EXE's first, followed by DLL's.