### PR TITLE
Major deflaking

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
@@ -86,8 +86,12 @@ namespace Microsoft.AspNet.SignalR.Client.Http
                      }
                      else
                      {
+                         // Dispose the response (https://github.com/SignalR/SignalR/issues/4092)
                          responseMessage.RequestMessage.Dispose();
                          responseMessage.Dispose();
+
+                         // None of the getters on HttpResponseMessage throw ODE, so it should be safe to give the catcher of the exception
+                         // access to the response. They may get an ODE if they try to read the body, but that's OK.
                          throw new HttpClientException(responseMessage);
                      }
 

--- a/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/DefaultHttpClient.cs
@@ -86,11 +86,9 @@ namespace Microsoft.AspNet.SignalR.Client.Http
                      }
                      else
                      {
-                         // Dispose the response (https://github.com/SignalR/SignalR/issues/4092)
-                         var message = responseMessage.ToString();
                          responseMessage.RequestMessage.Dispose();
                          responseMessage.Dispose();
-                         throw new HttpClientException(message);
+                         throw new HttpClientException(responseMessage);
                      }
 
                      return (IResponse)new HttpResponseMessageWrapper(responseMessage);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/HubProxyFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/HubProxyFacts.cs
@@ -184,12 +184,12 @@ namespace Microsoft.AspNet.SignalR.Tests
                         wh.TrySetResult(null);
                     });
 
-                    hubConnection.Start(host.Transport).Wait();
+                    await hubConnection.Start(host.Transport).OrTimeout();
 
                     // The calls should be complete once the start task returns
                     Assert.Equal(2, bufferMeCalls);
 
-                    proxy.Invoke("Ping").Wait();
+                    await proxy.Invoke("Ping").OrTimeout();
 
                     await wh.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
@@ -432,7 +432,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     await hubConnection.Start(host.Transport);
                     var ignore = proxy.Invoke("Send").Catch();
 
-                    Assert.True(tcs.Task.Wait(TimeSpan.FromSeconds(10)));
+                    await tcs.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/WebSocketFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/WebSocketFacts.cs
@@ -2,15 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR.Client;
-using Microsoft.AspNet.SignalR.Tests.Common;
 using Microsoft.AspNet.SignalR.Tests.Common.Infrastructure;
-using Microsoft.AspNet.SignalR.Tests.Utilities;
 using Xunit;
-using Xunit.Extensions;
-using Microsoft.AspNet.SignalR.Infrastructure;
 
 namespace Microsoft.AspNet.SignalR.Tests
 {
@@ -25,7 +19,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 host.Initialize();
 
-                HubConnection connection = CreateHubConnection(host);
+                var connection = CreateHubConnection(host);
 
                 using (connection)
                 {
@@ -49,7 +43,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 host.Initialize();
 
-                HubConnection connection = CreateHubConnection(host);
+                var connection = CreateHubConnection(host);
 
                 using (connection)
                 {
@@ -57,10 +51,7 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                     await connection.Start(host.Transport);
 
-                    TestUtilities.AssertUnwrappedException<InvalidOperationException>(() =>
-                    {
-                        hub.Invoke<string>("EchoReturn", new string('a', 64 * 1024)).Wait();
-                    });
+                    await Assert.ThrowsAsync<InvalidOperationException>(() => hub.Invoke<string>("EchoReturn", new string('a', 64 * 1024))).OrTimeout();
                 }
             }
         }
@@ -75,7 +66,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 // Disable max message size
                 host.Initialize(maxIncomingWebSocketMessageSize: null);
 
