### PR TITLE
Crank: Allow testing of AD-secured endpoints (e.g. Azure WebApp)

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Crank/AzureActiveDirectoryAwareConnectionFactory.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/AzureActiveDirectoryAwareConnectionFactory.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Globalization;
+using CmdLine;
+using Microsoft.AspNet.SignalR.Client;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Microsoft.AspNet.SignalR.Crank
+{
+    public class AzureActiveDirectoryAwareConnectionFactory : IConnectionFactory
+    {
+        private readonly AuthenticationResult _authenticationResult;
+
+        public AzureActiveDirectoryAwareConnectionFactory()
+        {
+            var arguments = EnsureAllArgumentsHaveBeenSet();
+
+            var authority = string.Format(CultureInfo.InvariantCulture, arguments.AadInstance, arguments.Tenant);
+            var authenticationContext = new AuthenticationContext(authority);
+            Console.WriteLine("Starting Authentication...");
+            try
+            {
+                if (string.IsNullOrWhiteSpace(arguments.Username) || string.IsNullOrWhiteSpace(arguments.Password))
+                {
+                    _authenticationResult = authenticationContext.AcquireTokenAsync(arguments.ResourceId, arguments.ClientId, new Uri(arguments.RedirectUri), new PlatformParameters(PromptBehavior.Auto)).Result;
+                }
+                else
+                {
+                    Console.WriteLine($"Trying to authenticate using username '{arguments.Username}' and provided password...");
+
+                    _authenticationResult = authenticationContext.AcquireTokenAsync(arguments.ResourceId, arguments.ClientId, new UserPasswordCredential(arguments.Username, arguments.Password)).Result;
+
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("An error occurred during authentication:");
+                Console.WriteLine(ex.ToString());
+                Console.WriteLine();
+                Console.WriteLine("Note that silent login using username and password is not available for Microsoft Accounts or accounts using multi-factor-authentication. Use the interactive login for those.");
+                Console.ReadKey();
+                Environment.Exit(1);
+            }
+            Console.WriteLine($"Authenticated as {_authenticationResult.UserInfo.DisplayableId} - Token acquired successfully.");
+        }
+
+        private static CrankArguments EnsureAllArgumentsHaveBeenSet()
+        {
+            var arguments = CommandLine.Parse<CrankArguments>();
+            while (string.IsNullOrWhiteSpace(arguments.AadInstance))
+            {
+                Console.WriteLine("Please enter the AAD instance URI:");
+                arguments.AadInstance = Console.ReadLine();
+            }
+
+            while (string.IsNullOrWhiteSpace(arguments.Tenant))
+            {
+                Console.WriteLine("Please enter the AAD Tenant name:");
+                arguments.Tenant = Console.ReadLine();
+            }
+
+            while (string.IsNullOrWhiteSpace(arguments.ResourceId))
+            {
+                Console.WriteLine("Please enter the AAD ResourceId:");
+                arguments.ResourceId = Console.ReadLine();
+            }
+
+            while (string.IsNullOrWhiteSpace(arguments.ClientId))
+            {
+                Console.WriteLine("Please enter the AAD ClientId:");
+                arguments.ClientId = Console.ReadLine();
+            }
+
+            while (string.IsNullOrWhiteSpace(arguments.RedirectUri))
+            {
+                Console.WriteLine("Please enter the AAD Redirect URI:");
+                arguments.RedirectUri = Console.ReadLine();
+            }
+
+            return arguments;
+        }
+
+        public Connection CreateConnection(string url)
+        {
+            var connection = new Connection(url);
+            connection.Headers.Add("Authorization", $"Bearer {_authenticationResult.AccessToken}");
+            return connection;
+        }
+    }
+}

--- a/src/Microsoft.AspNet.SignalR.Crank/Client.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/Client.cs
@@ -68,13 +68,13 @@ namespace Microsoft.AspNet.SignalR.Crank
 
             if (Arguments.UseAadAwareConnectionFactory)
             {
-                Factory = new AzureActiveDirectoryAwareConnectionFactory();
                 Console.WriteLine("Using Azure Active Directory Aware connection factory...");
+                Factory = new AzureActiveDirectoryAwareConnectionFactory();
             }
             else
             {
-                Factory = new DefaultConnectionFactory();
                 Console.WriteLine("Using default connection factory...");
+                Factory = new DefaultConnectionFactory();
             }
         }
 

