### PR TITLE
fix version start year in dev

### DIFF
--- a/build/Microsoft.AspNet.SignalR.versions.targets
+++ b/build/Microsoft.AspNet.SignalR.versions.targets
@@ -16,6 +16,7 @@
         <KatanaVersion>2.1.0</KatanaVersion>
 
         <!-- Ensure that we come up with a new version every 65535 years -->
-        <VersionStartYear>2012</VersionStartYear>
+        <!-- This started as 2012, but in 2018 we had to update it because it's been 6 years! -->
+        <VersionStartYear>2018</VersionStartYear>
     </PropertyGroup>
 </Project>


### PR DESCRIPTION
We calculate the 3rd segment of the Assembly File Version using something like: `$"{(Current Year - 2012) + 1}{DateTime.Now.ToString("MMdd")}`. But, `(2018 - 2012) + 1 = 7`, meaning our numbers will be `7MMdd`, which overflows the max of `65535`. So, it's time to rev the "start year" :). This is safe as long as the version number is also incremented at the same time, which was done in #4059, so we're good.