-                HubConnection connection = CreateHubConnection(host);
+                var connection = CreateHubConnection(host);
 
                 using (connection)
                 {
@@ -101,7 +92,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 // Increase max message size
                 host.Initialize(maxIncomingWebSocketMessageSize: 128 * 1024);
 
-                HubConnection connection = CreateHubConnection(host);
+                var connection = CreateHubConnection(host);
 
                 using (connection)
                 {
@@ -127,7 +118,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 // Reduce max message size
                 host.Initialize(maxIncomingWebSocketMessageSize: 8 * 1024);
 
-                HubConnection connection = CreateHubConnection(host);
+                var connection = CreateHubConnection(host);
 
                 using (connection)
                 {
@@ -155,16 +146,16 @@ namespace Microsoft.AspNet.SignalR.Tests
                                 connectionTimeout: 2,
                                 enableAutoRejoiningGroups: true);
 
-                using (HubConnection connection = CreateHubConnection(host))
+                using (var connection = CreateHubConnection(host))
                 {
                     var proxy = connection.CreateHubProxy("demo");
-                    
+
                     connection.Reconnecting += async () =>
                     {
                         try
                         {
                             await connection.Send("test");
-                        } 
+                        }
                         catch (InvalidOperationException)
                         {
                             wh1.TrySetResult(null);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Microsoft.AspNet.SignalR.FunctionalTests.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(DefaultTestFrameworks)</TargetFrameworks>
-    <IncludeDefaultXunitConfig>false</IncludeDefaultXunitConfig>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="$(CastleCorePackageVersion)" />

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/FarmFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/FarmFacts.cs
@@ -64,7 +64,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Connections
 
                 for (int i = 0; i < nodeCount; i++)
                 {
-                    broadcasters[i].Broadcast(String.Format("From Node {0}: {1}", i, i + 1)).Wait();
+                    await broadcasters[i].Broadcast(String.Format("From Node {0}: {1}", i, i + 1)).OrTimeout();
                     await Task.Delay(TimeSpan.FromSeconds(1));
                 }
 
@@ -127,12 +127,12 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Connections
                     const string group = "group";
                     const string message = "message";
 
-                    var mre = new AsyncManualResetEvent();
+                    var mre = new TaskCompletionSource<object>();
                     proxy.On<string>("message", m =>
                     {
                         if (m == message)
                         {
-                            mre.Set();
+                            mre.TrySetResult(null);
                         }
                     });
 
@@ -155,7 +155,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Connections
                     await proxy.Invoke("JoinGroup", group);
                     await proxy.Invoke("SendToGroup", group, message);
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(5)));
+                    await mre.Task.OrTimeout();
                 }
             }
         }
@@ -186,12 +186,12 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Connections
                     const string group = "group";
                     const string message = "message";
 
-                    var mre = new AsyncManualResetEvent();
+                    var mre = new TaskCompletionSource<object>();
                     proxy.On<string>("message", m =>
                     {
                         if (m == message)
                         {
-                            mre.Set();
+                            mre.TrySetResult(null);
                         }
                     });
 
@@ -205,7 +205,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Connections
                     await secondHubContext.Groups.Add(connection.ConnectionId, group);
                     await proxy.Invoke("SendToGroup", group, message);
 
-                    Assert.True(await mre.WaitAsync(TimeSpan.FromSeconds(5)));
+                    await mre.Task.OrTimeout();
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/DateFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/DateFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -32,17 +32,17 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server
                 var hub = connection.CreateHubProxy("DateAsStringHub");
                 var request = new TypeWithDateAsString();
                 request.DateAsString = expected;
-                var wh = new AsyncManualResetEvent(false);
+                var wh = new TaskCompletionSource<object>();
                 hub.On<TypeWithDateAsString>("Callback", (data) =>
                 {
                     callback = data;
-                    wh.Set();
+                    wh.TrySetResult(null);
                 });
 
                 await connection.Start(host.Transport);
                 var response = await hub.Invoke<TypeWithDateAsString>("Invoke", request);
                 Assert.Equal(expected, response.DateAsString);
