### PR TITLE
fix #4175 by making TryGetConnectionId virtual

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/PersistentConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/PersistentConnection.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -290,8 +290,17 @@ namespace Microsoft.AspNet.SignalR
             return Transport.ProcessRequest(connection).OrEmpty().Catch(Trace, Counters.ErrorsAllTotal, Counters.ErrorsAllPerSec);
         }
 
+        /// <summary>
+        /// Validates the connection token and extracts the connection ID from it.
+        /// </summary>
+        /// <param name="context">The <see cref="HostContext" /> representing the request.</param>
+        /// <param name="connectionToken">The connection token to validate.</param>
+        /// <param name="connectionId">If this method returns true, this output parameter receives the connection ID contained within the token.</param>
+        /// <param name="message">If this method returns false, this output parameter receives an error message to report.</param>
+        /// <param name="statusCode">If this method returns false, this output parameter receives an HTTP status code to report.</param>
+        /// <returns>A boolean indicating if the connection token was valid.</returns>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to catch any exception when unprotecting data.")]
-        internal bool TryGetConnectionId(HostContext context,
+        protected virtual bool TryGetConnectionId(HostContext context,
                                            string connectionToken,
                                            out string connectionId,
                                            out string message,

--- a/src/Microsoft.AspNet.SignalR.Core/PersistentConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/PersistentConnection.cs
@@ -300,7 +300,7 @@ namespace Microsoft.AspNet.SignalR
         /// <param name="statusCode">If this method returns false, this output parameter receives an HTTP status code to report.</param>
         /// <returns>A boolean indicating if the connection token was valid.</returns>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to catch any exception when unprotecting data.")]
-        protected virtual bool TryGetConnectionId(HostContext context,
+        protected internal virtual bool TryGetConnectionId(HostContext context,
                                            string connectionToken,
                                            out string connectionId,
                                            out string message,

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestRequest.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestRequest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Hosting;
+using Microsoft.AspNet.SignalR.Tests.Common.Infrastructure;
+
+namespace Microsoft.AspNet.SignalR.Tests.Common
+{
+    public class TestRequest : IRequest
+    {
+        public Uri Url { get; set; }
+
+        public string LocalPath { get; set; }
+
+        public IDictionary<string, Cookie> Cookies { get; } = new Dictionary<string, Cookie>();
+
+        public IPrincipal User { get; set; }
+
+        public IDictionary<string, object> Environment { get; } = new Dictionary<string, object>();
+
+        public NameValueCollection QueryString { get; } = new NameValueCollection();
+
+        public NameValueCollection Headers { get; } = new NameValueCollection();
+
+        public NameValueCollection Form {get; } = new NameValueCollection();
+
+        INameValueCollection IRequest.QueryString => new NameValueCollectionWrapper(QueryString);
+
+        INameValueCollection IRequest.Headers => new NameValueCollectionWrapper(Headers);
+
+        public Task<INameValueCollection> ReadForm()
+        {
+            return Task.FromResult<INameValueCollection>(new NameValueCollectionWrapper(Form));
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestResponse.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestResponse.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Hosting;
+
+namespace Microsoft.AspNet.SignalR.Tests.Common
+{
+    public class TestResponse : IResponse
+    {
+        private MemoryStream _body = new MemoryStream();
+
+        public CancellationToken CancellationToken => CancellationTokenSource.Token;
+
+        public CancellationTokenSource CancellationTokenSource { get; } = new CancellationTokenSource();
+
+        public int StatusCode { get; set; }
+
+        public string ContentType { get; set; }
+
+        public byte[] GetBody() => _body.ToArray();
+
+        public Task Flush()
+        {
+            return Task.CompletedTask;
+        }
+
+        public void Write(ArraySegment<byte> data)
+        {
+            _body.Write(data.Array, data.Offset, data.Count);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestResponse.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestResponse.cs
@@ -23,14 +23,10 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
 
         public byte[] GetBody() => _body.ToArray();
 
-        public Task Flush()
-        {
-            return Task.CompletedTask;
-        }
+        public string GetBodyAsString() => Encoding.UTF8.GetString(GetBody());
 
-        public void Write(ArraySegment<byte> data)
-        {
-            _body.Write(data.Array, data.Offset, data.Count);
-        }
+        public Task Flush() => Task.CompletedTask;
+
+        public void Write(ArraySegment<byte> data) => _body.Write(data.Array, data.Offset, data.Count);
     }
 }

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransport.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransport.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Transports;
+
+namespace Microsoft.AspNet.SignalR.Tests.Common
+{
+    public class TestTransport : ITransport
+    {
+        public Func<string, Task> Received { get; set; }
+
+        public Func<Task> Connected { get; set; }
+
+        public Func<Task> Reconnected { get; set; }
+
+        public Func<bool, Task> Disconnected { get; set; }
+
+        public string ConnectionId { get; set; }
+
+        public string GroupsToken { get; set; }
+
+        public Task<string> GetGroupsToken()
+        {
+            return Task.FromResult(GroupsToken);
+        }
+
+        public Task ProcessRequest(ITransportConnection connection)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Send(object value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransport.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransport.cs
@@ -6,6 +6,8 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
 {
     public class TestTransport : ITransport
     {
+        public int ProcessRequestCalls { get; private set; } = 0;
+
         public Func<string, Task> Received { get; set; }
 
         public Func<Task> Connected { get; set; }
@@ -25,12 +27,14 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
 
         public Task ProcessRequest(ITransportConnection connection)
         {
-            throw new NotImplementedException();
+            ProcessRequestCalls += 1;
+            // Just no-op
+            return Task.CompletedTask;
         }
 
         public Task Send(object value)
         {
-            throw new NotImplementedException();
+            throw new InvalidOperationException("Reached TestTransport.Send");
         }
     }
 }

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransportManager.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransportManager.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNet.SignalR.Hosting;
+using Microsoft.AspNet.SignalR.Transports;
+
+namespace Microsoft.AspNet.SignalR.Tests.Common
+{
+    public class TestTransportManager : ITransportManager
+    {
+        public static readonly string TestTransportName = "test";
+        private Dictionary<string, Func<ITransport>> _transports;
+
+        public TestTransport TestTransport { get; } = new TestTransport();
+
+        public TestTransportManager()
+        {
+            _transports.Add(TestTransportName, () => TestTransport);
+        }
+
+        public void AddTransport(string name, Func<ITransport> factory)
+        {
+            _transports[name] = factory;
+        }
+
+        public ITransport GetTransport(HostContext hostContext)
+        {
+            if (_transports.TryGetValue(hostContext.Request.QueryString["transport"], out var factory))
+            {
+                return factory();
+            }
+            return null;
+        }
+
+        public bool SupportsTransport(string transportName)
+        {
+            return _transports.Contains(transportName);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransportManager.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/TestTransportManager.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
     public class TestTransportManager : ITransportManager
     {
         public static readonly string TestTransportName = "test";
-        private Dictionary<string, Func<ITransport>> _transports;
+        private Dictionary<string, Func<ITransport>> _transports = new Dictionary<string, Func<ITransport>>();
 
         public TestTransport TestTransport { get; } = new TestTransport();
 
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
 
         public bool SupportsTransport(string transportName)
         {
-            return _transports.Contains(transportName);
+            return _transports.ContainsKey(transportName);
         }
     }
 }

--- a/test/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/PersistentConnectionFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -14,6 +14,7 @@ using Moq.Protected;
 using Xunit;
 using Microsoft.AspNet.SignalR.Tests.Utilities;
 using System.Threading;
+using Microsoft.AspNet.SignalR.Tests.Common;
 
 namespace Microsoft.AspNet.SignalR.Tests
 {
@@ -334,6 +335,33 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 Assert.Equal(true, connection.Object.TryGetConnectionId(context, connectionId + ":::11:::::::1:1", out cid, out message, out statusCode));
                 Assert.Equal(connectionId, cid);
+            }
+
+            [Fact]
+            public void TryGetConnectionIdIsUsedToExtractConnectionIdFromToken()
+            {
+                var connection = new TokenValidatingPersistentConnection();
+                var req = new TestRequest();
+                var resp = new TestResponse();
+                req.QueryString["connectionToken"] = TokenValidatingPersistentConnection.ExpectedConnectionToken;
+
+                var resolver = new DefaultDependencyResolver();
+
+                // Initialize the connection
+                connection.Initialize(resolver);
+
+                // Run the request
+                var context = new HostContext(req, resp);
+                connection.ProcessRequest(context);
+            }
+
+            private class TokenValidatingPersistentConnection : PersistentConnection
+            {
+                public static readonly string ExpectedConnectionToken = "expectedToken";
+
+                protected internal override bool TryGetConnectionId(HostContext context, string connectionToken, out string connectionId, out string message, out int statusCode)
+                {
+                }
             }
         }
     }


### PR DESCRIPTION
The Azure SignalR Service SDK uses it's own custom connection tokens. Currently, make things work, they manually hack up a connection token that will validate correctly when they pass it through their PersistentConnection. This change allows any PersistentConnection to provide custom `connectionToken` validation and parsing logic by overriding the `TryGetConnectionId` method.

cc @vicancy

Fixes #4175 