### PR TITLE
fix #4170 by updating netstandard2.0 build to JSON.NET 11

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -37,7 +37,8 @@
 
   <PropertyGroup Label="Package Versions: Pinned">
     <Release_NewtonsoftJsonPackageVersion>6.0.4</Release_NewtonsoftJsonPackageVersion>
-    <ReleaseNetStandard_NewtonsoftJsonPackageVersion>9.0.1</ReleaseNetStandard_NewtonsoftJsonPackageVersion>	
+    <ReleaseNetStandard13_NewtonsoftJsonPackageVersion>9.0.1</ReleaseNetStandard13_NewtonsoftJsonPackageVersion>	
+    <ReleaseNetStandard20_NewtonsoftJsonPackageVersion>11.0.2</ReleaseNetStandard20_NewtonsoftJsonPackageVersion>	
     <ServiceBus3_WindowsAzureServiceBusPackageVersion>3.4.5</ServiceBus3_WindowsAzureServiceBusPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.AspNet.SignalR.Client/Microsoft.AspNet.SignalR.Client.csproj
+++ b/src/Microsoft.AspNet.SignalR.Client/Microsoft.AspNet.SignalR.Client.csproj
@@ -38,11 +38,11 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="Newtonsoft.Json" Version="$(ReleaseNetStandard_NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(ReleaseNetStandard13_NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="$(ReleaseNetStandard_NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(ReleaseNetStandard20_NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This updates only the (new in 2.4.0) `netstandard2.0` target to JSON.NET 11. This is the lowest version of JSON.NET with an explicit `netstandard2.0` target. It also happens to be the latest version :).

Fixes #4170 