### PR TITLE
fix #4232 by enabling WebSocket transport on .NET Standard 2.0

### DIFF
--- a/samples/Common/CommonClient.cs
+++ b/samples/Common/CommonClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 #if !NET40

--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/Microsoft.AspNet.SignalR.Client.Samples.csproj
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/Microsoft.AspNet.SignalR.Client.Samples.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net461</TargetFrameworks>
+    <TargetFrameworks>net40;net461;netcoreapp2.1</TargetFrameworks>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <DefineConstants>$(DefineConstants);MONO</DefineConstants>

--- a/samples/Microsoft.AspNet.SignalR.Client.Samples/Program.cs
+++ b/samples/Microsoft.AspNet.SignalR.Client.Samples/Program.cs
@@ -1,17 +1,26 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNet.SignalR.Client.Hubs;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Samples
 {
-    class Program
+    internal class Program
     {
-        static void Main(string[] args)
+        private static void Main(string[] args)
         {
+#if DEBUG
+            if (args.Any(a => a == "--debug"))
+            {
+                args = args.Where(a => a != "--debug").ToArray();
+                Console.WriteLine($"Ready for debugger to attach. Process ID: {Process.GetCurrentProcess().Id}.");
+                Console.WriteLine("Press ENTER to continue.");
+                Console.ReadLine();
+            }
+#endif
+
             var writer = Console.Out;
             var client = new CommonClient(writer);
             client.Run("http://localhost:40476/");

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -29,9 +29,9 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             _transports = new List<IClientTransport>()
             {
-#if NET45 || NETSTANDARD1_3 || NETSTANDARD2_0
+#if NET45 || NETSTANDARD2_0
                 new WebSocketTransport(httpClient),
-#elif NET40
+#elif NET40 || NETSTANDARD1_3
                 // WebSockets not supported
 #else
 #error Unsupported target framework.

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -31,7 +31,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
             {
 #if NET45 || NETSTANDARD1_3 || NETSTANDARD2_0
                 new WebSocketTransport(httpClient),
-#elif !NET40
+#elif NET40
                 // WebSockets not supported
 #else
 #error Unsupported target framework.

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -29,8 +29,12 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
 
             _transports = new List<IClientTransport>()
             {
-#if NET45 || WINDOWS_UWP || WINDOWS_APP
+#if NET45 || NETSTANDARD1_3 || NETSTANDARD2_0
                 new WebSocketTransport(httpClient),
+#elif !NET40
+                // WebSockets not supported
+#else
+#error Unsupported target framework.
 #endif
                 new ServerSentEventsTransport(httpClient),
                 new LongPollingTransport(httpClient)


### PR DESCRIPTION
fixes #4232

Cleaned up the old #ifdef logic to make sure the WebSocket transport is enabled in the .NET Standard 2.0 build