### PR TITLE
Replacing TaskCompletionSource with DispatchingTaskCompletionSource

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Microsoft.AspNet.SignalR.LoadTestHarness.csproj
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/Microsoft.AspNet.SignalR.LoadTestHarness.csproj
@@ -26,6 +26,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -172,9 +173,6 @@
     <None Include="wcat\wcat.bat" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\..\src\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
-      <Link>TaskAsyncHelper.cs</Link>
-    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.Samples\Hubs\RealtimeBroadcast\HighFrequencyTimer.cs">
       <Link>HighFrequencyTimer.cs</Link>
     </Compile>

--- a/samples/Microsoft.AspNet.SignalR.LoadTestHarness/TestConnection.cs
+++ b/samples/Microsoft.AspNet.SignalR.LoadTestHarness/TestConnection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.SignalR.LoadTestHarness
             {
                 Connection.Broadcast(data);
             }
-            return TaskAsyncHelper.Empty;
+            return Task.FromResult<object>(null);
         }
     }
 

--- a/src/Microsoft.AspNet.SignalR.Client.Store/Transports/WebSocketTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client.Store/Transports/WebSocketTransport.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNet.SignalR.Client.Http;
 using Windows.Networking.Sockets;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
 using Windows.Storage.Streams;
+using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Client.Transports
 {
@@ -162,7 +163,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     ex = new InvalidOperationException(ResourcesStore.GetResourceString("Error_DataCannotBeSentDuringWebSocketReconnect"));
                 }
 
-                var tcs = new TaskCompletionSource<object>();
+                var tcs = new DispatchingTaskCompletionSource<object>();
                 tcs.SetException(ex);
                 return tcs.Task;
             }

--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.SignalR.Client
 
         private Task _lastQueuedReceiveTask;
 
-        private TaskCompletionSource<object> _startTcs;
+        private DispatchingTaskCompletionSource<object> _startTcs;
 
         // Used to synchronize state changes
         private readonly object _stateLock = new object();
@@ -78,7 +78,7 @@ namespace Microsoft.AspNet.SignalR.Client
         // Used to synchronize starting and stopping specifically
         private readonly object _startLock = new object();
 
-        // Used to ensure we don't write to the Trace TextWriter from multiple threads simultaneously 
+        // Used to ensure we don't write to the Trace TextWriter from multiple threads simultaneously
         private readonly object _traceLock = new object();
 
         private DateTime _lastMessageAt;
@@ -456,7 +456,7 @@ namespace Microsoft.AspNet.SignalR.Client
                 }
 
                 _disconnectCts = new CancellationTokenSource();
-                _startTcs = new TaskCompletionSource<object>();
+                _startTcs = new DispatchingTaskCompletionSource<object>();
                 _receiveQueueMonitor = new TaskQueueMonitor(this, DeadlockErrorTimeout);
                 _receiveQueue = new TaskQueue(_startTcs.Task, _receiveQueueMonitor);
                 _lastQueuedReceiveTask = TaskAsyncHelper.Empty;

