### PR TITLE
Fix: synchronous XMLHttpRequest.

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -596,7 +596,7 @@
                     connection._.initHandler.start(transport, function () { // success
                         // Firefox 11+ doesn't allow sync XHR withCredentials: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#withCredentials
                         var isFirefox11OrGreater = signalR._.firefoxMajorVersion(window.navigator.userAgent) >= 11,
-                            asyncAbort = !!connection.withCredentials && isFirefox11OrGreater;
+                            asyncAbort = true;
 
                         connection.log("The start request succeeded. Transitioning to the connected state.");
 
@@ -950,7 +950,7 @@
 
             // Clear out our message buffer
             connection._.connectingMessageBuffer.clear();
-            
+
             // Clean up this event
             $(connection).unbind(events.onStart);
 


### PR DESCRIPTION
- Was async for only Firefox, because firefox won't allow it to be
synchronous.
- No case where async shouldn't be an option here. Server would
eventually timeout after 30 seconds (default).
- Leaving firefox version check that handles different issue.
- asyncAbort set to true always.

fixes
#3624 