### PR TITLE
Fix tracing null ref and tweak the logs

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutMessageBus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutSubscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutSubscription.cs
@@ -110,12 +110,12 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 // anything we already processed
                 if (nextCursor == null || mapping.Id > nextCursor)
                 {
-                    ExtractMessages(streamIndex, mapping, items, ref totalCount);
+                    ulong mappingId = ExtractMessages(streamIndex, mapping, items, ref totalCount);
 
                     // Update the cursor id
-                    nextCursors[streamIndex] = mapping.Id;
+                    nextCursors[streamIndex] = mappingId;
                     _trace.TraceVerbose("Updated cursor for mapping id {0} stream idx {1} to {2} [{3}]",
-                        mapping.Id, streamIndex, mapping.Id, Identity);
+                        mapping.Id, streamIndex, mappingId, Identity);
                 }
             }
 

--- a/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
@@ -29,6 +29,7 @@ namespace Microsoft.AspNet.SignalR.Redis
         private IRedisConnection _connection;
         private string _connectionString;
         private readonly object _callbackLock = new object();
+        private ulong? lastId = null;
 
         public RedisMessageBus(IDependencyResolver resolver, RedisScaleoutConfiguration configuration, IRedisConnection connection)
             : this(resolver, configuration, connection, true)
@@ -80,7 +81,7 @@ namespace Microsoft.AspNet.SignalR.Redis
             Func<Task<RedisResult>, Task> waitForAndTraceResult = async (Task<RedisResult> task) =>
             {
                 var result = await task;
-                var values = (RedisValue[]) result;
+                var values = (RedisValue[])result;
                 _trace.TraceEvent(TraceEventType.Verbose, 0, $"Published message with key: {(int)values[0]}");
             };
 
@@ -193,6 +194,11 @@ namespace Microsoft.AspNet.SignalR.Redis
             // to preserve order on the subscription)
             lock (_callbackLock)
             {
+                if (lastId.HasValue && message.Id < lastId.Value)
+                {
+                    _trace.TraceEvent(TraceEventType.Error, 0, $"ID regression occurred. The next message ID {message.Id} was less than the previous message {lastId.Value}");
+                }
+                lastId = message.Id;
                 OnReceived(streamIndex, message.Id, message.ScaleoutMessage);
             }
         }


### PR DESCRIPTION
* Fix a null ref in GetMappings logs
* Remove the per-iteration logs in GetMappings, way too spammy
* @halter73 has a hunch about where the issue may lie. He suspects that ExtractMessages returning a new mapping ID is a Bad Idea. I'm adding tracing for now so we can see when that happens to see if that's causing the problem.
* Add logs in ScaleoutSubscription and RedisMessageBus to watch for ID regression.

I'm going to merge this ASAP to get a build going.