--- a/src/Microsoft.AspNet.SignalR.Crank/CrankArguments.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/CrankArguments.cs
@@ -65,6 +65,9 @@ namespace Microsoft.AspNet.SignalR.Crank
         [CommandLineParameter(Command = "SignalRInstance", Required = false, Description = "Instance name for SignalR counters on the server. Defaults to using client connection states.")]
         public string SignalRInstance { get; set; }
 
+        [CommandLineParameter(Command = "SkipPerformanceCounters", Required = false, Default = false, Description = "Skip performance counter connection. Performance counters are not available on Azure WebApps.")]
+        public bool SkipPerformanceCounters { get; set; }
+
         [CommandLineParameter(Command = "UseADAuthentication", Required = false, Default = false, Description = "Enable Azure Active Directory Authentication for the SignalR endpoint.")]
         public bool UseAadAwareConnectionFactory { get; set; }
 

--- a/src/Microsoft.AspNet.SignalR.Crank/CrankArguments.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/CrankArguments.cs
@@ -68,28 +68,28 @@ namespace Microsoft.AspNet.SignalR.Crank
         [CommandLineParameter(Command = "SkipPerformanceCounters", Required = false, Default = false, Description = "Skip performance counter connection. Performance counters are not available on Azure WebApps.")]
         public bool SkipPerformanceCounters { get; set; }
 
-        [CommandLineParameter(Command = "UseADAuthentication", Required = false, Default = false, Description = "Enable Azure Active Directory Authentication for the SignalR endpoint.")]
+        [CommandLineParameter(Command = "UseADAuthentication", Required = false, Default = false, Description = "(ADAuthentication) Enable Azure Active Directory Authentication for the SignalR endpoint.")]
         public bool UseAadAwareConnectionFactory { get; set; }
 
-        [CommandLineParameter(Command = "ADInstance", Required = false, Default = "https://login.windows.net/{0}", Description = "The Active Directory instance URL. The default value is suitable for Azure Active Directory.")]
+        [CommandLineParameter(Command = "ADInstance", Required = false, Default = "https://login.windows.net/{0}", Description = "(ADAuthentication) The Active Directory instance URL. The default value is suitable for Azure Active Directory.")]
         public string AadInstance { get; set; }
 
-        [CommandLineParameter(Command = "ADTenant", Required = false, Description = "The name of the tenant, e.g. 'example.onmicrosoft.com'.")]
+        [CommandLineParameter(Command = "ADTenant", Required = false, Description = "(ADAuthentication) The name of the tenant, e.g. 'example.onmicrosoft.com'.")]
         public string Tenant { get; set; }
 
-        [CommandLineParameter(Command = "ADClientId", Required = false, Description = "The client id of the application registration for this app.")]
+        [CommandLineParameter(Command = "ADClientId", Required = false, Description = "(ADAuthentication) The client id of the application registration for this app.")]
         public string ClientId { get; set; }
 
-        [CommandLineParameter(Command = "ADRedirectUri", Required = false, Description = "The redirect URI provided during application registration.")]
+        [CommandLineParameter(Command = "ADRedirectUri", Required = false, Description = "(ADAuthentication) The redirect URI provided during application registration.")]
         public string RedirectUri { get; set; }
 
-        [CommandLineParameter(Command = "ADResourceId", Required = false, Description = "The ID of the resource to be accessed, e.g. the client id of another registered application.")]
+        [CommandLineParameter(Command = "ADResourceId", Required = false, Description = "(ADAuthentication) The ID of the resource to be accessed, e.g. the client id of another registered application.")]
         public string ResourceId { get; set; }
 
-        [CommandLineParameter(Command = "ADUsername", Required = false, Description = "The username to log in with. If not given, interactive login will be used. MSA or MFA accounts require interactive login.")]
+        [CommandLineParameter(Command = "ADUsername", Required = false, Description = "(ADAuthentication) The username to log in with. If not given, interactive login will be used. MSA or MFA accounts require interactive login.")]
         public string Username { get; set; }
 
-        [CommandLineParameter(Command = "ADPassword", Required = false, Description = "The password belonging to the username. If not given, interactive login will be used. MSA or MFA accounts require interactive login.")]
+        [CommandLineParameter(Command = "ADPassword", Required = false, Description = "(ADAuthentication) The password belonging to the username. If not given, interactive login will be used. MSA or MFA accounts require interactive login.")]
         public string Password { get; set; }
 
         public string Controller