--- a/src/Microsoft.AspNet.SignalR.Client/Http/IResponseExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/IResponseExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Client.Transports;
+using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Client.Http
 {
@@ -20,7 +21,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
             var stream = response.GetStream();
             var reader = new AsyncStreamReader(stream);
             var result = new StringBuilder();
-            var resultTcs = new TaskCompletionSource<string>();
+            var resultTcs = new DispatchingTaskCompletionSource<string>();
 
             reader.Data = buffer =>
             {

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/StreamExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/StreamExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exceptions are flowed back to the caller.")]
         private static Task<T> FromAsync<T>(Func<AsyncCallback, IAsyncResult> begin, Func<IAsyncResult, T> end)
         {
-            var tcs = new TaskCompletionSource<T>();
+            var tcs = new DispatchingTaskCompletionSource<T>();
             try
             {
                 var result = begin(ar =>
@@ -70,7 +70,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exceptions are flowed back to the caller.")]
-        private static void CompleteAsync<T>(TaskCompletionSource<T> tcs, IAsyncResult ar, Func<IAsyncResult, T> end)
+        private static void CompleteAsync<T>(DispatchingTaskCompletionSource<T> tcs, IAsyncResult ar, Func<IAsyncResult, T> end)
         {
             try
             {

--- a/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportInitializationHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Infrastructure/TransportInitializationHandler.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
     internal class TransportInitializationHandler
     {
         private readonly ThreadSafeInvoker _initializationInvoker;
-        private readonly TaskCompletionSource<object> _initializationTask;
+        private readonly DispatchingTaskCompletionSource<object> _initializationTask;
         private readonly IConnection _connection;
         private readonly IHttpClient _httpClient;
         private readonly string _connectionData;
@@ -49,7 +49,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
             _transport = transport;
             _transportHelper = transportHelper;
 
-            _initializationTask = new TaskCompletionSource<object>();
+            _initializationTask = new DispatchingTaskCompletionSource<object>();
             _initializationInvoker = new ThreadSafeInvoker();
 
             // Default event

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Client.Http;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
+using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Client.Transports
 {
@@ -91,7 +92,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
         public Task Start(IConnection connection, string connectionData, CancellationToken disconnectToken)
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new DispatchingTaskCompletionSource<object>();
 
             // Resolve the transport
             ResolveTransport(connection, connectionData, disconnectToken, tcs, _startIndex);
@@ -99,7 +100,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             return tcs.Task;
         }
 
-        private void ResolveTransport(IConnection connection, string data, CancellationToken disconnectToken, TaskCompletionSource<object> tcs, int index)
+        private void ResolveTransport(IConnection connection, string data, CancellationToken disconnectToken, DispatchingTaskCompletionSource<object> tcs, int index)
         {
             // Pick the current transport
             IClientTransport transport = _transports[index];

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
@@ -192,7 +192,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
         {
             // TODO: Make adding parameters here pluggable? IValueProvider? ;)
             HubInvocationProgress progress = GetProgressInstance(methodDescriptor, value => SendProgressUpdate(hub.Context.ConnectionId, tracker, value, hubRequest), Trace);
-            
+
             Task<object> piplineInvocation;
             try
             {
@@ -303,7 +303,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "A faulted task is returned.")]
         internal static Task<object> Incoming(IHubIncomingInvokerContext context)
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new DispatchingTaskCompletionSource<object>();
 
             try
             {
@@ -395,8 +395,8 @@ namespace Microsoft.AspNet.SignalR.Hubs
             var signals = _hubs.SelectMany(info =>
             {
                 var items = new List<string>
-                { 
-                    PrefixHelper.GetHubName(info.Name), 
+                {
+                    PrefixHelper.GetHubName(info.Name),
                     PrefixHelper.GetHubConnectionId(info.CreateQualifiedName(connectionId)),
                 };
 
@@ -407,8 +407,8 @@ namespace Microsoft.AspNet.SignalR.Hubs
 
                 return items;
             })
-            .Concat(new[] 
-            { 
+            .Concat(new[]
+            {
                 PrefixHelper.GetConnectionId(connectionId)
             });
 
@@ -426,7 +426,7 @@ namespace Microsoft.AspNet.SignalR.Hubs
                 return TaskAsyncHelper.Empty;
             }
 
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new DispatchingTaskCompletionSource<object>();
             Task.Factory.ContinueWhenAll(operations, tasks =>
             {
                 DisposeHubs(hubs);
@@ -547,6 +547,55 @@ namespace Microsoft.AspNet.SignalR.Hubs
             Trace.TraceVerbose("Sending hub invocation result to connection {0} using transport {1}", Transport.ConnectionId, Transport.GetType().Name);
 
             return Transport.Send(hubResult);
+        }
+
+        // This method is being used to buld a callback with reflection
+        private static void ContinueWith<T>(Task<T> task, DispatchingTaskCompletionSource<object> tcs)
+        {
+            if (task.IsCompleted)
+            {
+                // Fast path for tasks that completed synchronously
+                ContinueSync<T>(task, tcs);
+            }
+            else
+            {
+                ContinueAsync<T>(task, tcs);
+            }
+        }
+
+        private static void ContinueSync<T>(Task<T> task, DispatchingTaskCompletionSource<object> tcs)
+        {
+            if (task.IsFaulted)
+            {
+                tcs.TrySetUnwrappedException(task.Exception);
+            }
+            else if (task.IsCanceled)
+            {
+                tcs.TrySetCanceled();
+            }
+            else
+            {
+                tcs.TrySetResult(task.Result);
+            }
+        }
+
+        private static void ContinueAsync<T>(Task<T> task, DispatchingTaskCompletionSource<object> tcs)
+        {
+            task.ContinueWithPreservedCulture(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    tcs.TrySetUnwrappedException(t.Exception);
+                }
+                else if (t.IsCanceled)
+                {
+                    tcs.TrySetCanceled();
+                }
+                else
+                {
+                    tcs.TrySetResult(t.Result);
+                }
+            });
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1812:AvoidUninstantiatedInternalClasses", Justification = "It is instantiated through JSON deserialization.")]

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/AckHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/AckHandler.cs
@@ -100,12 +100,12 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
 
         private class AckInfo
         {
-            public TaskCompletionSource<object> Tcs { get; private set; }
+            public DispatchingTaskCompletionSource<object> Tcs { get; private set; }
             public DateTime Created { get; private set; }
 
             public AckInfo()
             {
-                Tcs = new TaskCompletionSource<object>();
+                Tcs = new DispatchingTaskCompletionSource<object>();
                 Created = DateTime.UtcNow;
             }
         }

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/DispatchingTaskCompletionSource.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/DispatchingTaskCompletionSource.cs
@@ -26,6 +26,11 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             TaskAsyncHelper.Dispatch(() => _tcs.SetException(exception));
         }
 
+        public void SetException(IEnumerable<Exception> exceptions)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.SetException(exceptions));
+        }
+
         public void SetResult(TResult result)
         {
             TaskAsyncHelper.Dispatch(() => _tcs.SetResult(result));
@@ -41,16 +46,21 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             TaskAsyncHelper.Dispatch(() => _tcs.TrySetException(exception));
         }
 
+        public void TrySetException(IEnumerable<Exception> exceptions)
+        {
+            TaskAsyncHelper.Dispatch(() => _tcs.TrySetException(exceptions));
+        }
+
         public void SetUnwrappedException(Exception e)
         {
             var aggregateException = e as AggregateException;
             if (aggregateException != null)
             {
-                _tcs.SetException(aggregateException.InnerExceptions);
+                SetException(aggregateException.InnerExceptions);
             }
             else
             {
-                _tcs.SetException(e);
+                SetException(e);
             }
         }
 
@@ -59,11 +69,11 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             var aggregateException = e as AggregateException;
             if (aggregateException != null)
             {
-                _tcs.TrySetException(aggregateException.InnerExceptions);
+                TrySetException(aggregateException.InnerExceptions);
             }
             else
             {
-                _tcs.TrySetException(e);
+                TrySetException(e);
             }
         }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/DispatchingTaskCompletionSource.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/DispatchingTaskCompletionSource.cs
@@ -26,11 +26,6 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             TaskAsyncHelper.Dispatch(() => _tcs.SetException(exception));
         }
 
-        public void SetException(IEnumerable<Exception> exceptions)
-        {
-            TaskAsyncHelper.Dispatch(() => _tcs.SetException(exceptions));
-        }
-
         public void SetResult(TResult result)
         {
             TaskAsyncHelper.Dispatch(() => _tcs.SetResult(result));
@@ -46,9 +41,17 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             TaskAsyncHelper.Dispatch(() => _tcs.TrySetException(exception));
         }
 
-        public void TrySetException(IEnumerable<Exception> exceptions)
+        public void SetUnwrappedException(Exception e)
         {
-            TaskAsyncHelper.Dispatch(() => _tcs.TrySetException(exceptions));
+            var aggregateException = e as AggregateException;
+            if (aggregateException != null)
+            {
+                _tcs.SetException(aggregateException.InnerExceptions);
+            }
+            else
+            {
+                _tcs.SetException(e);
+            }
         }
 
         public void TrySetUnwrappedException(Exception e)

--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/TaskQueue.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/TaskQueue.cs
@@ -43,7 +43,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
             _lastQueuedTask = initialTask;
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is shared code")]        
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is shared code")]
         public TaskQueue(Task initialTask, int maxSize)
         {
             _lastQueuedTask = initialTask;

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutMessageBus.cs
@@ -100,7 +100,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 return StreamManager.Send(0, messages);
             }
 
-            var taskCompletionSource = new TaskCompletionSource<object>();
+            var taskCompletionSource = new DispatchingTaskCompletionSource<object>();
 
             // Group messages by source (connection id)
             var messagesBySource = messages.GroupBy(m => m.Source);
@@ -116,7 +116,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We return a faulted tcs")]
-        private void SendImpl(IEnumerator<IGrouping<string, Message>> enumerator, TaskCompletionSource<object> taskCompletionSource)
+        private void SendImpl(IEnumerator<IGrouping<string, Message>> enumerator, DispatchingTaskCompletionSource<object> taskCompletionSource)
         {
         send:
 

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutStream.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutStream.cs
@@ -304,12 +304,12 @@ namespace Microsoft.AspNet.SignalR.Messaging
             private readonly object _state;
 
             public readonly ScaleoutStream Stream;
-            public readonly TaskCompletionSource<object> TaskCompletionSource;
+            public readonly DispatchingTaskCompletionSource<object> TaskCompletionSource;
 
             public SendContext(ScaleoutStream stream, Func<object, Task> send, object state)
             {
                 Stream = stream;
-                TaskCompletionSource = new TaskCompletionSource<object>();
+                TaskCompletionSource = new DispatchingTaskCompletionSource<object>();
                 _send = send;
                 _state = state;
             }

--- a/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
@@ -271,7 +271,7 @@ namespace Microsoft.AspNet.SignalR
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is a shared file")]
-        public static void ContinueWithNotComplete(this Task task, TaskCompletionSource<object> tcs)
+        public static void ContinueWithNotComplete(this Task task, DispatchingTaskCompletionSource<object> tcs)
         {
             task.ContinueWithPreservedCulture(t =>
             {
@@ -288,7 +288,7 @@ namespace Microsoft.AspNet.SignalR
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This is a shared file")]
-        public static Task ContinueWith(this Task task, TaskCompletionSource<object> tcs)
+        public static Task ContinueWith(this Task task, DispatchingTaskCompletionSource<object> tcs)
         {
             task.ContinueWithPreservedCulture(t =>
             {

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/HttpRequestLifeTime.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/HttpRequestLifeTime.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNet.SignalR.Transports
 {
     internal class HttpRequestLifeTime
     {
-        private readonly TaskCompletionSource<object> _lifetimeTcs;
+        private readonly DispatchingTaskCompletionSource<object> _lifetimeTcs;
         private readonly TransportDisconnectBase _transport;
         private readonly TaskQueue _writeQueue;
         private readonly TraceSource _trace;
@@ -18,7 +18,7 @@ namespace Microsoft.AspNet.SignalR.Transports
 
         public HttpRequestLifeTime(TransportDisconnectBase transport, TaskQueue writeQueue, TraceSource trace, string connectionId)
         {
-            _lifetimeTcs = new TaskCompletionSource<object>();
+            _lifetimeTcs = new DispatchingTaskCompletionSource<object>();
             _transport = transport;
             _trace = trace;
             _connectionId = connectionId;
@@ -67,11 +67,11 @@ namespace Microsoft.AspNet.SignalR.Transports
 
         private class LifetimeContext
         {
-            private readonly TaskCompletionSource<object> _lifetimeTcs;
+            private readonly DispatchingTaskCompletionSource<object> _lifetimeTcs;
             private readonly Exception _error;
             private readonly TransportDisconnectBase _transport;
 
-            public LifetimeContext(TransportDisconnectBase transport, TaskCompletionSource<object> lifeTimetcs, Exception error)
+            public LifetimeContext(TransportDisconnectBase transport, DispatchingTaskCompletionSource<object> lifeTimetcs, Exception error)
             {
                 _transport = transport;
                 _lifetimeTcs = lifeTimetcs;

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/TransportDisconnectBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/TransportDisconnectBase.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Transports
         internal static readonly Func<Task> _emptyTaskFunc = () => TaskAsyncHelper.Empty;
 
         // The TCS that completes when the task returned by PersistentConnection.OnConnected does.
-        internal TaskCompletionSource<object> _connectTcs;
+        internal DispatchingTaskCompletionSource<object> _connectTcs;
 
         // Token that represents the end of the connection based on a combination of
         // conditions (timeout, disconnect, connection forcibly ended, host shutdown)
@@ -255,7 +255,7 @@ namespace Microsoft.AspNet.SignalR.Transports
         public abstract void IncrementConnectionsCount();
 
         public abstract void DecrementConnectionsCount();
-        
+
         public Task Disconnect()
         {
             return Abort(clean: false);
@@ -376,7 +376,7 @@ namespace Microsoft.AspNet.SignalR.Transports
             _requestLifeTime = new HttpRequestLifeTime(this, WriteQueue, Trace, ConnectionId);
 
             // Create the TCS that completes when the task returned by PersistentConnection.OnConnected does.
-            _connectTcs = new TaskCompletionSource<object>();
+            _connectTcs = new DispatchingTaskCompletionSource<object>();
 
             // Create a token that represents the end of this connection's life
             _connectionEndTokenSource = new SafeCancellationTokenSource();

--- a/src/Microsoft.AspNet.SignalR.Redis/Microsoft.AspNet.SignalR.Redis.csproj
+++ b/src/Microsoft.AspNet.SignalR.Redis/Microsoft.AspNet.SignalR.Redis.csproj
@@ -55,6 +55,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
       <Link>Infrastructure\TaskAsyncHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="DependencyResolverExtensions.cs" />
     <Compile Include="IRedisConnection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Microsoft.AspNet.SignalR.ServiceBus/Microsoft.AspNet.SignalR.ServiceBus.csproj
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus/Microsoft.AspNet.SignalR.ServiceBus.csproj
@@ -69,6 +69,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
       <Link>Infrastructure\TaskAsyncHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="DependencyResolverExtensions.cs" />
     <Compile Include="Infrastructure\ServiceBusTaskExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Microsoft.AspNet.SignalR.ServiceBus3/Microsoft.AspNet.SignalR.ServiceBus3.csproj
+++ b/src/Microsoft.AspNet.SignalR.ServiceBus3/Microsoft.AspNet.SignalR.ServiceBus3.csproj
@@ -61,6 +61,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
       <Link>Infrastructure\TaskAsyncHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="..\Microsoft.AspNet.SignalR.ServiceBus\DependencyResolverExtensions.cs">
       <Link>DependencyResolverExtensions.cs</Link>
     </Compile>

--- a/src/Microsoft.AspNet.SignalR.SqlServer/DbOperation.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/DbOperation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.AspNet.SignalR.Infrastructure;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -22,7 +23,6 @@ namespace Microsoft.AspNet.SignalR.SqlServer
         public DbOperation(string connectionString, string commandText, TraceSource traceSource)
             : this(connectionString, commandText, traceSource, SqlClientFactory.Instance.AsIDbProviderFactory())
         {
-            
         }
 
         public DbOperation(string connectionString, string commandText, TraceSource traceSource, IDbProviderFactory dbProviderFactory)
@@ -67,7 +67,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
 
         public virtual Task<int> ExecuteNonQueryAsync()
         {
-            var tcs = new TaskCompletionSource<int>();
+            var tcs = new DispatchingTaskCompletionSource<int>();
             Execute(cmd => cmd.ExecuteNonQueryAsync(), tcs);
             return tcs.Task;
         }
@@ -122,7 +122,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
         {
             T result = default(T);
             IDbConnection connection = null;
-            
+
             try
             {
                 connection = _dbProviderFactory.CreateConnection();
@@ -156,10 +156,10 @@ namespace Microsoft.AspNet.SignalR.SqlServer
 
         [SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Disposed in async Finally block"),
          SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposed in async Finally block")]
-        private void Execute<T>(Func<IDbCommand, Task<T>> commandFunc, TaskCompletionSource<T> tcs)
+        private void Execute<T>(Func<IDbCommand, Task<T>> commandFunc, DispatchingTaskCompletionSource<T> tcs)
         {
             IDbConnection connection = null;
-           
+
             try
             {
                 connection = _dbProviderFactory.CreateConnection();

--- a/src/Microsoft.AspNet.SignalR.SqlServer/Microsoft.AspNet.SignalR.SqlServer.csproj
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/Microsoft.AspNet.SignalR.SqlServer.csproj
@@ -53,6 +53,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
       <Link>TaskAsyncHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="AssemblyExtensions.cs" />
     <Compile Include="DbProviderFactoryAdapter.cs" />
     <Compile Include="DbProviderFactoryExtensions.cs" />

--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlReceiver.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlReceiver.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Messaging;
+using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.SqlServer
 {
@@ -51,7 +52,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
 
         public Task StartReceiving()
         {
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new DispatchingTaskCompletionSource<object>();
 
             ThreadPool.QueueUserWorkItem(Receive, tcs);
 
@@ -75,7 +76,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
          SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "On a background thread with explicit error processing")]
         private void Receive(object state)
         {
-            var tcs = (TaskCompletionSource<object>)state;
+            var tcs = (DispatchingTaskCompletionSource<object>)state;
 
             if (!_lastPayloadId.HasValue)
             {

--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
@@ -47,7 +47,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
             parameter.ParameterName = "Payload";
             parameter.DbType = DbType.Binary;
             parameter.Value = SqlPayload.ToBytes(messages);
-            
+
             var operation = new DbOperation(_connectionString, _insertDml, _trace, parameter);
 
             return operation.ExecuteNonQueryAsync();

--- a/src/Microsoft.AspNet.SignalR.Stress/Microsoft.AspNet.SignalR.Stress.csproj
+++ b/src/Microsoft.AspNet.SignalR.Stress/Microsoft.AspNet.SignalR.Stress.csproj
@@ -87,6 +87,9 @@
     <Compile Include="..\Microsoft.AspNet.SignalR.Core\TaskAsyncHelper.cs">
       <Link>TaskAsyncHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Microsoft.AspNet.SignalR.Core\Infrastructure\DispatchingTaskCompletionSource.cs">
+      <Link>Infrastructure\DispatchingTaskCompletionSource.cs</Link>
+    </Compile>
     <Compile Include="Performance\ClientServerMemoryRun.cs" />
     <Compile Include="Performance\ConnectionRun.cs" />
     <Compile Include="Performance\HostedRun.cs" />

--- a/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/TransportFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.Tests/Client/TransportFacts.cs
@@ -16,14 +16,14 @@ using Moq.Protected;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
-using Xunit.Extensions;
+using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Client.Tests
 {
     public class TransportFacts
     {
         [Fact]
-        public void CancelledTaskHandledinServerSentEvents()
+        public async Task CancelledTaskHandledinServerSentEvents()
         {
             var tcs = new TaskCompletionSource<IResponse>();
             tcs.TrySetCanceled();
@@ -43,14 +43,12 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
 
             var sse = new ServerSentEventsTransport(httpClient.Object);
 
-            var exception = Assert.Throws<AggregateException>(
-                () => sse.Start(connection.Object, string.Empty, CancellationToken.None).Wait(TimeSpan.FromSeconds(5)));
-
-            Assert.IsType(typeof(OperationCanceledException), exception.InnerException);
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => sse.Start(connection.Object, string.Empty, CancellationToken.None).OrTimeout());
         }
 
         [Fact]
-        public void CancelledTaskHandledinAutoTransport()
+        public async Task CancelledTaskHandledinAutoTransport()
         {
             var tcs = new TaskCompletionSource<IResponse>();
 
@@ -64,13 +62,13 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             transports.Add(transport.Object);
 
             var autoTransport = new AutoTransport(new DefaultHttpClient(), transports);
-            var task = autoTransport.Start(new Connection("http://foo"), string.Empty, CancellationToken.None);
 
-            Assert.IsType(typeof(OperationCanceledException), task.Exception.InnerException);
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => autoTransport.Start(new Connection("http://foo"), string.Empty, CancellationToken.None));
         }
 
         [Fact]
-        public void StartExceptionStopsAutoTransportFallback()
+        public async Task StartExceptionStopsAutoTransportFallback()
         {
             var errorTcs = new TaskCompletionSource<IResponse>();
             errorTcs.SetException(new StartException());
@@ -87,16 +85,15 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             transports.Add(unusedTransport.Object);
 
             var autoTransport = new AutoTransport(new DefaultHttpClient(), transports);
-            var startTask = autoTransport.Start(new Connection("http://foo"), string.Empty, CancellationToken.None);
+            await Assert.ThrowsAsync<StartException>(
+                () => autoTransport.Start(new Connection("http://foo"), string.Empty, CancellationToken.None));
 
             failingTransport.Verify();
             unusedTransport.Verify(t => t.Start(It.IsAny<IConnection>(), It.IsAny<string>(), CancellationToken.None), Times.Never());
-
-            Assert.IsType(typeof(StartException), startTask.Exception.InnerException);
         }
 
         [Fact]
-        public void CancelledTaskHandledWhenStartingLongPolling()
+        public async Task CancelledTaskHandledWhenStartingLongPolling()
         {
             var tcs = new TaskCompletionSource<IResponse>();
             tcs.SetCanceled();
@@ -112,11 +109,8 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
 
             var longPollingTransport = new LongPollingTransport(httpClient.Object);
 
-            var unwrappedException = Assert.Throws<AggregateException>(() =>
-                longPollingTransport.Start(mockConnection.Object, null, CancellationToken.None)
-                    .Wait(TimeSpan.FromSeconds(5))).InnerException;
-
-            Assert.IsType<OperationCanceledException>(unwrappedException);
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => longPollingTransport.Start(mockConnection.Object, null, CancellationToken.None).OrTimeout());
         }
 
         [Fact]
@@ -162,7 +156,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             webSocketTransport.Protected()
                 .Setup("OnStart", ItExpr.IsAny<IConnection>(), ItExpr.IsAny<string>(), CancellationToken.None)
                 .Callback(mre.Set);
-            
+
             transports.Add(webSocketTransport.Object);
             transports.Add(new ServerSentEventsTransport());
             transports.Add(new LongPollingTransport());
@@ -253,7 +247,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             mockWebSocket.SetupGet(ws => ws.State).Returns(state);
             mockConnection.Setup(c => c.OnError(It.IsAny<InvalidOperationException>()));
             mockWebSocketHandler.Object.WebSocket = mockWebSocket.Object;
-            
+
             var wsTransport = new WebSocketTransport(mockWebSocketHandler.Object);
 
             var task = wsTransport.Send(mockConnection.Object, "", "");

--- a/tests/Microsoft.AspNet.SignalR.Client.UWP.Tests/Properties/AssemblyInfo.cs
+++ b/tests/Microsoft.AspNet.SignalR.Client.UWP.Tests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -28,3 +29,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: ComVisible(false)]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Client/WebSocketFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Client/WebSocketFacts.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNet.SignalR.Tests.Common.Infrastructure;
 using Microsoft.AspNet.SignalR.Tests.Utilities;
 using Xunit;
 using Xunit.Extensions;
+using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Tests
 {
@@ -32,7 +33,7 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                     await connection.Start(host.Transport);
 
-                    var result = hub.InvokeWithTimeout<string>("ReturnLargePayload");
+                    var result = await hub.Invoke<string>("ReturnLargePayload").OrTimeout();
 
                     Assert.Equal(new string('a', 64 * 1024), result);
                 }

--- a/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
@@ -1111,7 +1111,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                         testGuidInvocations++;
                         if (testGuidInvocations < 2)
                         {
-                            hub.Invoke("TestGuid").ContinueWithNotComplete(tcs);
+                            hub.Invoke("TestGuid").ContinueWithPreservedCulture(t =>
+                                {
+                                    if (t.IsFaulted)
+                                    {
+                                        tcs.SetUnwrappedException(t.Exception);
+                                    }
+                                    else if (t.IsCanceled)
+                                    {
+                                        tcs.SetCanceled();
+                                    }
+                                },
+                                TaskContinuationOptions.NotOnRanToCompletion);
                         }
                         else
                         {

--- a/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/HostedTestFactory.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/HostedTestFactory.cs
@@ -54,7 +54,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common.Infrastructure
                     host.Transport = host.TransportFactory();
                     break;
                 case HostType.Memory:
-                default: 
+                default:
                     var mh = new MemoryHost();
                     host = new MemoryTestHost(mh, Path.Combine(logBasePath, testName));
                     host.TransportFactory = () => CreateTransport(transportType, mh);

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/AckHandlerFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/AckHandlerFacts.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
         [Fact]
         public void AcksLastingLongerThanThresholdAreCompleted()
         {
-            var ackHandler = new AckHandler(completeAcksOnTimeout: true, 
+            var ackHandler = new AckHandler(completeAcksOnTimeout: true,
                                             ackThreshold: TimeSpan.FromSeconds(1),
                                             ackInterval: TimeSpan.FromSeconds(1));
 
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
         }
 
         [Fact]
-        public void TriggeredAcksAreCompleted()
+        public async Task TriggeredAcksAreCompleted()
         {
             var ackHandler = new AckHandler(completeAcksOnTimeout: false,
                                             ackThreshold: TimeSpan.Zero,
@@ -36,7 +36,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             Task task = ackHandler.CreateAck("foo");
 
             Assert.True(ackHandler.TriggerAck("foo"));
-            Assert.True(task.IsCompleted);
+            await task.OrTimeout();
         }
 
         [Fact]


### PR DESCRIPTION
to prevent user's code to be run on SignalR threads