### PR TITLE
Fix for #3895

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.NetStandard/Microsoft.AspNet.SignalR.Client.NetStandard.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.NetStandard/Microsoft.AspNet.SignalR.Client.NetStandard.csproj
@@ -224,6 +224,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\CancellationTokenExtensions.cs">
       <Link>Infrastructure\CancellationTokenExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DisposableAction.cs">
       <Link>Infrastructure\DisposableAction.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNet.SignalR.Client.Portable/Microsoft.AspNet.SignalR.Client.Portable.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.Portable/Microsoft.AspNet.SignalR.Client.Portable.csproj
@@ -229,6 +229,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\CancellationTokenExtensions.cs">
       <Link>Infrastructure\CancellationTokenExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DisposableAction.cs">
       <Link>Infrastructure\DisposableAction.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNet.SignalR.Client.Store/Microsoft.AspNet.SignalR.Client.Store.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.Store/Microsoft.AspNet.SignalR.Client.Store.csproj
@@ -232,6 +232,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\CancellationTokenExtensions.cs">
       <Link>Infrastructure\CancellationTokenExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DisposableAction.cs">
       <Link>Infrastructure\DisposableAction.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNet.SignalR.Client.UWP/Microsoft.AspNet.SignalR.Client.UWP.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.UWP/Microsoft.AspNet.SignalR.Client.UWP.csproj
@@ -253,6 +253,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Client\ObservableConnection.cs">
       <Link>ObservableConnection.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="Resources.Designer.cs" />
     <Compile Include="..\Microsoft.AspNet.SignalR.Client\StateChange.cs">
       <Link>StateChange.cs</Link>

--- a/src/Microsoft.AspNet.SignalR.Client.WinRT/Microsoft.AspNet.SignalR.Client.WinRT.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client.WinRT/Microsoft.AspNet.SignalR.Client.WinRT.csproj
@@ -315,6 +315,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
       <Link>TaskAsyncHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Hubs/HubProxy.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Hubs
 {
@@ -101,7 +102,7 @@ namespace Microsoft.AspNet.SignalR.Client.Hubs
                     : JValue.CreateNull();
             }
 
