### PR TITLE
chat client sample that works with the service sample

### DIFF
--- a/samples/Common/CommonClient.cs
+++ b/samples/Common/CommonClient.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
-
-#if !NET40
 
 using System;
 using System.IO;
@@ -10,7 +8,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR.Client.Hubs;
 
 namespace Microsoft.AspNet.SignalR.Client.Samples
 {
@@ -56,12 +53,12 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
 
             await hubProxy.Invoke("DisplayMessageCaller", "Hello Caller!");
 
-            string joinGroupResponse = await hubProxy.Invoke<string>("JoinGroup", hubConnection.ConnectionId, "CommonClientGroup");
+            var joinGroupResponse = await hubProxy.Invoke<string>("JoinGroup", hubConnection.ConnectionId, "CommonClientGroup");
             hubConnection.TraceWriter.WriteLine("joinGroupResponse={0}", joinGroupResponse);
 
             await hubProxy.Invoke("DisplayMessageGroup", "CommonClientGroup", "Hello Group Members!");
 
-            string leaveGroupResponse = await hubProxy.Invoke<string>("LeaveGroup", hubConnection.ConnectionId, "CommonClientGroup");
+            var leaveGroupResponse = await hubProxy.Invoke<string>("LeaveGroup", hubConnection.ConnectionId, "CommonClientGroup");
             hubConnection.TraceWriter.WriteLine("leaveGroupResponse={0}", leaveGroupResponse);
 
             await hubProxy.Invoke("DisplayMessageGroup", "CommonClientGroup", "Hello Group Members! (caller should not see this message)");
@@ -77,7 +74,7 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
             var hubProxy = hubConnection.CreateHubProxy("demo");
             hubProxy.On<int>("invoke", (i) =>
             {
-                int n = hubProxy.GetValue<int>("index");
+                var n = hubProxy.GetValue<int>("index");
                 hubConnection.TraceWriter.WriteLine("{0} client state index -> {1}", i, n);
             });
 
@@ -95,7 +92,7 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
 
         private async Task RunRawConnection(string serverUrl)
         {
-            string url = serverUrl + "raw-connection";
+            var url = serverUrl + "raw-connection";
 
             var connection = new Connection(url);
             connection.TraceWriter = _traceWriter;
@@ -110,7 +107,7 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
 
         private async Task RunStreaming(string serverUrl)
         {
-            string url = serverUrl + "streaming-connection";
+            var url = serverUrl + "streaming-connection";
 
             var connection = new Connection(url);
             connection.TraceWriter = _traceWriter;
@@ -121,7 +118,7 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
 
         private async Task RunAuth(string serverUrl)
         {
-            string url = serverUrl + "cookieauth";
+            var url = serverUrl + "cookieauth";
 
             var handler = new HttpClientHandler();
             handler.CookieContainer = new CookieContainer();
@@ -192,11 +189,11 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
             hubConnection.TraceLevel = TraceLevels.StateChanges;
 
             var hubProxy = hubConnection.CreateHubProxy("LongRunningHub");
-            ManualResetEvent event1 = new ManualResetEvent(false);
-            ManualResetEvent event2 = new ManualResetEvent(false);
+            var event1 = new ManualResetEvent(false);
+            var event2 = new ManualResetEvent(false);
 
-            int callbacks = 1000;
-            int counter = 0;
+            var callbacks = 1000;
+            var counter = 0;
             hubProxy.On<int>("serverIsWaiting", (i) =>
             {
                 if (i % 100 == 0)
@@ -215,12 +212,12 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
 
             hubConnection.TraceWriter.WriteLine("check memory size before sending longRunning");
 
-            for (int messageNumber = 1; messageNumber <= callbacks; messageNumber++)
+            for (var messageNumber = 1; messageNumber <= callbacks; messageNumber++)
             {
 #pragma warning disable 4014
                 hubProxy.Invoke("LongRunningMethod", messageNumber).ContinueWith(task =>
                 {
-                    int i = Interlocked.Increment(ref counter);
+                    var i = Interlocked.Increment(ref counter);
                     if (i % 100 == 0)
                     {
                         hubConnection.TraceWriter.WriteLine("{0} completed: {1} task.Status={2}", DateTime.Now, i, task.Status);
@@ -242,5 +239,3 @@ namespace Microsoft.AspNet.SignalR.Client.Samples
         }
     }
 }
-
-#endif

--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/ChatSample.cs
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/ChatSample.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.SignalR.Client.Samples
+{
+    public static class ChatSample
+    {
+        private static readonly string DefaultHub = "EchoHub";
+
+        public static async Task<int> SampleMain(string[] args)
+        {
+            string url = null;
+            string hub = null;
+            for (var i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "-u":
+                    case "--url":
+                        if(!TryReadArg(args, ref i, out url))
+                        {
+                            return 1;
+                        }
+                        break;
+                    case "-h":
+                    case "--hub":
+                        if(!TryReadArg(args, ref i, out hub))
+                        {
+                            return 1;
+                        }
+                        break;
+                }
+            }
+
+            if(string.IsNullOrEmpty(url))
+            {
+                Console.Error.WriteLine("Missing required argument '--url'");
+                return 1;
+            }
+
+            Console.Write("Enter your name: ");
+            var name = Console.ReadLine();
+
+            hub = string.IsNullOrEmpty(hub) ? DefaultHub : hub;
+
+            var connection = new HubConnection(url);
+            var proxy = connection.CreateHubProxy(hub);
+
+            proxy.On<string, string>("receive", (user, message) =>
+            {
+                Console.WriteLine($"{user}: {message}");
+            });
+
+            Console.WriteLine("Connecting...");
+            await connection.Start();
+            Console.WriteLine("Connected. Start chatting! Type 'exit' to exit.");
+
+            var running = true;
+            while(running)
+            {
+                Console.Write("> ");
+                var message = Console.ReadLine();
+                if(string.Equals(message, "exit", StringComparison.OrdinalIgnoreCase))
+                {
+                    running = false;
+                }
+                else
+                {
+                    await proxy.Invoke("Broadcast", name, message);
+                }
+            }
+
+            connection.Stop();
+            return 0;
+        }
+
+        private static bool TryReadArg(string[] args, ref int index, out string value)
+        {
+            if (index >= args.Length - 1)
+            {
+                Console.Error.WriteLine($"Missing value for argument '{args[index]}'");
+                value = null;
+                return false;
+            }
+
+            index += 1;
+            value = args[index];
+            return true;
+        }
+    }
+}

--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/Microsoft.AspNet.SignalR.Client.Samples.csproj
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/Microsoft.AspNet.SignalR.Client.Samples.csproj
@@ -1,27 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net40;net461</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
-    <DefineConstants>$(DefineConstants);MONO</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Net" />
-    <Reference Include="System.Net.Http" Condition="'$(TargetFramework)' != 'net40'" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\Common\CommonClient.net40.cs">
-      <Link>CommonClient.net40.cs</Link>
-    </Compile>
-    <Compile Include="..\Common\CommonClient.cs">
-      <Link>CommonClient.cs</Link>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.AspNet.SignalR.Client\Microsoft.AspNet.SignalR.Client.csproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net461</TargetFramework>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+        <DefineConstants>$(DefineConstants);MONO</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup>
+        <Reference Include="Microsoft.CSharp" />
+        <Reference Include="System" />
+        <Reference Include="System.Core" />
+        <Reference Include="System.Net" />
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Include="..\Common\CommonClient.cs">
+            <Link>CommonClient.cs</Link>
+        </Compile>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Microsoft.AspNet.SignalR.Client\Microsoft.AspNet.SignalR.Client.csproj" />
+    </ItemGroup>
 </Project>

--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/Program.cs
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/Program.cs
@@ -1,22 +1,43 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR.Client.Hubs;
 
 namespace Microsoft.AspNet.SignalR.Client.Samples
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static Task<int> Main(string[] args)
         {
-            var writer = Console.Out;
-            var client = new CommonClient(writer);
-            client.Run("http://localhost:40476/");
+            if (args.Length == 0)
+            {
+                PrintUsage();
+                return Task.FromResult(0);
+            }
 
-            Console.ReadKey();
+            switch (args[0])
+            {
+                case "chat":
+                    return ChatSample.SampleMain(args.Skip(1).ToArray());
+                default:
+                    PrintUsage();
+                    Console.Error.WriteLine($"Unknown subcommand: {args[0]}.");
+                    return Task.FromResult(1);
+            }
         }
+
+        private static void PrintUsage()
+        {
+            Console.WriteLine("ASP.NET SignalR Sample .NET Client");
+            Console.WriteLine();
+            Console.WriteLine($"Usage: {typeof(Program).Assembly.GetName().Name} <SAMPLE> <SAMPLE ARGS...>");
+            Console.WriteLine();
+            Console.WriteLine("Samples:");
+            Console.WriteLine("  chat - A chat sample");
+            Console.WriteLine();
+        }
+
     }
 }

--- a/samples/Microsoft.AspNet.SignalR.ServiceSample/EchoHub.cs
+++ b/samples/Microsoft.AspNet.SignalR.ServiceSample/EchoHub.cs
@@ -4,14 +4,14 @@ namespace Microsoft.AspNet.SignalR.ServiceSample
 {
     public class EchoHub : Hub
     {
-        public string SayHi(string name)
+        public override Task OnConnected()
         {
-            return $"Hello, {name}!";
+            return Clients.All.receive("<system>", "User joined");
         }
 
-        public async Task Broadcast(string message)
+        public Task Broadcast(string user, string message)
         {
-            await Clients.All.receive(message);
+            return Clients.All.receive(user, message);
         }
     }
 }

--- a/samples/Microsoft.AspNet.SignalR.ServiceSample/Startup.cs
+++ b/samples/Microsoft.AspNet.SignalR.ServiceSample/Startup.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+using System.Web.Configuration;
 using Microsoft.Owin;
 using Owin;
 
@@ -9,7 +11,30 @@ namespace Microsoft.AspNet.SignalR.ServiceSample
     {
         public void Configuration(IAppBuilder app)
         {
-            app.MapAzureSignalR(typeof(Startup).FullName);
+            if (!string.IsNullOrEmpty(WebConfigurationManager.ConnectionStrings["Azure:SignalR:ConnectionString"]?.ConnectionString))
+            {
+                app.Use((context, next) => ServerInfoMiddleware(context, next, usingAzureSignalR: true));
+                app.MapAzureSignalR(typeof(Startup).FullName);
+            }
+            else
+            {
+                app.Use((context, next) => ServerInfoMiddleware(context, next, usingAzureSignalR: false));
+                app.MapSignalR();
+            }
+        }
+
+        private static async Task ServerInfoMiddleware(IOwinContext context, System.Func<Task> next, bool usingAzureSignalR)
+        {
+            if (context.Request.Path.StartsWithSegments(new PathString("/server-info")))
+            {
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "application/javascript";
+                await context.Response.WriteAsync($"window._server = {{ azureSignalR: {usingAzureSignalR.ToString().ToLowerInvariant()} }};");
+            }
+            else
+            {
+                await next();
+            }
         }
     }
 }

--- a/samples/Microsoft.AspNet.SignalR.ServiceSample/index.html
+++ b/samples/Microsoft.AspNet.SignalR.ServiceSample/index.html
@@ -13,9 +13,12 @@
             font-weight: bold;
         }
     </style>
+    <script src="/server-info"></script>
 </head>
 <body>
     <h1>Azure SignalR Service Sample</h1>
+    <h2 id="azureSignalRBanner" style="display: none">Using the Azure SignalR Service</h2>
+    <h2 id="localSignalRBanner" style="display: none">Using Local SignalR App</h2>
 
     <div>
         <select id="transportSelect">
@@ -51,12 +54,23 @@
     <script src="signalr/hubs"></script>
     <script>
         $(function () {
+            var name = prompt("Enter your name:");
+            if (window._server.azureSignalR) {
+                $("#azureSignalRBanner").show();
+                $("#localSignalRBanner").hide();
+            }
+            else {
+                $("#localSignalRBanner").show();
+                $("#azureSignalRBanner").hide();
+            }
+
             var connection = $.hubConnection("/signalr", { useDefaultPath: false, logging: true });
             var echoHub = connection.createHubProxy("echoHub");
 
-            echoHub.on("receive", function (message) {
-                var encodedMsg = $("<div />").text(message).html();
-                $("#messagesList").append("<li>" + encodedMsg + "</li>");
+            echoHub.on("receive", function (user, message) {
+                user = $("<div />").text(user).html();
+                message = $("<div />").text(message).html();
+                $("#messagesList").append("<li><strong>" + user + "</strong>: " + message + "</li>");
             });
             $("#connectButton").click(function () {
                 connection.start({ transport: $("#transportSelect").val() }).done(function () {
@@ -86,7 +100,7 @@
 
             $("#broadcast").submit(function (evt) {
                 evt.preventDefault();
-                echoHub.invoke("broadcast", $("#messageInput").val());
+                echoHub.invoke("broadcast", name, $("#messageInput").val());
             });
         });
     </script>


### PR DESCRIPTION
This sample works with the Azure SignalR Service sample!

Usage:
1. Launch Microsoft.AspNet.SignalR.ServiceSample with an Azure SignalR connection string in the Web.config
2. `cd samples/MIcrosoft.AspNet.SignalR.Client.Samples`
3. `dotnet run -- chat --url [url]` where `[url]` is the `/signalr` endpoint for the service sample (`http://localhost:1234/signalr`, if the sample is running on `localhost:1234`)