### PR TITLE
fix #4092 by disposing the response if it's a failed status code

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
@@ -86,7 +86,11 @@ namespace Microsoft.AspNet.SignalR.Client.Http
                      }
                      else
                      {
-                         throw new HttpClientException(responseMessage);
+                         // Dispose the response (https://github.com/SignalR/SignalR/issues/4092)
+                         var message = responseMessage.ToString();
+                         responseMessage.RequestMessage?.Dispose();
+                         responseMessage.Dispose();
+                         throw new HttpClientException(message);
                      }
 
                      return (IResponse)new HttpResponseMessageWrapper(responseMessage);
@@ -154,7 +158,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
         /// </summary>
         /// <param name="isLongRunning">Indicates whether the request is long running</param>
         /// <returns></returns>
-        private HttpClient GetHttpClient(bool isLongRunning)
+        private protected virtual HttpClient GetHttpClient(bool isLongRunning)
         {
             return isLongRunning ? _longRunningClient : _shortRunningClient;
         }

--- a/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
@@ -75,7 +75,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
 
             prepareRequest(request);
 
-            HttpClient httpClient = GetHttpClient(isLongRunning);
+            var httpClient = GetHttpClient(isLongRunning);
 
             return httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token)
                  .Then(responseMessage =>
@@ -88,7 +88,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
                      {
                          // Dispose the response (https://github.com/SignalR/SignalR/issues/4092)
                          var message = responseMessage.ToString();
-                         responseMessage.RequestMessage?.Dispose();
+                         responseMessage.RequestMessage.Dispose();
                          responseMessage.Dispose();
                          throw new HttpClientException(message);
                      }
@@ -135,9 +135,9 @@ namespace Microsoft.AspNet.SignalR.Client.Http
 
             prepareRequest(request);
 
-            HttpClient httpClient = GetHttpClient(isLongRunning);
+            var httpClient = GetHttpClient(isLongRunning);
 
-            return httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token)                
+            return httpClient.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cts.Token)
                 .Then(responseMessage =>
                 {
                     if (responseMessage.IsSuccessStatusCode)
@@ -146,7 +146,11 @@ namespace Microsoft.AspNet.SignalR.Client.Http
                     }
                     else
                     {
-                        throw new HttpClientException(responseMessage);
+                        // Dispose the response (https://github.com/SignalR/SignalR/issues/4092)
+                        var message = responseMessage.ToString();
+                        responseMessage.RequestMessage.Dispose();
+                        responseMessage.Dispose();
+                        throw new HttpClientException(message);
                     }
 
                     return (IResponse)new HttpResponseMessageWrapper(responseMessage);

--- a/src/Microsoft.AspNet.SignalR.Client/Http/HttpResponseMessageWrapper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/HttpResponseMessageWrapper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
         {
             if (disposing)
             {
-                _httpResponseMessage.RequestMessage.Dispose();
+                _httpResponseMessage.RequestMessage?.Dispose();
                 _httpResponseMessage.Dispose();
             }
         }

--- a/src/Microsoft.AspNet.SignalR.Client/Http/HttpResponseMessageWrapper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/HttpResponseMessageWrapper.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
         {
             if (disposing)
             {
-                _httpResponseMessage.RequestMessage?.Dispose();
+                _httpResponseMessage.RequestMessage.Dispose();
                 _httpResponseMessage.Dispose();
             }
         }

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Http/TestHttpMessageHandler.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Http/TestHttpMessageHandler.cs
@@ -1,0 +1,109 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.SignalR.Client.Http
+{
+    internal delegate Task<HttpResponseMessage> RequestDelegate(HttpRequestMessage requestMessage, CancellationToken cancellationToken);
+
+    public class TestHttpMessageHandler : HttpMessageHandler
+    {
+        private List<HttpRequestMessage> _receivedRequests = new List<HttpRequestMessage>();
+        private RequestDelegate _app;
+
+        private List<Func<RequestDelegate, RequestDelegate>> _middleware = new List<Func<RequestDelegate, RequestDelegate>>();
+
+        public bool Disposed { get; private set; }
+
+        public IReadOnlyList<HttpRequestMessage> ReceivedRequests
+        {
+            get
+            {
+                lock (_receivedRequests)
+                {
+                    return _receivedRequests.ToArray();
+                }
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+
+            lock (_receivedRequests)
+            {
+                _receivedRequests.Add(request);
+
+                if (_app == null)
+                {
+                    _middleware.Reverse();
+                    RequestDelegate handler = BaseHandler;
+                    foreach (var middleware in _middleware)
+                    {
+                        handler = middleware(handler);
+                    }
+
+                    _app = handler;
+                }
+            }
+
+            return await _app(request, cancellationToken);
+        }
+
+        public void OnRequest(Func<HttpRequestMessage, Func<Task<HttpResponseMessage>>, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            void OnRequestCore(Func<RequestDelegate, RequestDelegate> middleware)
+            {
+                _middleware.Add(middleware);
+            }
+
+            OnRequestCore(next =>
+            {
+                return (request, cancellationToken) =>
+                {
+                    return handler(request, () => next(request, cancellationToken), cancellationToken);
+                };
+            });
+        }
+
+        public void OnGet(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Get, pathAndQuery, handler);
+        public void OnPost(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Post, pathAndQuery, handler);
+        public void OnPut(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Put, pathAndQuery, handler);
+        public void OnDelete(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Delete, pathAndQuery, handler);
+        public void OnHead(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Head, pathAndQuery, handler);
+        public void OnOptions(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Options, pathAndQuery, handler);
+        public void OnTrace(string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler) => OnRequest(HttpMethod.Trace, pathAndQuery, handler);
+
+        public void OnRequest(HttpMethod method, string pathAndQuery, Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> handler)
+        {
+            OnRequest((request, next, cancellationToken) =>
+            {
+                if (request.Method.Equals(method) && string.Equals(request.RequestUri.PathAndQuery, pathAndQuery))
+                {
+                    return handler(request, cancellationToken);
+                }
+                else
+                {
+                    return next();
+                }
+            });
+        }
+
+        private Task<HttpResponseMessage> BaseHandler(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromException<HttpResponseMessage>(new InvalidOperationException($"Http endpoint not implemented: {request.Method} {request.RequestUri}"));
+        }
+    }
+}


### PR DESCRIPTION
fixes #4092 by disposing the response on a failure.

TODO:
* [ ] Verify the full end-to-end behavior is fixed using repro for #4092