### PR TITLE
[SignalR Service Client]Add redirect support for js client

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Infrastructure/ProtocolResolver.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Infrastructure/ProtocolResolver.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.SignalR.Infrastructure
         private readonly Version _minimumDelayedStartVersion = new Version(1, 4);
 
         public ProtocolResolver() :
-            this(new Version(1, 2), new Version(1, 5))
+            this(new Version(1, 2), new Version(2, 0))
         {
         }
 

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -20,6 +20,7 @@
         stoppedWhileLoading: "The connection was stopped during page load.",
         stoppedWhileNegotiating: "The connection was stopped during the negotiate request.",
         errorParsingNegotiateResponse: "Error parsing negotiate response.",
+        errorRedirectionExceedsLimit: "Negotiate redirection limit exceeded.",
         errorDuringStartRequest: "Error during start request. Stopping the connection.",
         stoppedDuringStartRequest: "The connection was stopped during the start request.",
         errorParsingStartResponse: "Error parsing start response: '{0}'. Stopping the connection.",
@@ -408,7 +409,7 @@
 
         state: signalR.connectionState.disconnected,
 
-        clientProtocol: "1.5",
+        clientProtocol: "2.0",
 
         reconnectDelay: 2000,
 
@@ -674,35 +675,18 @@
             connection.log("Negotiating with '" + url + "'.");
 
             // Save the ajax negotiate request object so we can abort it if stop is called while the request is in flight.