-                Assert.True(await wh.WaitAsync(TimeSpan.FromSeconds(10)));
+                await wh.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 Assert.Equal(expected, callback.DateAsString);
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/GetHubContextFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/GetHubContextFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -36,18 +36,18 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 using (connection1)
                 {
-                    var wh1 = new AsyncManualResetEvent(initialState: false);
+                    var wh1 = new TaskCompletionSource<object>();
 
                     var hub1 = connection1.CreateHubProxy("SendToSome");
 
                     await connection1.Start(host);
 
-                    hub1.On("send", wh1.Set);
+                    hub1.On("send", () => wh1.TrySetResult(null));
 
-                    hubContext.Groups.Add(connection1.ConnectionId, "Foo").Wait();
+                    await hubContext.Groups.Add(connection1.ConnectionId, "Foo");
                     hubContext.Clients.Group("Foo").send();
 
-                    Assert.True(await wh1.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh1.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 IHubContext<IBasicClient> hubContext = HubFacts.InitializeUserByQuerystring(host);
 
-                var wh = new AsyncManualResetEvent();
+                var wh = new TaskCompletionSource<object>();
 
                 using (var connection = HubFacts.GetUserConnection("myuser"))
                 {
@@ -67,11 +67,11 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                     await connection.Start(host);
 
-                    hub.On("send", wh.Set);
+                    hub.On("send", () => wh.TrySetResult(null));
 
                     hubContext.Clients.User("myuser").send();
 
-                    Assert.True(await wh.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -83,8 +83,8 @@ namespace Microsoft.AspNet.SignalR.Tests
             {
                 IHubContext<IBasicClient> hubContext = HubFacts.InitializeUserByQuerystring(host);
 
-                var wh1 = new AsyncManualResetEvent();
-                var wh2 = new AsyncManualResetEvent();
+                var wh1 = new TaskCompletionSource<object>();
+                var wh2 = new TaskCompletionSource<object>();
 
                 var connection1 = HubFacts.GetUserConnection("myuser");
                 var connection2 = HubFacts.GetUserConnection("myuser2");
@@ -98,13 +98,13 @@ namespace Microsoft.AspNet.SignalR.Tests
                     await connection1.Start(host);
                     await connection2.Start(host);
 
-                    proxy1.On("send", wh1.Set);
-                    proxy2.On("send", wh2.Set);
+                    proxy1.On("send", () => wh1.TrySetResult(null));
+                    proxy2.On("send", () => wh2.TrySetResult(null));
 
                     hubContext.Clients.Users(new List<string> { "myuser", "myuser2" }).send();
 
-                    Assert.True(await wh1.WaitAsync(TimeSpan.FromSeconds(10)));
-                    Assert.True(await wh2.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh1.Task.OrTimeout(TimeSpan.FromSeconds(10));
+                    await wh2.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -130,18 +130,18 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 using (connection1)
                 {
-                    var wh1 = new AsyncManualResetEvent(initialState: false);
+                    var wh1 = new TaskCompletionSource<object>();
 
                     var hub1 = connection1.CreateHubProxy("SendToSome");
 
                     await connection1.Start(host);
 
-                    hub1.On("send", () => wh1.Set());
+                    hub1.On("send", () => wh1.TrySetResult(null));
 
                     await hubContext.Groups.Add(connection1.ConnectionId, "Foo");
                     hubContext.Clients.Groups(new[] { "Foo" }).send();
 
-                    Assert.True(await wh1.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh1.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -167,17 +167,17 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 using (connection1)
                 {
-                    var wh1 = new AsyncManualResetEvent(initialState: false);
+                    var wh1 = new TaskCompletionSource<object>();
 
                     var hub1 = connection1.CreateHubProxy("SendToSome");
 
                     await connection1.Start(host);
 
-                    hub1.On("send", wh1.Set);
+                    hub1.On("send", () => wh1.TrySetResult(null));
 
                     hubContext.Clients.Client(connection1.ConnectionId).send();
 
-                    Assert.True(await wh1.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh1.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -203,17 +203,17 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 using (connection1)
                 {
-                    var wh1 = new AsyncManualResetEvent(initialState: false);
+                    var wh1 = new TaskCompletionSource<object>();
 
                     var hub1 = connection1.CreateHubProxy("SendToSome");
 
                     await connection1.Start(host);
 
-                    hub1.On("send", wh1.Set);
+                    hub1.On("send", () => wh1.TrySetResult(null));
 
                     hubContext.Clients.Clients(new[] { connection1.ConnectionId }).send();
 
-                    Assert.True(await wh1.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh1.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }
@@ -241,8 +241,8 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection1)
                 using (connection2)
                 {
-                    var wh1 = new AsyncManualResetEvent(initialState: false);
-                    var wh2 = new AsyncManualResetEvent(initialState: false);
+                    var wh1 = new TaskCompletionSource<object>();
+                    var wh2 = new TaskCompletionSource<object>();
 
                     var hub1 = connection1.CreateHubProxy("SendToSome");
                     var hub2 = connection2.CreateHubProxy("SendToSome");
@@ -250,13 +250,13 @@ namespace Microsoft.AspNet.SignalR.Tests
                     await connection1.Start(host);
                     await connection2.Start(host);
 
-                    hub1.On("send", wh1.Set);
-                    hub2.On("send", wh2.Set);
+                    hub1.On("send", () => wh1.TrySetResult(null));
+                    hub2.On("send", () => wh2.TrySetResult(null));
 
                     hubContext.Clients.All.send();
 
-                    Assert.True(await wh1.WaitAsync(TimeSpan.FromSeconds(10)));
-                    Assert.True(await wh2.WaitAsync(TimeSpan.FromSeconds(10)));
+                    await wh1.Task.OrTimeout(TimeSpan.FromSeconds(10));
+                    await wh2.Task.OrTimeout(TimeSpan.FromSeconds(10));
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
@@ -349,22 +350,22 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
 
         [Fact]
-        public void UnauthenticatedUserCannotInvokeMethodsInAuthorizedHubs()
+        public async Task UnauthenticatedUserCannotInvokeMethodsInAuthorizedHubs()
         {
             using (var host = new MemoryHost())
             {
@@ -384,14 +385,12 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AuthHub");
-                    var wh = new ManualResetEvent(false);
                     hub.On<string, string>("invoked", (id, time) =>
                     {
-                        Assert.NotNull(id);
-                        wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }
@@ -417,24 +416,24 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string>("invoked", (id, time) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
                     await hub.Invoke("InvokedFromClient").OrTimeout();
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
 
         [Fact]
-        public void UnauthenticatedUserCannotReceiveHubMessagesFromHubsInheritingFromAuthorizedHubs()
+        public async Task UnauthenticatedUserCannotReceiveHubMessagesFromHubsInheritingFromAuthorizedHubs()
         {
             using (var host = new MemoryHost())
             {
@@ -453,14 +452,12 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("InheritAuthHub");
-                    var wh = new ManualResetEvent(false);
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
-                        Assert.NotNull(id);
-                        wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }
@@ -486,22 +483,22 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("InheritAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
 
         [Fact]
-        public void UnauthenticatedUserCannotInvokeMethodsInHubsInheritingFromAuthorizedHubs()
+        public async Task UnauthenticatedUserCannotInvokeMethodsInHubsInheritingFromAuthorizedHubs()
         {
             using (var host = new MemoryHost())
             {
@@ -521,14 +518,12 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("InheritAuthHub");
-                    var wh = new ManualResetEvent(false);
                     hub.On<string, string>("invoked", (id, time) =>
                     {
-                        Assert.NotNull(id);
-                        wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }
@@ -554,24 +549,24 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("InheritAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string>("invoked", (id, time) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
                     await hub.Invoke("InvokedFromClient").OrTimeout();
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
 
         [Fact]
-        public void UnauthenticatedUserCannotReceiveHubMessagesFromHubsAuthorizedWithRoles()
+        public async Task UnauthenticatedUserCannotReceiveHubMessagesFromHubsAuthorizedWithRoles()
         {
             using (var host = new MemoryHost())
             {
@@ -591,20 +586,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AdminAuthHub");
-                    var wh = new ManualResetEvent(false);
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
-                        Assert.NotNull(id);
-                        wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }
 
         [Fact]
-        public void UnauthenticatedUserCannotInvokeMethodsInHubsAuthorizedWithRoles()
+        public async Task UnauthenticatedUserCannotInvokeMethodsInHubsAuthorizedWithRoles()
         {
             using (var host = new MemoryHost())
             {
@@ -631,13 +624,14 @@ namespace Microsoft.AspNet.SignalR.Tests
                         wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode); 
                 }
             }
         }
 
         [Fact]
-        public void UnauthorizedUserCannotReceiveHubMessagesFromHubsAuthorizedWithRoles()
+        public async Task UnauthorizedUserCannotReceiveHubMessagesFromHubsAuthorizedWithRoles()
         {
             using (var host = new MemoryHost())
             {
@@ -664,13 +658,14 @@ namespace Microsoft.AspNet.SignalR.Tests
                         wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Forbidden, ex.Response.StatusCode);
                 }
             }
         }
 
         [Fact]
-        public void UnauthorizedUserCannotInvokeMethodsInHubsAuthorizedWithRoles()
+        public async Task UnauthorizedUserCannotInvokeMethodsInHubsAuthorizedWithRoles()
         {
             using (var host = new MemoryHost())
             {
@@ -690,14 +685,12 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AdminAuthHub");
-                    var wh = new ManualResetEvent(false);
                     hub.On<string, string>("invoked", (id, time) =>
                     {
-                        Assert.NotNull(id);
-                        wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Forbidden, ex.Response.StatusCode);
                 }
             }
         }
@@ -723,16 +716,16 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AdminAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
@@ -758,24 +751,24 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("AdminAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string>("invoked", (id, time) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
                     await hub.Invoke("InvokedFromClient").OrTimeout();
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
 
         [Fact]
-        public void UnauthorizedUserCannotReceiveHubMessagesFromHubsAuthorizedSpecifyingUserAndRole()
+        public async Task UnauthorizedUserCannotReceiveHubMessagesFromHubsAuthorizedSpecifyingUserAndRole()
         {
             using (var host = new MemoryHost())
             {
@@ -795,20 +788,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("UserAndRoleAuthHub");
-                    var wh = new ManualResetEvent(false);
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
-                        Assert.NotNull(id);
-                        wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Forbidden, ex.Response.StatusCode);
                 }
             }
         }
 
         [Fact]
-        public void UnauthorizedUserCannotInvokeMethodsInHubsAuthorizedSpecifyingUserAndRole()
+        public async Task UnauthorizedUserCannotInvokeMethodsInHubsAuthorizedSpecifyingUserAndRole()
         {
             using (var host = new MemoryHost())
             {
@@ -835,7 +826,8 @@ namespace Microsoft.AspNet.SignalR.Tests
                         wh.Set();
                     });
 
-                    Assert.Throws<AggregateException>(() => connection.Start(host).Wait());
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Forbidden, ex.Response.StatusCode);
                 }
             }
         }
@@ -861,16 +853,16 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("UserAndRoleAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
@@ -896,18 +888,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("UserAndRoleAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string>("invoked", (id, time) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
                     await hub.Invoke("InvokedFromClient").OrTimeout();
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
@@ -933,16 +925,16 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("IncomingAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
@@ -997,16 +989,16 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("IncomingAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string, object>("joined", (id, time, authInfo) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
@@ -1032,18 +1024,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("IncomingAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string>("invoked", (id, time) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
                     await hub.Invoke("InvokedFromClient").OrTimeout();
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }
@@ -1127,18 +1119,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                 using (connection)
                 {
                     var hub = connection.CreateHubProxy("InvokeAuthHub");
-                    var wh = new ManualResetEvent(false);
+                    var wh = new TaskCompletionSource<object>();
                     hub.On<string, string>("invoked", (id, time) =>
                     {
                         Assert.NotNull(id);
-                        wh.Set();
+                        wh.TrySetResult(null);
                     });
 
                     await connection.Start(host);
 
                     await hub.Invoke("InvokedFromClient").OrTimeout();
 
-                    Assert.True(wh.WaitOne(TimeSpan.FromSeconds(3)));
+                    await wh.Task.OrTimeout(TimeSpan.FromSeconds(3));
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -399,8 +399,15 @@ namespace Microsoft.AspNet.SignalR.Tests
                     Assert.NotNull(timeoutTask);
 
                     var ex = await timeoutTask;
-                    Assert.NotNull(ex);
-                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
+                    if (ex is null)
+                    {
+                        throw new Exception("WTF IS GOING ON?");
+                    }
+                    else
+                    {
+                        throw new Exception($"ex.GetType().Name: {ex.GetType().Name}; ex.Message: {ex.Message}");
+                    }
+                    //Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -388,26 +388,8 @@ namespace Microsoft.AspNet.SignalR.Tests
                     {
                     });
 
-                    var throwsTask = Assert.ThrowsAsync<HttpClientException>(() =>
-                    {
-                        var t = connection.Start(host);
-                        Assert.NotNull(t);
-                        return t;
-                    });
-                    Assert.NotNull(throwsTask);
-                    var timeoutTask = throwsTask.OrTimeout();
-                    Assert.NotNull(timeoutTask);
-
-                    var ex = await timeoutTask;
-                    if (ex.Response is null)
-                    {
-                        throw new Exception("THAT'S IT!");
-                    }
-                    else
-                    {
-                        throw new Exception($"ex.GetType().Name: {ex.GetType().Name}; ex.Message: {ex.Message}; Status: {ex.Response.StatusCode}");
-                    }
-                    //Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Client;
 using Microsoft.AspNet.SignalR.Hosting.Memory;
 using Microsoft.AspNet.SignalR.Hubs;
-using Microsoft.AspNet.SignalR.Tests.Common;
 using Microsoft.AspNet.SignalR.Tests.Common.Infrastructure;
 using Owin;
 using Xunit;
@@ -389,7 +388,10 @@ namespace Microsoft.AspNet.SignalR.Tests
                     {
                     });
 
-                    var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
+                    var ex = await Assert.ThrowsAsync<HttpClientException>(() =>
+                    {
+                        return connection.Start(host);
+                    }).OrTimeout();
                     Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
@@ -625,7 +627,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     });
 
                     var ex = await Assert.ThrowsAsync<HttpClientException>(() => connection.Start(host)).OrTimeout();
-                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode); 
+                    Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -388,10 +388,18 @@ namespace Microsoft.AspNet.SignalR.Tests
                     {
                     });
 
-                    var ex = await Assert.ThrowsAsync<HttpClientException>(() =>
+                    var throwsTask = Assert.ThrowsAsync<HttpClientException>(() =>
                     {
-                        return connection.Start(host);
-                    }).OrTimeout();
+                        var t = connection.Start(host);
+                        Assert.NotNull(t);
+                        return t;
+                    });
+                    Assert.NotNull(throwsTask);
+                    var timeoutTask = throwsTask.OrTimeout();
+                    Assert.NotNull(timeoutTask);
+
+                    var ex = await timeoutTask;
+                    Assert.NotNull(ex);
                     Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }
             }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubAuthFacts.cs
@@ -399,13 +399,13 @@ namespace Microsoft.AspNet.SignalR.Tests
                     Assert.NotNull(timeoutTask);
 
                     var ex = await timeoutTask;
-                    if (ex is null)
+                    if (ex.Response is null)
                     {
-                        throw new Exception("WTF IS GOING ON?");
+                        throw new Exception("THAT'S IT!");
                     }
                     else
                     {
-                        throw new Exception($"ex.GetType().Name: {ex.GetType().Name}; ex.Message: {ex.Message}");
+                        throw new Exception($"ex.GetType().Name: {ex.GetType().Name}; ex.Message: {ex.Message}; Status: {ex.Response.StatusCode}");
                     }
                     //Assert.Equal(HttpStatusCode.Unauthorized, ex.Response.StatusCode);
                 }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubProgressFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubProgressFacts.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
 {
     public class HubProgressFacts : HostedTest
     {
-        [Theory(Skip = "Flaky when run in parallel.")]
+        [Theory(Skip = "Flaky on CI")]
         //[InlineData(HostType.IISExpress, TransportType.Websockets, MessageBusType.Default, Skip = "Disabled IIS Express tests because they fail to initialize")]
         //[InlineData(HostType.IISExpress, TransportType.ServerSentEvents, MessageBusType.Default, Skip = "Disabled IIS Express tests because they fail to initialize")]
         //[InlineData(HostType.IISExpress, TransportType.LongPolling, MessageBusType.Default, Skip = "Disabled IIS Express tests because they fail to initialize")]
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
 
                     // Give up after 2 minutes
                     var cts = new CancellationTokenSource();
-                    cts.CancelAfter(TimeSpan.FromMinutes(2));
+                    cts.CancelAfter(TimeSpan.FromSeconds(10));
 
                     var updatesSeen = 0;
                     try
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
                     }
                     catch (OperationCanceledException)
                     {
-                        Assert.True(false, "Timed out while waiting for all progress items to arrive");
+                        Assert.True(false, $"Timed out while waiting for all progress items to arrive. Received: {updatesSeen} items.");
                     }
 
                     Assert.Equal(10, updatesSeen);

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/MemoryHost.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/Infrastructure/MemoryHost.cs
@@ -65,7 +65,7 @@ namespace Microsoft.AspNet.SignalR.Hosting.Memory
 
         public void Dispose()
         {
-            _host.Dispose();
+            _host?.Dispose();
         }
     }
 }


### PR DESCRIPTION
I think I've removed most of the synchronous `Wait` calls from our tests so the thread-pool won't be starved during the test run. This should improve functional test reliability.