### PR TITLE
HeartBeatMonitor: Use thread as a timer instead of System.Threading.Timer

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client.NetStandard/project.json
+++ b/src/Microsoft.AspNet.SignalR.Client.NetStandard/project.json
@@ -4,7 +4,8 @@
     "Microsoft.Bcl.Build": "1.0.21",
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
     "NETStandard.Library": "1.6.0",
-    "Newtonsoft.Json": "9.0.1"
+    "Newtonsoft.Json": "9.0.1",
+    "System.Threading.Thread": "4.3.0"
   },
   "frameworks": {
     "netstandard1.3": {}


### PR DESCRIPTION
It resolves #3233 issue. System.Threading.Timer causes to enter CheckKeepAlive method multiple times because of _connectionStateLock. I also tried with Monitor.TryEnter but not worked same issue occured. So instead of more complex timer routines, I replaced it simple thread loop using signalling.