### PR TITLE
fix issue with ScaleoutStore minMappingId being incorrect

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutStore.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Microsoft.AspNet.SignalR.Infrastructure;
@@ -164,7 +165,9 @@ namespace Microsoft.AspNet.SignalR.Messaging
                         if (overwrite)
                         {
                             _minMessageId = (long)(existingFragment.MaxId + 1);
-                            _minMappingId = existingFragment.MaxId;
+
+                            Debug.Assert(existingFragment.MaxValue.HasValue, "The fragment being overwritten should be full!");
+                            _minMappingId = existingFragment.MaxValue.Value;
                         }
                         else if (idxIntoFragmentsArray == 0)
                         {

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutSubscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutSubscription.cs
@@ -100,9 +100,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 ScaleoutMapping mapping = enumerator.Current.Item1;
                 int streamIndex = enumerator.Current.Item2;
 
-                _trace.TraceVerbose("Extracting message for scaleout mapping: {0}, stream index {1}, [{2}]",
-                    mapping.Id, streamIndex, Identity);
-
                 ulong? nextCursor = nextCursors[streamIndex];
 
                 // Only keep going with this stream if the cursor we're looking at is bigger than
@@ -113,8 +110,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
                     // Update the cursor id
                     nextCursors[streamIndex] = mappingId;
-                    _trace.TraceVerbose("Updated cursor for mapping id {0} stream idx {1} to {2} [{3}]",
-                        mapping.Id, streamIndex, mappingId, Identity);
                 }
             }
 

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutSubscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutSubscription.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -163,7 +163,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
             }
 
             var counter = 0;
-            ulong? lastMapping = null;
             while (enumerators.Count > 0)
             {
                 ScaleoutMapping minMapping = null;

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/ScaleoutStoreFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/ScaleoutStoreFacts.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 {
     public class ScaleoutStoreFacts
     {
+        private static readonly ulong CursorBase = 100000;
+
         [Fact]
         public void BinarySearchNoOverwriteSuccess()
         {
@@ -18,7 +20,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
             for (int i = 0; i < 5; i++)
             {
-                store.Add(new ScaleoutMapping((ulong)i, new ScaleoutMessage()));
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), new ScaleoutMessage()));
             }
 
             ScaleoutStore.Fragment fragment;
@@ -34,7 +36,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
             for (int i = 0; i < 5; i++)
             {
-                store.Add(new ScaleoutMapping((ulong)i, new ScaleoutMessage()));
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), new ScaleoutMessage()));
             }
 
             ScaleoutStore.Fragment fragment;
@@ -50,7 +52,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
             for (int i = 1; i <= 5; i++)
             {
-                store.Add(new ScaleoutMapping((ulong)i, new ScaleoutMessage()));
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), new ScaleoutMessage()));
             }
 
             ScaleoutStore.Fragment fragment;
@@ -69,7 +71,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
-                    store.Add(new ScaleoutMapping((ulong)id, new ScaleoutMessage()));
+                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), new ScaleoutMessage()));
                     id++;
                 }
             }
@@ -90,7 +92,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
-                    store.Add(new ScaleoutMapping((ulong)id, new ScaleoutMessage()));
+                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), new ScaleoutMessage()));
                     id++;
                 }
             }
@@ -111,7 +113,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
-                    store.Add(new ScaleoutMapping((ulong)id, new ScaleoutMessage()));
+                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), new ScaleoutMessage()));
                     id++;
                 }
             }
@@ -157,7 +159,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
                     var message = new ScaleoutMessage();
-                    store.Add(new ScaleoutMapping((ulong)id, message));
+                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), message));
                     id++;
                 }
             }
@@ -173,7 +175,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 10; i < 15; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping((ulong)i, message));
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
             }
 
             var result = store.GetMessagesByMappingId(16);
@@ -188,7 +190,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 0; i < 5; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping((ulong)i, message));
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
             }
 
             var result = store.GetMessagesByMappingId(6);
@@ -203,13 +205,31 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 5; i < 10; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping((ulong)i, message));
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
             }
 
             var result = store.GetMessagesByMappingId(4);
-            Assert.Equal(0ul, result.FirstMessageId);
+            Assert.Equal(6ul, result.FirstMessageId);
             Assert.Equal(5ul, store.MinMappingId);
             Assert.Equal(5, result.Messages.Count);