-            var tcs = new TaskCompletionSource<TResult>();
+            var tcs = new DispatchingTaskCompletionSource<TResult>();
             var callbackId = _connection.RegisterCallback(result =>
             {
                 if (result != null)

--- a/src/Microsoft.AspNet.SignalR.Client/Microsoft.AspNet.SignalR.Client.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client/Microsoft.AspNet.SignalR.Client.csproj
@@ -52,6 +52,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\CancellationTokenExtensions.cs">
       <Link>Infrastructure\CancellationTokenExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DisposableAction.cs">
       <Link>Infrastructure\DisposableAction.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNet.SignalR.Client45/Microsoft.AspNet.SignalR.Client45.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client45/Microsoft.AspNet.SignalR.Client45.csproj
@@ -168,6 +168,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\CancellationTokenExtensions.cs">
       <Link>Infrastructure\CancellationTokenExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DisposableAction.cs">
       <Link>Infrastructure\DisposableAction.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
@@ -549,54 +549,6 @@ namespace Microsoft.AspNet.SignalR.Hubs
             return Transport.Send(hubResult);
         }
 
-        private static void ContinueWith<T>(Task<T> task, TaskCompletionSource<object> tcs)
-        {
-            if (task.IsCompleted)
-            {
-                // Fast path for tasks that completed synchronously
-                ContinueSync<T>(task, tcs);
-            }
-            else
-            {
-                ContinueAsync<T>(task, tcs);
-            }
-        }
-
-        private static void ContinueSync<T>(Task<T> task, TaskCompletionSource<object> tcs)
-        {
-            if (task.IsFaulted)
-            {
-                tcs.TrySetUnwrappedException(task.Exception);
-            }
-            else if (task.IsCanceled)
-            {
-                tcs.TrySetCanceled();
-            }
-            else
-            {
-                tcs.TrySetResult(task.Result);
-            }
-        }
-
-        private static void ContinueAsync<T>(Task<T> task, TaskCompletionSource<object> tcs)
-        {
-            task.ContinueWithPreservedCulture(t =>
-            {
-                if (t.IsFaulted)
-                {
-                    tcs.TrySetUnwrappedException(t.Exception);
-                }
-                else if (t.IsCanceled)
-                {
-                    tcs.TrySetCanceled();
-                }
-                else
-                {
-                    tcs.TrySetResult(t.Result);
-                }
-            });
-        }
-
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "It is instantiated through JSON deserialization.")]
         private class ClientHubInfo
         {

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/DispatchingTaskCompletionSource.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/DispatchingTaskCompletionSource.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.SignalR.Infrastructure
+{
+    internal class DispatchingTaskCompletionSource<TResult>
+    {
+        private readonly TaskCompletionSource<TResult> _tcs = new TaskCompletionSource<TResult>();
+
+        public Task<TResult> Task
+        {
+            get { return _tcs.Task; }
+        }
+
+        public void SetCanceled()
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.SetCanceled());
+        }
+
+        public void SetException(Exception exception)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.SetException(exception));
+        }
+
+        public void SetException(IEnumerable<Exception> exceptions)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.SetException(exceptions));
+        }
+
+        public void SetResult(TResult result)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.SetResult(result));
+        }
+
+        public void TrySetCanceled()
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.TrySetCanceled());
+        }
+
+        public void TrySetException(Exception exception)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.TrySetException(exception));
+        }
+
+        public void TrySetException(IEnumerable<Exception> exceptions)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.TrySetException(exceptions));
+        }
+
+        public void TrySetUnwrappedException(Exception e)
+        {
+            var aggregateException = e as AggregateException;
+            if (aggregateException != null)
+            {
+                _tcs.TrySetException(aggregateException.InnerExceptions);
+            }
+            else
+            {
+                _tcs.TrySetException(e);
+            }
+        }
+
+        public void TrySetResult(TResult result)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.TrySetResult(result));
+        }
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
+++ b/src/Microsoft.AspNet.SignalR.Core/Microsoft.AspNet.SignalR.Core.csproj
@@ -105,6 +105,7 @@
     <Compile Include="ConnectionMessage.cs" />
     <Compile Include="Infrastructure\DataProtectionProviderProtectedData.cs" />
     <Compile Include="Infrastructure\DefaultProtectedData.cs" />
+    <Compile Include="Infrastructure\DispatchingTaskCompletionSource.cs" />
     <Compile Include="Infrastructure\IMemoryPool.cs" />
     <Compile Include="Infrastructure\MemoryPool.cs" />
     <Compile Include="Infrastructure\MemoryPoolTextWriter.cs" />

--- a/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
@@ -161,7 +161,7 @@ namespace Microsoft.AspNet.SignalR
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is a shared file")]
 #if SERVER
         private static void AttachFaultedContinuation<TTask>(TTask task, Action<AggregateException, object> handler, object state, TraceSource traceSource) where TTask : Task
-#else      
+#else
         private static void AttachFaultedContinuation<TTask>(TTask task, Action<AggregateException, object> handler, object state, IConnection connection) where TTask : Task
 #endif
         {
@@ -1353,6 +1353,25 @@ namespace Microsoft.AspNet.SignalR
         private static class TaskCache<T>
         {
             public static Task<T> Empty = MakeTask<T>(default(T));
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is a shared file")]
+        public static void Dispatch(Action action)
+        {
+#if PORTABLE
+            ThreadPool.QueueUserWorkItem(_ =>
+#elif NETFX_CORE || NETSTANDARD
+            Task.Run(() =>
+#else
+            ThreadPool.UnsafeQueueUserWorkItem(_ =>
+#endif
+            {
+                action();
+            }
+#if !(NETFX_CORE || NETSTANDARD)
+, state: null
+#endif
+);
         }
     }
 }


### PR DESCRIPTION
Fixing an issue where user's code would run a continuation of `HubProxy.Invoke` on a SignalR thread because we were using TaskCompletionSource with default settings. If the user's code blocked it would completely block the receive queue and the user will no longer get any notifications even though the client processes them and add to the queue.  The fix is to dispatch the completion of `HubProxy.Invoke` to a different thread (note that we can't use `TaskCreationOptions.RunContinuationsAsynchronously` because some platforms we compile for do not support this).