--- a/src/Microsoft.AspNet.SignalR.Crank/CrankArguments.cs
+++ b/src/Microsoft.AspNet.SignalR.Crank/CrankArguments.cs
@@ -65,6 +65,30 @@ namespace Microsoft.AspNet.SignalR.Crank
         [CommandLineParameter(Command = "SignalRInstance", Required = false, Description = "Instance name for SignalR counters on the server. Defaults to using client connection states.")]
         public string SignalRInstance { get; set; }
 
+        [CommandLineParameter(Command = "UseADAuthentication", Required = false, Default = false, Description = "Enable Azure Active Directory Authentication for the SignalR endpoint.")]
+        public bool UseAadAwareConnectionFactory { get; set; }
+
+        [CommandLineParameter(Command = "ADInstance", Required = false, Default = "https://login.windows.net/{0}", Description = "The Active Directory instance URL. The default value is suitable for Azure Active Directory.")]
+        public string AadInstance { get; set; }
+
+        [CommandLineParameter(Command = "ADTenant", Required = false, Description = "The name of the tenant, e.g. 'example.onmicrosoft.com'.")]
+        public string Tenant { get; set; }
+
+        [CommandLineParameter(Command = "ADClientId", Required = false, Description = "The client id of the application registration for this app.")]
+        public string ClientId { get; set; }
+
+        [CommandLineParameter(Command = "ADRedirectUri", Required = false, Description = "The redirect URI provided during application registration.")]
+        public string RedirectUri { get; set; }
+
+        [CommandLineParameter(Command = "ADResourceId", Required = false, Description = "The ID of the resource to be accessed, e.g. the client id of another registered application.")]
+        public string ResourceId { get; set; }
+
+        [CommandLineParameter(Command = "ADUsername", Required = false, Description = "The username to log in with. If not given, interactive login will be used. MSA or MFA accounts require interactive login.")]
+        public string Username { get; set; }
+
+        [CommandLineParameter(Command = "ADPassword", Required = false, Description = "The password belonging to the username. If not given, interactive login will be used. MSA or MFA accounts require interactive login.")]
+        public string Password { get; set; }
+
         public string Controller
         {
             get

--- a/src/Microsoft.AspNet.SignalR.Crank/Microsoft.AspNet.SignalR.Crank.csproj
+++ b/src/Microsoft.AspNet.SignalR.Crank/Microsoft.AspNet.SignalR.Crank.csproj
@@ -42,6 +42,12 @@
     <Reference Include="CmdLine">
       <HintPath>..\..\packages\CmdLine.1.0.7.509\lib\net40-Client\CmdLine.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.13.9.1126, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.Platform, Version=3.13.9.1126, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.13.9\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.Platform.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Owin.2.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -78,6 +84,7 @@
     <Compile Include="..\Common\CommonVersionInfo.cs">
       <Link>Properties\CommonVersionInfo.cs</Link>
     </Compile>
+    <Compile Include="AzureActiveDirectoryAwareConnectionFactory.cs" />
     <Compile Include="ConnectionsSample.cs" />
     <Compile Include="ControllerEvents.cs" />
     <Compile Include="ControllerHub.cs" />
@@ -101,7 +108,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="CsvToExcel.ps1" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="SampleServer.ps1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Microsoft.AspNet.SignalR.Crank/packages.config
+++ b/src/Microsoft.AspNet.SignalR.Crank/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CmdLine" version="1.0.7.509" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.13.9" targetFramework="net45" />
   <package id="Microsoft.Owin" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Diagnostics" version="2.1.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="2.1.0" targetFramework="net45" />


### PR DESCRIPTION
We needed to run the Crank tool against our in-development product, which is currently hosted on an Azure WebApp and secured via AAD for confidentiality.
This PR extends the Crank tool with a new `AzureActiveDirectoryAwareConnectionFactory` which makes use of ADAL to authenticate requests. This PR also adds accompanying commandline options (and a utility one, `SkipPerformanceCounters`, useful for preventing timeouts when testing against Azure WebApps that do not support performance counters).

I would be glad to get some feedback and make adjustments as requested :)