+        }
+
+        [Fact]
+        public void GettingMessagesWithCursorLowerThanMinReturnsAllEvenAfterMultipleOverwrites()
+        {
+            var store = new ScaleoutStore(10);
+
+            for (int i = 0; i < 100; i++)
+            {
+                var message = new ScaleoutMessage();
+                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
+            }
+
+            var result = store.GetMessagesByMappingId(CursorBase);
+            Assert.Equal(64ul, result.FirstMessageId);
+            Assert.Equal(64ul + CursorBase, store.MinMappingId);
+            Assert.Equal(8, result.Messages.Count);
+            Assert.True(result.HasMoreData);
         }
 
         [Fact]

--- a/tests/Microsoft.AspNet.SignalR.Tests/Server/ScaleoutStoreFacts.cs
+++ b/tests/Microsoft.AspNet.SignalR.Tests/Server/ScaleoutStoreFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -11,7 +11,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 {
     public class ScaleoutStoreFacts
     {
-        private static readonly ulong CursorBase = 100000;
+        private static readonly ulong MappingIdBase = 100000;
 
         [Fact]
         public void BinarySearchNoOverwriteSuccess()
@@ -20,11 +20,11 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
             for (int i = 0; i < 5; i++)
             {
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), new ScaleoutMessage()));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), new ScaleoutMessage()));
             }
 
             ScaleoutStore.Fragment fragment;
-            bool result = store.TryGetFragmentFromMappingId(0, out fragment);
+            bool result = store.TryGetFragmentFromMappingId(MappingIdBase, out fragment);
 
             Assert.True(result);
         }
@@ -36,11 +36,11 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
             for (int i = 0; i < 5; i++)
             {
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), new ScaleoutMessage()));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), new ScaleoutMessage()));
             }
 
             ScaleoutStore.Fragment fragment;
-            bool result = store.TryGetFragmentFromMappingId(20, out fragment);
+            bool result = store.TryGetFragmentFromMappingId(MappingIdBase + 20, out fragment);
 
             Assert.False(result);
         }
@@ -52,11 +52,11 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
             for (int i = 1; i <= 5; i++)
             {
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), new ScaleoutMessage()));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), new ScaleoutMessage()));
             }
 
             ScaleoutStore.Fragment fragment;
-            bool result = store.TryGetFragmentFromMappingId(0, out fragment);
+            bool result = store.TryGetFragmentFromMappingId(MappingIdBase, out fragment);
 
             Assert.False(result);
         }
@@ -71,13 +71,13 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
-                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), new ScaleoutMessage()));
+                    store.Add(new ScaleoutMapping(((ulong)id + MappingIdBase), new ScaleoutMessage()));
                     id++;
                 }
             }
 
             ScaleoutStore.Fragment fragment;
-            bool result = store.TryGetFragmentFromMappingId(10, out fragment);
+            bool result = store.TryGetFragmentFromMappingId(MappingIdBase + 10, out fragment);
 
             Assert.True(result);
         }
@@ -92,13 +92,13 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
-                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), new ScaleoutMessage()));
+                    store.Add(new ScaleoutMapping(((ulong)id + MappingIdBase), new ScaleoutMessage()));
                     id++;
                 }
             }
 
             ScaleoutStore.Fragment fragment;
-            bool result = store.TryGetFragmentFromMappingId(0, out fragment);
+            bool result = store.TryGetFragmentFromMappingId(MappingIdBase, out fragment);
 
             Assert.False(result);
         }
@@ -113,13 +113,13 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
-                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), new ScaleoutMessage()));
+                    store.Add(new ScaleoutMapping(((ulong)id + MappingIdBase), new ScaleoutMessage()));
                     id++;
                 }
             }
 
             ScaleoutStore.Fragment fragment;
-            bool result = store.TryGetFragmentFromMappingId(100, out fragment);
+            bool result = store.TryGetFragmentFromMappingId(MappingIdBase + 100, out fragment);
 
             Assert.False(result);
         }
