### PR TITLE
Subscribing to events before starting processing webSocket messages

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/OwinWebSocketHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/OwinWebSocketHandler.cs
@@ -48,12 +48,14 @@ namespace Microsoft.AspNet.SignalR.Owin
     internal class OwinWebSocketHandler
     {
         private readonly Func<IWebSocket, Task> _callback;
+        private readonly Action<IWebSocket> _prepareWebSocket;
 
         private readonly int? _maxIncomingMessageSize;
 
-        public OwinWebSocketHandler(Func<IWebSocket, Task> callback, int? maxIncomingMessageSize)
+        public OwinWebSocketHandler(Func<IWebSocket, Task> callback, Action<IWebSocket> prepareWebsocket, int? maxIncomingMessageSize)
         {
             _callback = callback;
+            _prepareWebSocket = prepareWebsocket;
             _maxIncomingMessageSize = maxIncomingMessageSize;
         }
 
@@ -75,6 +77,7 @@ namespace Microsoft.AspNet.SignalR.Owin
 
             var cts = new CancellationTokenSource();
             var webSocketHandler = new DefaultWebSocketHandler(_maxIncomingMessageSize);
+            _prepareWebSocket(webSocketHandler);
             var task = webSocketHandler.ProcessWebSocketRequestAsync(webSocket, cts.Token);
 
             RunWebSocketHandler(webSocketHandler, cts);

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/WebSocketTransport.cs
@@ -102,11 +102,6 @@ namespace Microsoft.AspNet.SignalR.Transports
             {
                 return AcceptWebSocketRequest(socket =>
                 {
-                    _socket = socket;
-                    socket.OnClose = _closed;
-                    socket.OnMessage = _message;
-                    socket.OnError = _error;
-
                     return ProcessRequestCore(connection);
                 });
             }
@@ -148,7 +143,14 @@ namespace Microsoft.AspNet.SignalR.Transports
                 return _context.Response.End(Resources.Error_NotWebSocketRequest);
             }
 
-            var handler = new OwinWebSocketHandler(callback, _maxIncomingMessageSize);
+            Action<IWebSocket> prepareWebSocket = socket => {
+                _socket = socket;
+                socket.OnClose = _closed;
+                socket.OnMessage = _message;
+                socket.OnError = _error;
+            };
+
+            var handler = new OwinWebSocketHandler(callback, prepareWebSocket, _maxIncomingMessageSize);
             accept(null, handler.ProcessRequest);
             return TaskAsyncHelper.Empty;
         }


### PR DESCRIPTION
Previously we would subscribe to webSocketHandler events after starting processing webSocket messages this could lead to missing some events. After the change we would subscribe to webSocketHandler events before we start processing webSocket messages.