### PR TITLE
Removing extraneous call to IHttpClient.Initialize

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
@@ -57,8 +57,6 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             var startUrl = UrlBuilder.BuildStart(connection, transport, connectionData);
 
-            httpClient.Initialize(connection);
-
             return httpClient.Get(startUrl, connection.PrepareRequest, isLongRunning: false)
                             .Then(response => response.ReadAsString());
         }


### PR DESCRIPTION
An extraneous call to IHttpClient.Initialize when sending the start requests resets httpClients in the DefaultHttpClient. This may break load balancers and prevent reusing HTTPS connections (SSL negotation will happen twice - once for negotiate and once for start)

More: #3829