### PR TITLE
add pdbs to nuget packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,6 +9,9 @@
 
     <!-- Suppress missing documentation warnings -->
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!-- Embed PDBs in NuGet Packages -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes #4109 by embedding the PDBs in the NuGet packages. See below for the impact on package sizes (all packages measured in Release builds):

| Package | Without (KB) | With (KB) | Increase |
|----------------------------------------------------------------|--------------|-----------|----------|
| Microsoft.AspNet.SignalR.Client| 242.34       | 325.64    | 34%      |
| Microsoft.AspNet.SignalR.Core| 160.60       | 213.52    | 33%      |
| Microsoft.AspNet.SignalR.Redis| 24.31        | 30.01     | 23%      |
| Microsoft.AspNet.SignalR.ServiceBus| 23.96        | 30.43     | 27%      |
| Microsoft.AspNet.SignalR.ServiceBus3| 24.93        | 31.50     | 26%      |
| Microsoft.AspNet.SignalR.SqlServer| 31.46        | 39.54     | 26%      |
| Microsoft.AspNet.SignalR.SystemWeb| 6.12         | 7.04      | 15%      |
| Microsoft.AspNet.SignalR.Utils| 19.53        | 24.14     | 24%      |
| **Total** | 533.25 | 701.81 | 32%|

If we need to use a symbol server I can investigate it, but this is a lot easier on the infrastructure and means users don't need to use a symbol server to download the PDBs (they're just always there). The percentages make it look a little high but given the improved debugging experience and the low absolute numbers (Redis + Core + SystemWeb = ~60KB total extra size; Client = ~85KB total extra size) I think this is the best way to do this.

+ @Eilon / @muratg in case they have any comments on shipping PDBs in the packages for **ASP.NET** SignalR