### PR TITLE
Fix compatibility with Microsoft.AspNetCore.Owin

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/OwinWebSocketHandler.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/OwinWebSocketHandler.cs
@@ -66,13 +66,17 @@ namespace Microsoft.AspNet.SignalR.Owin
             WebSocket webSocket;
 
             // Try to get the websocket context from the environment
-            if (!environment.TryGetValue(typeof(WebSocketContext).FullName, out value))
+            if (environment.TryGetValue(typeof(WebSocketContext).FullName, out value))
             {
-                webSocket = new OwinWebSocket(environment);
+                webSocket = ((WebSocketContext)value).WebSocket;
+            }
+            else if (environment.TryGetValue(typeof(WebSocket).FullName, out value))
+            {
+                webSocket = (WebSocket)value;
             }
             else
             {
-                webSocket = ((WebSocketContext)value).WebSocket;
+                webSocket = new OwinWebSocket(environment);
             }
 
             var cts = new CancellationTokenSource();


### PR DESCRIPTION
This PR addresses a very specific issue we're having while running SignalR on top of Asp.Net Core using  `Microsoft.AspNetCore.Owin`.
We're aware this is an unsupported setup and it's part of our migration path going forward.

Running SignalR on Core actually works when addressing 2 separate issues.
The first one is `Microsoft.AspNetCore.Owin` not setting `server.Capabilities[websocket.Version]`, which is easily fixed with some middleware gymnastics.

The second issue is core's owin bridge does not expose a `WebSocketContext` and causes SignalR to fall back to using `OwinWebSocket`. However `OwinWebSocket`'s implementation is incomplete and causes it to fail only moments later when SignalR calls `WebSocket.State`.

Fixing this second issue would be rather involved. Rather we opted to take advantage of `Microsoft.AspNetCore.Owin` setting the `WebSocket` instance on the OWIN environment directly, thus accomplishing the same behavior that `WebSocketContext` would have provided.

With custom Middleware on our end, and this fix on SignalR's end, SignalR behaves entirely as expected on Asp.Net Core in our testing.