@@ -159,12 +159,12 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
                 for (int j = 0; j < store.FragmentCount; j++)
                 {
                     var message = new ScaleoutMessage();
-                    store.Add(new ScaleoutMapping(((ulong)id + CursorBase), message));
+                    store.Add(new ScaleoutMapping(((ulong)id + MappingIdBase), message));
                     id++;
                 }
             }
 
-            Assert.Equal((ulong)store.FragmentSize - 1, store.MinMappingId);
+            Assert.Equal(((ulong)store.FragmentSize - 1) + MappingIdBase, store.MinMappingId);
         }
 
         [Fact]
@@ -175,10 +175,10 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 10; i < 15; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), message));
             }
 
-            var result = store.GetMessagesByMappingId(16);
+            var result = store.GetMessagesByMappingId(MappingIdBase + 16);
             Assert.Equal(0, result.Messages.Count);
         }
 
@@ -190,10 +190,10 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 0; i < 5; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), message));
             }
 
-            var result = store.GetMessagesByMappingId(6);
+            var result = store.GetMessagesByMappingId(MappingIdBase + 6);
             Assert.Equal(0, result.Messages.Count);
         }
 
@@ -205,12 +205,12 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 5; i < 10; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), message));
             }
 
-            var result = store.GetMessagesByMappingId(4);
-            Assert.Equal(6ul, result.FirstMessageId);
-            Assert.Equal(5ul, store.MinMappingId);
+            var result = store.GetMessagesByMappingId(MappingIdBase + 4);
+            Assert.Equal(0ul, result.FirstMessageId);
+            Assert.Equal(5ul + MappingIdBase, store.MinMappingId);
             Assert.Equal(5, result.Messages.Count);
         }
 
@@ -222,12 +222,12 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             for (int i = 0; i < 100; i++)
             {
                 var message = new ScaleoutMessage();
-                store.Add(new ScaleoutMapping(((ulong)i + CursorBase), message));
+                store.Add(new ScaleoutMapping(((ulong)i + MappingIdBase), message));
             }
 
-            var result = store.GetMessagesByMappingId(CursorBase);
+            var result = store.GetMessagesByMappingId(MappingIdBase + 62);
             Assert.Equal(64ul, result.FirstMessageId);
-            Assert.Equal(64ul + CursorBase, store.MinMappingId);
+            Assert.Equal(63ul + MappingIdBase, store.MinMappingId);
             Assert.Equal(8, result.Messages.Count);
             Assert.True(result.HasMoreData);
         }
@@ -266,10 +266,10 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             var message = new ScaleoutMessage();
             foreach (var v in values)
             {
-                store.Add(new ScaleoutMapping((ulong)v, message));
+                store.Add(new ScaleoutMapping((ulong)v + MappingIdBase, message));
             }
 
-            var result = store.GetMessagesByMappingId(targetId);
+            var result = store.GetMessagesByMappingId(MappingIdBase + targetId);
             Assert.Equal(firstId, result.FirstMessageId);
             Assert.Equal(count, result.Messages.Count);
         }
@@ -300,9 +300,9 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             var store = new ScaleoutStore(10);
 
             var message = new ScaleoutMessage();
-            store.Add(new ScaleoutMapping((ulong)1, message));
+            store.Add(new ScaleoutMapping((ulong)1 + MappingIdBase, message));
 
-            var result = store.GetMessagesByMappingId(2);
+            var result = store.GetMessagesByMappingId(2 + MappingIdBase);
             Assert.Equal(0ul, result.FirstMessageId);
             Assert.Equal(0, result.Messages.Count);
         }


### PR DESCRIPTION
The `TryAddImpl` method on ScaleoutStore doesn't properly update `_minMappingId`. This is mostly benign except for the one case where `_minMappingId` is used: to detect that a cursor is so far behind that they should just be given all messages when requesting new messages.

Instead of being set to a "Mapping ID", the `_minMappingId` value gets set to a local message ID whenever a fragment is overwritten. This means the value gets corrupted. It was hard to detect this in our tests because they use the same value for both Mapping ID and Local ID, so I changed the tests to have the Mapping IDs start much higher (which is usually the case when deep into a long-running application).

This issue can cause a long-idle connection to end up being frozen out and seeing no new messages because their cursor value (which might be very high) is never lower than the `_minMappingId` (because local IDs tend to be much smaller).

Fixes: https://github.com/SignalR/SignalR/issues/4121