-            connection._.negotiateRequest = signalR.transports._logic.ajax(connection, {
-                url: url,
-                error: function (error, statusText) {
-                    // We don't want to cause any errors if we're aborting our own negotiate request.
-                    if (statusText !== _negotiateAbortText) {
-                        onFailed(error, connection);
-                    } else {
-                        // This rejection will noop if the deferred has already been resolved or rejected.
-                        deferred.reject(signalR._.error(resources.stoppedWhileNegotiating, null /* error */, connection._.negotiateRequest));
-                    }
-                },
-                success: function (result) {
-                    var res;
-
-                    try {
-                        res = connection._parseResponse(result);
-                    } catch (error) {
-                        onFailed(signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
-                        return;
-                    }
-
-                    // redirect case
-                    if (res.AccessToken && res.Url) {
-                        // initiate the actual connection to res.Url with res.AccessToken
-                        connection.accessToken = res.AccessToken;
-                        setConnectionUrl(connection, res.Url);
-                        var serviceNegotiateUrl = connection.url + "/negotiate";
-                        var url = signalR.transports._logic.prepareQueryString(connection, serviceNegotiateUrl);
-                        signalR.transports._logic.ajax(connection, {
+            connection._.negotiateRequest = function () {
+                var res,
+                    redirects = 0,
+                    MAX_REDIRECTS = 100,
+                    keepAliveData,
+                    protocolError,
+                    transports = [],
+                    supportedTransports = [],
+                    negotiate = function (connection, onSuccess) {
+                        var url = signalR.transports._logic.prepareQueryString(connection, connection.url + "/negotiate");
+                        connection.log("Negotiating with '" + url + "'.");
+                        var options = {
                             url: url,
                             error: function (error, statusText) {
                                 // We don't want to cause any errors if we're aborting our own negotiate request.
@@ -713,64 +697,22 @@
                                     deferred.reject(signalR._.error(resources.stoppedWhileNegotiating, null /* error */, connection._.negotiateRequest));
                                 }
                             },
-                            success: function (result) {
-                                var serverResponse;
+                            success: onSuccess
+                        };
 
-                                try {
-                                    serverResponse = connection._parseResponse(result);
-                                } catch (error) {
-                                    onFailed(signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
-                                    return;
-                                }
-
-                                process(connection, serverResponse);
-                            },
-                            headers: { "Authorization": "Bearer " + connection.accessToken }
-                        });
-                    } else {
-                        process(connection, res);
-                    }
-
-                    function process(connection, res) {
-                        var keepAliveData,
-                            protocolError,
-                            transports = [],
-                            supportedTransports = [];
-
-                        keepAliveData = connection._.keepAliveData;
-                        connection.appRelativeUrl = res.Url;
-                        connection.id = res.ConnectionId;
-                        connection.token = res.ConnectionToken;
-                        connection.webSocketServerUrl = res.WebSocketServerUrl;
-
-                        // The long poll timeout is the ConnectionTimeout plus 10 seconds
-                        connection._.pollTimeout = res.ConnectionTimeout * 1000 + 10000; // in ms
-
-                        // Once the server has labeled the PersistentConnection as Disconnected, we should stop attempting to reconnect
-                        // after res.DisconnectTimeout seconds.
-                        connection.disconnectTimeout = res.DisconnectTimeout * 1000; // in ms
-
-                        // Add the TransportConnectTimeout from the response to the transportConnectTimeout from the client to calculate the total timeout
-                        connection._.totalTransportConnectTimeout = connection.transportConnectTimeout + res.TransportConnectTimeout * 1000;
-
-                        // If we have a keep alive
-                        if (res.KeepAliveTimeout) {
-                            // Register the keep alive data as activated
-                            keepAliveData.activated = true;
-
-                            // Timeout to designate when to force the connection into reconnecting converted to milliseconds
-                            keepAliveData.timeout = res.KeepAliveTimeout * 1000;
-
-                            // Timeout to designate when to warn the developer that the connection may be dead or is not responding.
-                            keepAliveData.timeoutWarning = keepAliveData.timeout * connection.keepAliveWarnAt;
-
-                            // Instantiate the frequency in which we check the keep alive.  It must be short in order to not miss/pick up any changes
-                            connection._.beatInterval = (keepAliveData.timeout - keepAliveData.timeoutWarning) / 3;
-                        } else {
-                            keepAliveData.activated = false;
+                        if (connection.accessToken) {
+                            options.headers = { "Authorization": "Bearer " + connection.accessToken };
                         }
 
-                        connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
+                        return signalR.transports._logic.ajax(connection, options);
+                    },
+                    callback = function (result) {
+                        try {
+                            res = connection._parseResponse(result);
+                        } catch (error) {
+                            onFailed(signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
+                            return;
+                        }
 
                         if (!res.ProtocolVersion || res.ProtocolVersion !== connection.clientProtocol) {
                             protocolError = signalR._.error(signalR._.format(resources.protocolIncompatible, connection.clientProtocol, res.ProtocolVersion));
@@ -780,29 +722,78 @@
                             return;
                         }
 
-                        $.each(signalR.transports, function (key) {
-                            if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
-                                return true;
+                        if (res.RedirectUrl) {
+                            if (redirects === MAX_REDIRECTS) {
+                                onFailed(signalR._.error(resources.errorRedirectionExceedsLimit, null /* error */), connection);
+                                return;
                             }
-                            supportedTransports.push(key);
-                        });
 
-                        if ($.isArray(config.transport)) {
-                            $.each(config.transport, function (_, transport) {
-                                if ($.inArray(transport, supportedTransports) >= 0) {
-                                    transports.push(transport);
+                            connection.log("Received redirect to: " + res.RedirectUrl);
+                            connection.accessToken = res.AccessToken;
+                            setConnectionUrl(connection, res.RedirectUrl);
+                            redirects++;
+                            negotiate(connection, callback);
+                        } else {
+                            keepAliveData = connection._.keepAliveData;
+                            connection.appRelativeUrl = res.Url;
+                            connection.id = res.ConnectionId;
+                            connection.token = res.ConnectionToken;
+                            connection.webSocketServerUrl = res.WebSocketServerUrl;
+
+                            // The long poll timeout is the ConnectionTimeout plus 10 seconds
+                            connection._.pollTimeout = res.ConnectionTimeout * 1000 + 10000; // in ms
+
+                            // Once the server has labeled the PersistentConnection as Disconnected, we should stop attempting to reconnect
+                            // after res.DisconnectTimeout seconds.
+                            connection.disconnectTimeout = res.DisconnectTimeout * 1000; // in ms
+
+                            // Add the TransportConnectTimeout from the response to the transportConnectTimeout from the client to calculate the total timeout
+                            connection._.totalTransportConnectTimeout = connection.transportConnectTimeout + res.TransportConnectTimeout * 1000;
+
+                            // If we have a keep alive
+                            if (res.KeepAliveTimeout) {
+                                // Register the keep alive data as activated
+                                keepAliveData.activated = true;
+
+                                // Timeout to designate when to force the connection into reconnecting converted to milliseconds
+                                keepAliveData.timeout = res.KeepAliveTimeout * 1000;
+
+                                // Timeout to designate when to warn the developer that the connection may be dead or is not responding.
+                                keepAliveData.timeoutWarning = keepAliveData.timeout * connection.keepAliveWarnAt;
+
+                                // Instantiate the frequency in which we check the keep alive.  It must be short in order to not miss/pick up any changes
+                                connection._.beatInterval = (keepAliveData.timeout - keepAliveData.timeoutWarning) / 3;
+                            } else {
+                                keepAliveData.activated = false;
+                            }
+
+                            connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
+
+                            $.each(signalR.transports, function (key) {
+                                if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
+                                    return true;
                                 }
+                                supportedTransports.push(key);
                             });
-                        } else if (config.transport === "auto") {
-                            transports = supportedTransports;
-                        } else if ($.inArray(config.transport, supportedTransports) >= 0) {
-                            transports.push(config.transport);
-                        }
 
-                        initialize(transports);
-                    }
-                }
-            });
+                            if ($.isArray(config.transport)) {
+                                $.each(config.transport, function (_, transport) {
+                                    if ($.inArray(transport, supportedTransports) >= 0) {
+                                        transports.push(transport);
+                                    }
+                                });
+                            } else if (config.transport === "auto") {
+                                transports = supportedTransports;
+                            } else if ($.inArray(config.transport, supportedTransports) >= 0) {
+                                transports.push(config.transport);
+                            }
+
+                            initialize(transports);
+                        }
+                    };
+
+                return negotiate(connection, callback);
+            }();
 
             return deferred.promise();
         },

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -433,7 +433,36 @@
                 },
                 initialize,
                 deferred = connection._deferral || $.Deferred(), // Check to see if there is a pre-existing deferral that's being built on, if so we want to keep using it
-                parser = window.document.createElement("a");
+                parser = window.document.createElement("a"),
+                setConnectionUrl = function (connection, url) {
+                    if (connection.url === url && connection.baseUrl) {
+                        // when the url related properties are already set
+                        return;
+                    }
+
+                    connection.url = url;
+
+                    // Resolve the full url
+                    parser.href = connection.url;
+                    if (!parser.protocol || parser.protocol === ":") {
+                        connection.protocol = window.document.location.protocol;
+                        connection.host = parser.host || window.document.location.host;
+                    } else {
+                        connection.protocol = parser.protocol;
+                        connection.host = parser.host;
+                    }
+
+                    connection.baseUrl = connection.protocol + "//" + connection.host;
+
+                    // Set the websocket protocol
+                    connection.wsProtocol = connection.protocol === "https:" ? "wss://" : "ws://";
+
+                    // If the url is protocol relative, prepend the current windows protocol to the url.
+                    if (connection.url.indexOf("//") === 0) {
+                        connection.url = window.location.protocol + connection.url;
+                        connection.log("Protocol relative URL detected, normalizing it to '" + connection.url + "'.");
+                    }
+                };
 
             connection.lastError = null;
 
@@ -490,20 +519,7 @@
 
             configureStopReconnectingTimeout(connection);
 
-            // Resolve the full url
-            parser.href = connection.url;
-            if (!parser.protocol || parser.protocol === ":") {
-                connection.protocol = window.document.location.protocol;
-                connection.host = parser.host || window.document.location.host;
-            } else {
-                connection.protocol = parser.protocol;
-                connection.host = parser.host;
-            }
-
-            connection.baseUrl = connection.protocol + "//" + connection.host;
-
-            // Set the websocket protocol
-            connection.wsProtocol = connection.protocol === "https:" ? "wss://" : "ws://";
+            setConnectionUrl(connection, connection.url);
 
             // If jsonp with no/auto transport is specified, then set the transport to long polling
             // since that is the only transport for which jsonp really makes sense.
@@ -511,12 +527,6 @@
             // as demonstrated by Issue #623.
             if (config.transport === "auto" && config.jsonp === true) {
                 config.transport = "longPolling";
-            }
-
-            // If the url is protocol relative, prepend the current windows protocol to the url.
-            if (connection.url.indexOf("//") === 0) {
-                connection.url = window.location.protocol + connection.url;
-                connection.log("Protocol relative URL detected, normalizing it to '" + connection.url + "'.");
             }
 
             if (this.isCrossDomain(connection.url)) {
@@ -676,11 +686,7 @@
                     }
                 },
                 success: function (result) {
-                    var res,
-                        keepAliveData,
-                        protocolError,
-                        transports = [],
-                        supportedTransports = [];
+                    var res;
 
                     try {
                         res = connection._parseResponse(result);
@@ -689,69 +695,112 @@
                         return;
                     }
 
-                    keepAliveData = connection._.keepAliveData;
-                    connection.appRelativeUrl = res.Url;
-                    connection.id = res.ConnectionId;
-                    connection.token = res.ConnectionToken;
-                    connection.webSocketServerUrl = res.WebSocketServerUrl;
+                    // redirect case
+                    if (res.AccessToken && res.Url) {
+                        // initiate the actual connection to res.Url with res.AccessToken
+                        connection.accessToken = res.AccessToken;
+                        setConnectionUrl(connection, res.Url);
+                        var serviceNegotiateUrl = connection.url + "/negotiate";
+                        var url = signalR.transports._logic.prepareQueryString(connection, serviceNegotiateUrl);
+                        signalR.transports._logic.ajax(connection, {
+                            url: url,
+                            error: function (error, statusText) {
+                                // We don't want to cause any errors if we're aborting our own negotiate request.
+                                if (statusText !== _negotiateAbortText) {
+                                    onFailed(error, connection);
+                                } else {
+                                    // This rejection will noop if the deferred has already been resolved or rejected.
+                                    deferred.reject(signalR._.error(resources.stoppedWhileNegotiating, null /* error */, connection._.negotiateRequest));
+                                }
+                            },
+                            success: function (result) {
+                                var serverResponse;
 
-                    // The long poll timeout is the ConnectionTimeout plus 10 seconds
-                    connection._.pollTimeout = res.ConnectionTimeout * 1000 + 10000; // in ms
+                                try {
+                                    serverResponse = connection._parseResponse(result);
+                                } catch (error) {
+                                    onFailed(signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
+                                    return;
+                                }
 
-                    // Once the server has labeled the PersistentConnection as Disconnected, we should stop attempting to reconnect
-                    // after res.DisconnectTimeout seconds.
-                    connection.disconnectTimeout = res.DisconnectTimeout * 1000; // in ms
-
-                    // Add the TransportConnectTimeout from the response to the transportConnectTimeout from the client to calculate the total timeout
-                    connection._.totalTransportConnectTimeout = connection.transportConnectTimeout + res.TransportConnectTimeout * 1000;
-
-                    // If we have a keep alive
-                    if (res.KeepAliveTimeout) {
-                        // Register the keep alive data as activated
-                        keepAliveData.activated = true;
-
-                        // Timeout to designate when to force the connection into reconnecting converted to milliseconds
-                        keepAliveData.timeout = res.KeepAliveTimeout * 1000;
-
-                        // Timeout to designate when to warn the developer that the connection may be dead or is not responding.
-                        keepAliveData.timeoutWarning = keepAliveData.timeout * connection.keepAliveWarnAt;
-
-                        // Instantiate the frequency in which we check the keep alive.  It must be short in order to not miss/pick up any changes
-                        connection._.beatInterval = (keepAliveData.timeout - keepAliveData.timeoutWarning) / 3;
-                    } else {
-                        keepAliveData.activated = false;
-                    }
-
-                    connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
-
-                    if (!res.ProtocolVersion || res.ProtocolVersion !== connection.clientProtocol) {
-                        protocolError = signalR._.error(signalR._.format(resources.protocolIncompatible, connection.clientProtocol, res.ProtocolVersion));
-                        $(connection).triggerHandler(events.onError, [protocolError]);
-                        deferred.reject(protocolError);
-
-                        return;
-                    }
-
-                    $.each(signalR.transports, function (key) {
-                        if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
-                            return true;
-                        }
-                        supportedTransports.push(key);
-                    });
-
-                    if ($.isArray(config.transport)) {
-                        $.each(config.transport, function (_, transport) {
-                            if ($.inArray(transport, supportedTransports) >= 0) {
-                                transports.push(transport);
-                            }
+                                process(connection, serverResponse);
+                            },
+                            headers: { "Authorization": "Bearer " + connection.accessToken }
                         });
-                    } else if (config.transport === "auto") {
-                        transports = supportedTransports;
-                    } else if ($.inArray(config.transport, supportedTransports) >= 0) {
-                        transports.push(config.transport);
+                    } else {
+                        process(connection, res);
                     }
 
-                    initialize(transports);
+                    function process(connection, res) {
+                        var keepAliveData,
+                            protocolError,
+                            transports = [],
+                            supportedTransports = [];
+
+                        keepAliveData = connection._.keepAliveData;
+                        connection.appRelativeUrl = res.Url;
+                        connection.id = res.ConnectionId;
+                        connection.token = res.ConnectionToken;
+                        connection.webSocketServerUrl = res.WebSocketServerUrl;
+
+                        // The long poll timeout is the ConnectionTimeout plus 10 seconds
+                        connection._.pollTimeout = res.ConnectionTimeout * 1000 + 10000; // in ms
+
+                        // Once the server has labeled the PersistentConnection as Disconnected, we should stop attempting to reconnect
+                        // after res.DisconnectTimeout seconds.
+                        connection.disconnectTimeout = res.DisconnectTimeout * 1000; // in ms
+
+                        // Add the TransportConnectTimeout from the response to the transportConnectTimeout from the client to calculate the total timeout
+                        connection._.totalTransportConnectTimeout = connection.transportConnectTimeout + res.TransportConnectTimeout * 1000;
+
+                        // If we have a keep alive
+                        if (res.KeepAliveTimeout) {
+                            // Register the keep alive data as activated
+                            keepAliveData.activated = true;
+
+                            // Timeout to designate when to force the connection into reconnecting converted to milliseconds
+                            keepAliveData.timeout = res.KeepAliveTimeout * 1000;
+
+                            // Timeout to designate when to warn the developer that the connection may be dead or is not responding.
+                            keepAliveData.timeoutWarning = keepAliveData.timeout * connection.keepAliveWarnAt;
+
+                            // Instantiate the frequency in which we check the keep alive.  It must be short in order to not miss/pick up any changes
+                            connection._.beatInterval = (keepAliveData.timeout - keepAliveData.timeoutWarning) / 3;
+                        } else {
+                            keepAliveData.activated = false;
+                        }
+
+                        connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
+
+                        if (!res.ProtocolVersion || res.ProtocolVersion !== connection.clientProtocol) {
+                            protocolError = signalR._.error(signalR._.format(resources.protocolIncompatible, connection.clientProtocol, res.ProtocolVersion));
+                            $(connection).triggerHandler(events.onError, [protocolError]);
+                            deferred.reject(protocolError);
+
+                            return;
+                        }
+
+                        $.each(signalR.transports, function (key) {
+                            if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
+                                return true;
+                            }
+                            supportedTransports.push(key);
+                        });
+
+                        if ($.isArray(config.transport)) {
+                            $.each(config.transport, function (_, transport) {
+                                if ($.inArray(transport, supportedTransports) >= 0) {
+                                    transports.push(transport);
+                                }
+                            });
+                        } else if (config.transport === "auto") {
+                            transports = supportedTransports;
+                        } else if ($.inArray(config.transport, supportedTransports) >= 0) {
+                            transports.push(config.transport);
+                        }
+
+                        initialize(transports);
+                    }
                 }
             });
 

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
@@ -202,6 +202,7 @@
 
                 xhr = transportLogic.ajax(connection, {
                     url: url,
+                    headers: connection.accessToken ? { "Authorization": "Bearer " + connection.accessToken } : {},
                     success: function (result) {
                         var data;
 
@@ -345,6 +346,13 @@
             url += "?" + qs;
             url = transportLogic.prepareQueryString(connection, url);
 
+            // With sse or ws, access_token in request header is not supported
+            if (connection.transport && connection.accessToken) {
+                if (connection.transport.name === "serverSentEvents" || connection.transport.name === "webSockets") {
+                    url += "&access_token=" + window.encodeURIComponent(connection.accessToken);
+                }
+            }
+
             if (!ajaxPost) {
                 url += "&tid=" + Math.floor(Math.random() * 11);
             }
@@ -389,6 +397,7 @@
                 url: url,
                 type: connection.ajaxDataType === "jsonp" ? "GET" : "POST",
                 contentType: signalR._.defaultContentType,
+                headers: connection.accessToken ? { "Authorization": "Bearer " + connection.accessToken } : {},
                 data: {
                     data: payload
                 },
@@ -437,7 +446,8 @@
                 url: url,
                 async: async,
                 timeout: 1000,
-                type: "POST"
+                type: "POST",
+                headers: connection.accessToken ? { "Authorization": "Bearer " + connection.accessToken } : {}
             });
 
             connection.log("Fired ajax abort async = " + async + ".");
@@ -459,6 +469,7 @@
 
             connection._.startRequest = transportLogic.ajax(connection, {
                 url: getAjaxUrl(connection, "/start"),
+                headers: connection.accessToken ? { "Authorization": "Bearer " + connection.accessToken } : {},
                 success: function (result, statusText, xhr) {
                     var data;
 

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.longPolling.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.longPolling.js
@@ -106,6 +106,7 @@
                         contentType: signalR._.defaultContentType,
                         data: postData,
                         timeout: connection._.pollTimeout,
+                        headers: connection.accessToken ? { "Authorization": "Bearer " + connection.accessToken } : {},
                         success: function (result) {
                             var minData,
                                 delay = 0,


### PR DESCRIPTION
1. Add redirect support with `{AccessToken: ..., Url:...}` response
2. Add bearer authorization support, for ws and sse, token is added in the query string, for longpolling, header is used