### PR TITLE
'signalr/negotiate' CustomAuthorizeAttribute conflicts 

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
@@ -141,9 +141,13 @@ namespace Microsoft.AspNet.SignalR.Hubs
                 }
             }
 
-            return base.AuthorizeRequest(request);
+            //bug fixed:otherwise when only use like paramaterless '{HOSTNAME}/signalr/negotiate', it always returns ConnectionToken without Authorization
+            if (request.LocalPath.ToLower().EndsWith("/negotiate"))
+                return false;
+            else
+                return base.AuthorizeRequest(request);
         }
-
+        
         /// <summary>
         /// Processes the hub's incoming method calls.
         /// </summary>


### PR DESCRIPTION
when we use **CustomAuthorizeAttribute** on our signalr server, anybody who call `signalr/negotiate` without parameters(malicious person) can give access from signalr **without visit** the CustomAuthorizeAttribute

**Examples**
`http://shootr.signalr.net/signalr/negotiate`
**and**
`http://shootr.signalr.net/signalr/negotiate?connectionData=%5B%7B%22name%22%3A%22h%22%7D%5D&clientProtocol=1.3&_=1485297186225`

- firstone can access without visit CustomAuthorizeAttr and their **"ProtocolVersion":"1.2"**
- secondone visits to CustomAuthorizeAttr then maybe it can be declined and their **"ProtocolVersion":"1.3"**

am i wrong?. Can somebody enlighten me.