### PR TITLE
add netstd to client nuspec to support xamarinmac20

### DIFF
--- a/nuspecs/Microsoft.AspNet.SignalR.Client.nuspec
+++ b/nuspecs/Microsoft.AspNet.SignalR.Client.nuspec
@@ -36,6 +36,8 @@
     <file src="Net40\Microsoft.AspNet.SignalR.Client.xml" target="lib\net40" />
     <file src="Net45\Microsoft.AspNet.SignalR.Client.dll" target="lib\net45" />
     <file src="Net45\Microsoft.AspNet.SignalR.Client.xml" target="lib\net45" />
+    <file src="portable-net45+sl50+win+wpa81+wp80\Microsoft.AspNet.SignalR.Client.dll" target="lib\netstandard1.1" />
+    <file src="portable-net45+sl50+win+wpa81+wp80\Microsoft.AspNet.SignalR.Client.xml" target="lib\netstandard1.1" />
     <file src="portable-net45+sl50+win+wpa81+wp80\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-net45+sl50+win+wpa81+wp80" />
     <file src="portable-net45+sl50+win+wpa81+wp80\Microsoft.AspNet.SignalR.Client.xml" target="lib\portable-net45+sl50+win+wpa81+wp80" />
     <file src="portable-win81+wpa81\Microsoft.AspNet.SignalR.Client.dll" target="lib\portable-win81+wpa81" />


### PR DESCRIPTION
Although it should be possible, SignalR cannot currently be added to xamarinmac20 (Xamarin Mac Mobile Framework) because the package targets 'portable-net45+sl50+win+wpa81+wp80' which the nuget installer in Xamarin Studio does not recognize as being valid. Targeting netstandard1.1 however, will allow it to work. 