### PR TITLE
update versions to 2.3.0

### DIFF
--- a/build/Microsoft.AspNet.SignalR.versions.targets
+++ b/build/Microsoft.AspNet.SignalR.versions.targets
@@ -2,8 +2,8 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <MajorVersion>2</MajorVersion>
-        <MinorVersion>2</MinorVersion>
-        <PatchVersion>3</PatchVersion>
+        <MinorVersion>3</MinorVersion>
+        <PatchVersion>0</PatchVersion>
 
         <!-- Change this to set the build quality of the project. Use values like "alpha", "beta", "rc1", "rtm", etc. -->
         <!-- These values are used in SemVer, so make sure to always increase these alphabetically. -->

--- a/samples/Microsoft.AspNet.SignalR.Samples/Scripts/hubs.js
+++ b/samples/Microsoft.AspNet.SignalR.Samples/Scripts/hubs.js
@@ -1,5 +1,5 @@
 /*!
- * ASP.NET SignalR JavaScript Library v2.2.3-alpha1
+ * ASP.NET SignalR JavaScript Library v2.3.0-alpha1
  * http://signalr.net/
  *
  * Copyright (c) .NET Foundation. All rights reserved.

--- a/src/Common/CommonVersionInfo.cs
+++ b/src/Common/CommonVersionInfo.cs
@@ -3,6 +3,6 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("2.2.3")]
+[assembly: AssemblyVersion("2.3.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("2.2.3-alpha1")]
+[assembly: AssemblyInformationalVersion("2.3.0-alpha1")]

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.core.js
@@ -1,6 +1,6 @@
 /*global window:false */
 /*!
- * ASP.NET SignalR JavaScript Library v2.2.3-alpha1
+ * ASP.NET SignalR JavaScript Library v2.3.0-alpha1
  * http://signalr.net/
  *
  * Copyright (c) .NET Foundation. All rights reserved.

--- a/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.version.js
+++ b/src/Microsoft.AspNet.SignalR.Client.JS/jquery.signalR.version.js
@@ -5,5 +5,5 @@
 /*global window:false */
 /// <reference path="jquery.signalR.core.js" />
 (function ($, undefined) {
-    $.signalR.version = "2.2.3-alpha1";
+    $.signalR.version = "2.3.0-alpha1";
 }(window.jQuery));

--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -936,7 +936,7 @@ namespace Microsoft.AspNet.SignalR.Client
             if (_assemblyVersion == null)
             {
 #if NETFX_CORE
-                _assemblyVersion = new Version("2.2.3");
+                _assemblyVersion = new Version("2.3.0");
 #elif NETSTANDARD
                 _assemblyVersion = new AssemblyName(typeof(Resources).GetTypeInfo().Assembly.FullName).Version;
 #else

--- a/src/Microsoft.AspNet.SignalR.Core/Scripts/hubs.js
+++ b/src/Microsoft.AspNet.SignalR.Core/Scripts/hubs.js
@@ -1,5 +1,5 @@
 /*!
- * ASP.NET SignalR JavaScript Library v2.2.3-alpha1
+ * ASP.NET SignalR JavaScript Library v2.3.0-alpha1
  * http://signalr.net/
  *
  * Copyright (c) .NET Foundation. All rights reserved.


### PR DESCRIPTION
Fixes #4090 

Time for some of the aspnet/SignalR folks to get involved in code reviews :). Here's a nice simple one. This updates all version numbers in SignalR/SignalR to 2.3.0-alpha1. This is needed because we ran out of patch versions in the file version.

Some history:
* .NET binaries have two versions: Assembly Version and File Version (the latter being a Windows concept). This is **in addition** to NuGet Package Version (which is stored as the Assembly "Informational" Version as well)
* Assembly Versions are always `[major].[minor].[patch]` (matching the NuGet Package)
* File Versions are of the form `[major].[minor].[revision].[build]`:
  * `[major]` and `[minor]` are set to the same version as the NuGet package. 
  * `[build]` is set to a sequence number based on the TeamCity build number. 
  * However, `[revision]` is set to the string `YMMdd` where `Y` is the number of years since the "Start Year" of the product (originally `2012`), with the first year being `1` (so `([Current Year] - [Start Year]) + 1`) and `MMdd` are the month and day number.
* `2.2.3` was shipped in `2018` and `(2018 - 2012) + 1 = 7`, so the release would have been `7MMdd`
* File Versions are limited to 16-bit integers in the `[revision]` field, which means the max is `65535`, thus `7MMdd` would overflow
* I updated the start year to `2018` in https://github.com/SignalR/SignalR/commit/ab0e76f4a116c299bde8a89a306c9d2cf003cf8a to resolve this
* However, this meant that File Versions were `2.2.1MMdd.[build]` meaning they sort **before** older `2.2.x` builds. This seemed OK because Assembly Versions were still good. However, MSI installers compare the File Version when updating files, so any application using the `2.2.3` client that is packaged as an MSI can fail to update properly as the older copy of SignalR looks newer to the Windows Installer.

The fix is simple: We're going to ship the next version as `2.3.0`, meaning we can update the File Version to `2.3.1MMdd.[build]`, which is always going to sort as **newer** than `2.2.*`.

There are no plans to do any feature work in `2.3.0` (which is normally the case in a new minor version release), just bug fixes, but the version number issue necessitates the minor version update.