### PR TITLE
fix #4100 by always trying

### DIFF
--- a/samples/Microsoft.AspNet.SignalR.Samples/Hubs/DemoHub/DemoHub.cs
+++ b/samples/Microsoft.AspNet.SignalR.Samples/Hubs/DemoHub/DemoHub.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -90,7 +90,7 @@ namespace Microsoft.AspNet.SignalR.Samples.Hubs.DemoHub
         public Task CancelledTask()
         {
             var tcs = new TaskCompletionSource<object>();
-            tcs.SetCanceled();
+            tcs.TrySetCanceled();
             return tcs.Task;
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.AspNet.SignalR.Samples.Hubs.DemoHub
             var tcs = new TaskCompletionSource<int>();
             return Task.Factory.StartNew(() =>
             {
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return tcs.Task;
             }).Unwrap();
         }

--- a/src/Microsoft.AspNet.SignalR.Client/Connection.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Connection.cs
@@ -559,7 +559,7 @@ namespace Microsoft.AspNet.SignalR.Client
 
                                  // Now that we're connected complete the start task that the
                                  // receive queue is waiting on
-                                 _startTcs.SetResult(null);
+                                 _startTcs.TrySetResult(null);
 
                                  // Start the monitor to check for server activity
                                  _lastMessageAt = DateTime.UtcNow;

--- a/src/Microsoft.AspNet.SignalR.Client/Http/IResponseExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Http/IResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -34,7 +34,7 @@ namespace Microsoft.AspNet.SignalR.Client.Http
             reader.Closed = exception =>
             {
                 response.Dispose();
-                resultTcs.SetResult(result.ToString());
+                resultTcs.TrySetResult(result.ToString());
             };
 
             reader.Start();

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/AutoTransport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -132,7 +132,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     else
                     {
                         // If there's nothing else to try then just fail
-                        tcs.SetException(ex);
+                        tcs.TrySetException(ex);
                     }
                 }
                 else
@@ -141,7 +141,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                     _transport = transport;
 
                     // Complete the process
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
                 }
 
             },

--- a/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Hubs/HubDispatcher.cs
@@ -431,15 +431,15 @@ namespace Microsoft.AspNet.SignalR.Hubs
                 var faulted = tasks.FirstOrDefault(t => t.IsFaulted);
                 if (faulted != null)
                 {
-                    tcs.SetUnwrappedException(faulted.Exception);
+                    tcs.TrySetUnwrappedException(faulted.Exception);
                 }
                 else if (tasks.Any(t => t.IsCanceled))
                 {
-                    tcs.SetCanceled();
+                    tcs.TrySetCanceled();
                 }
                 else
                 {
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
                 }
             });
 

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutStream.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/ScaleoutStream.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -288,7 +288,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
 
             queue.Drain().Catch(traceSource).ContinueWith(task =>
             {
-                tcs.SetResult(null);
+                tcs.TrySetResult(null);
             });
 
             return tcs.Task;

--- a/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
@@ -287,7 +287,7 @@ namespace Microsoft.AspNet.SignalR
                 }
                 else if (t.IsCanceled)
                 {
-                    tcs.SetCanceled();
+                    tcs.TrySetCanceled();
                 }
             },
             TaskContinuationOptions.NotOnRanToCompletion);
@@ -710,7 +710,7 @@ namespace Microsoft.AspNet.SignalR
 #else
             var tcs = new TaskCompletionSource<object>();
 
-            var timer = new Timer(tcs.SetResult,
+            var timer = new Timer(tcs.TrySetResult,
             null,
             timeOut,
             TimeSpan.FromMilliseconds(-1));
@@ -926,7 +926,7 @@ namespace Microsoft.AspNet.SignalR
         public static Task<T> FromResult<T>(T value)
         {
             var tcs = new TaskCompletionSource<T>();
-            tcs.SetResult(value);
+            tcs.TrySetResult(value);
             return tcs.Task;
         }
 
@@ -940,7 +940,7 @@ namespace Microsoft.AspNet.SignalR
         internal static Task<T> FromError<T>(Exception e)
         {
             var tcs = new TaskCompletionSource<T>();
-            tcs.SetUnwrappedException<T>(e);
+            tcs.TrySetUnwrappedException<T>(e);
             return tcs.Task;
         }
 
@@ -950,11 +950,11 @@ namespace Microsoft.AspNet.SignalR
             var aggregateException = e as AggregateException;
             if (aggregateException != null)
             {
-                tcs.SetException(aggregateException.InnerExceptions);
+                tcs.TrySetException(aggregateException.InnerExceptions);
             }
             else
             {
-                tcs.SetException(e);
+                tcs.TrySetException(e);
             }
         }
 
@@ -976,7 +976,7 @@ namespace Microsoft.AspNet.SignalR
         private static Task Canceled()
         {
             var tcs = new TaskCompletionSource<object>();
-            tcs.SetCanceled();
+            tcs.TrySetCanceled();
             return tcs.Task;
         }
 
@@ -984,7 +984,7 @@ namespace Microsoft.AspNet.SignalR
         private static Task<T> Canceled<T>()
         {
             var tcs = new TaskCompletionSource<T>();
-            tcs.SetCanceled();
+            tcs.TrySetCanceled();
             return tcs.Task;
         }
 
@@ -1111,14 +1111,14 @@ namespace Microsoft.AspNet.SignalR
                 }
                 else if (t.IsCanceled)
                 {
-                    tcs.SetCanceled();
+                    tcs.TrySetCanceled();
                 }
                 else
                 {
                     try
                     {
                         successor();
-                        tcs.SetResult(null);
+                        tcs.TrySetResult(null);
                     }
                     catch (Exception ex)
                     {
@@ -1155,12 +1155,12 @@ namespace Microsoft.AspNet.SignalR
                             next(state);
                         }
 
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                     }
                     else
                     {
                         next(state);
-                        tcs.SetResult(null);
+                        tcs.TrySetResult(null);
                     }
                 }
                 catch (Exception ex)
@@ -1194,7 +1194,7 @@ namespace Microsoft.AspNet.SignalR
                         try
                         {
                             successor(t.Result);
-                            tcs.SetResult(null);
+                            tcs.TrySetResult(null);
                         }
                         catch (Exception ex)
                         {
@@ -1219,14 +1219,14 @@ namespace Microsoft.AspNet.SignalR
                     }
                     else if (task.IsCanceled)
                     {
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                     }
                     else
                     {
                         try
                         {
                             successor(t);
-                            tcs.SetResult(null);
+                            tcs.TrySetResult(null);
                         }
                         catch (Exception ex)
                         {
@@ -1250,13 +1250,13 @@ namespace Microsoft.AspNet.SignalR
                     }
                     else if (t.IsCanceled)
                     {
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                     }
                     else
                     {
                         try
                         {
-                            tcs.SetResult(successor());
+                            tcs.TrySetResult(successor());
                         }
                         catch (Exception ex)
                         {
@@ -1280,13 +1280,13 @@ namespace Microsoft.AspNet.SignalR
                     }
                     else if (task.IsCanceled)
                     {
-                        tcs.SetCanceled();
+                        tcs.TrySetCanceled();
                     }
                     else
                     {
                         try
                         {
-                            tcs.SetResult(successor(t));
+                            tcs.TrySetResult(successor(t));
                         }
                         catch (Exception ex)
                         {

--- a/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
@@ -705,7 +705,7 @@ namespace Microsoft.AspNet.SignalR
 #else
             var tcs = new TaskCompletionSource<object>();
 
-            var timer = new Timer((state) => tcs.TrySetResult(state), null, timeOut, TimeSpan.FromMilliseconds(-1));
+            var timer = new Timer((state) => ((TaskCompletionSource<object>)state).TrySetResult(null), tcs, timeOut, TimeSpan.FromMilliseconds(-1));
             return tcs.Task.ContinueWithPreservedCulture(_ =>
             {
                 timer.Dispose();

--- a/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/TaskAsyncHelper.cs
@@ -2,14 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -710,11 +705,7 @@ namespace Microsoft.AspNet.SignalR
 #else
             var tcs = new TaskCompletionSource<object>();
 
-            var timer = new Timer(tcs.TrySetResult,
-            null,
-            timeOut,
-            TimeSpan.FromMilliseconds(-1));
-
+            var timer = new Timer((state) => tcs.TrySetResult(state), null, timeOut, TimeSpan.FromMilliseconds(-1));
             return tcs.Task.ContinueWithPreservedCulture(_ =>
             {
                 timer.Dispose();
@@ -1028,7 +1019,7 @@ namespace Microsoft.AspNet.SignalR
 
         internal static void RunWithPreservedCulture<T>(CulturePair preservedCulture, Action<T> action, T arg)
         {
-            RunWithPreservedCulture(preservedCulture, (f, state)  =>
+            RunWithPreservedCulture(preservedCulture, (f, state) =>
             {
                 f(state);
                 return (object)null;

--- a/src/Microsoft.AspNet.SignalR.SqlServer/DbOperation.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/DbOperation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNet.SignalR.Infrastructure;
@@ -169,7 +169,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
                 connection.Open();
 
                 commandFunc(command)
-                    .Then(result => tcs.SetResult(result))
+                    .Then(result => tcs.TrySetResult(result))
                     .Catch(ex => tcs.SetUnwrappedException(ex), Trace)
                     .Finally(state =>
                     {

--- a/src/Microsoft.AspNet.SignalR.Stress/Performance/SimpleEchoHubRun.cs
+++ b/src/Microsoft.AspNet.SignalR.Stress/Performance/SimpleEchoHubRun.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -59,7 +59,7 @@ namespace Microsoft.AspNet.SignalR.Stress.Performance
 #endif
                     _latencySamples.Add((long)elapsedMilliseconds);
                 }
-                _callbacks[connectionIndex].SetResult(true);
+                _callbacks[connectionIndex].TrySetResult(true);
             });
 
             connection.Start(Host.TransportFactory()).Wait();

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/ConnectionFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/ConnectionFacts.cs
@@ -171,7 +171,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                          .Returns(() =>
                          {
                              var tcs = new TaskCompletionSource<NegotiationResponse>();
-                             tcs.SetCanceled();
+                             tcs.TrySetCanceled();
                              return tcs.Task;
                          });
 
@@ -221,7 +221,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                          .Returns(() =>
                          {
                              var tcs = new TaskCompletionSource<object>();
-                             tcs.SetCanceled();
+                             tcs.TrySetCanceled();
                              return tcs.Task;
                          });
 

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/HubProxyFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/HubProxyFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -219,7 +219,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
                              {
                                  // EnsureReconnecting will change the state and ultimately clear the pending invocation callbacks
                                  connection.EnsureReconnecting();
-                                 testTcs.SetResult(null);
+                                 testTcs.TrySetResult(null);
                              }
                              catch (Exception ex)
                              {

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TaskQueueFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TaskQueueFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
@@ -83,7 +83,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
 
             mockMonitor.Verify(m => m.TaskCompleted(), Times.Never());
 
-            tcs.SetResult(null);
+            tcs.TrySetResult(null);
 
             mockMonitor.Verify(m => m.TaskStarted(), Times.Once());
             mockMonitor.Verify(m => m.TaskCompleted(), Times.Once());

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/TransportFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/TransportFacts.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
         public async Task CancelledTaskHandledWhenStartingLongPolling()
         {
             var tcs = new TaskCompletionSource<IResponse>();
-            tcs.SetCanceled();
+            tcs.TrySetCanceled();
 
             var httpClient = new Mock<IHttpClient>();
 
@@ -120,7 +120,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             mockConnection.Setup(c => c.TotalTransportConnectTimeout).Returns(TimeSpan.FromSeconds(1500));
 
             var tcs = new TaskCompletionSource<IResponse>();
-            tcs.SetCanceled();
+            tcs.TrySetCanceled();
 
             var onErrorWh = new TaskCompletionSource<object>();
 
@@ -167,7 +167,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
             var negotiationResponse = new NegotiationResponse();
             negotiationResponse.TryWebSockets = false;
 
-            tcs.SetResult(negotiationResponse);
+            tcs.TrySetResult(negotiationResponse);
 
             var autoTransport = new Mock<AutoTransport>(It.IsAny<IHttpClient>(), transports);
             autoTransport.Setup(c => c.GetNegotiateResponse(It.IsAny<Connection>(), It.IsAny<string>())).Returns(tcs.Task);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/HubProxyFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/HubProxyFacts.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             await RunWebSocketTransportWithConnectTask(() =>
             {
                 var tcs = new TaskCompletionSource<object>();
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return tcs.Task;
             }).OrTimeout(10000);
         }

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/LongPollingFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/LongPollingFacts.cs
@@ -62,7 +62,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             disconnectCts.Cancel();
 
             // finish polling request
-            pollTaskCompletionSource.SetResult(CreateResponse(string.Empty));
+            pollTaskCompletionSource.TrySetResult(CreateResponse(string.Empty));
 
             // give it some time to make sure a new poll was not setup after verification
             await Task.Delay(1000);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/ConnectionFacts.cs
@@ -167,7 +167,7 @@ namespace Microsoft.AspNet.SignalR.Client.Tests
 
                         connection2.Received += message =>
                         {
-                            messageTcs.SetResult(message);
+                            messageTcs.TrySetResult(message);
                         };
 
                         await connection1.Start(host1);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/PersistentConnectionFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Connections/PersistentConnectionFacts.cs
@@ -532,7 +532,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     connection.Received += data =>
                     {
                         // Should only be called once.
-                        tcs.SetResult(data);
+                        tcs.TrySetResult(data);
                     };
 
                     await connection.Start(host.Transport);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/HubFacts.cs
@@ -1084,19 +1084,19 @@ namespace Microsoft.AspNet.SignalR.Tests
                                     }
                                     else if (t.IsCanceled)
                                     {
-                                        tcs.SetCanceled();
+                                        tcs.TrySetCanceled();
                                     }
                                 },
                                 TaskContinuationOptions.NotOnRanToCompletion);
                         }
                         else
                         {
-                            tcs.SetResult(null);
+                            tcs.TrySetResult(null);
                         }
                     });
 
                     connection.Error += e => tcs.SetException(e);
-                    connection.Reconnecting += () => tcs.SetCanceled();
+                    connection.Reconnecting += () => tcs.TrySetCanceled();
 
                     await connection.Start(host.Transport);
 

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/SecurityFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Server/Hubs/SecurityFacts.cs
@@ -112,7 +112,7 @@ namespace Microsoft.AspNet.SignalR.FunctionalTests.Server.Hubs
 
                     connection.Received += data =>
                     {
-                        connectionTcs.SetResult(data.Trim());
+                        connectionTcs.TrySetResult(data.Trim());
                     };
 
                     await connection.Start(host).OrTimeout();

--- a/test/Microsoft.AspNet.SignalR.Redis.Tests/RedisMessageBusFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Redis.Tests/RedisMessageBusFacts.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.SignalR.Redis.Tests
             {
                 if (++invokationCount == 2)
                 {
-                    connectRetryTcs.SetResult(null);
+                    connectRetryTcs.TrySetResult(null);
                     return Task.FromResult(0);
                 }
                 else
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.SignalR.Redis.Tests
                 // Open would be called twice - once when connection starts and once when it is restored
                 if (++openInvoked == 2)
                 {
-                    tcs.SetResult(null);
+                    tcs.TrySetResult(null);
                 }
             };
 
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.SignalR.Redis.Tests
                 .Setup(c => c.SubscribeAsync(It.IsAny<string>(), It.IsAny<Action<int, RedisMessage>>()))
                 .Returns<string, Action<int, RedisMessage>>((_, __) =>
                 {
-                    atSubscribeTcs.SetResult(null);
+                    atSubscribeTcs.TrySetResult(null);
                     return subscribeTcs.Task;
                 });
 
@@ -152,7 +152,7 @@ namespace Microsoft.AspNet.SignalR.Redis.Tests
             redisConnection.Raise(connection => connection.ConnectionRestored += null, new Exception());
 
             // Now allow the connection task to finish and wait for it
-            subscribeTcs.SetResult(null);
+            subscribeTcs.TrySetResult(null);
             await connectionTask.OrTimeout();
 
             // Make sure OpenStream got called

--- a/test/Microsoft.AspNet.SignalR.Tests/Server/MessageBusFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Server/MessageBusFacts.cs
@@ -81,7 +81,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
 
                     await Task.Delay(50);
                     var tcs = new TaskCompletionSource<bool>();
-                    tcs.SetCanceled();
+                    tcs.TrySetCanceled();
                     wh.Set();
                     return await tcs.Task;
 

--- a/test/Microsoft.AspNet.SignalR.Tests/Server/SubscriptionFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Server/SubscriptionFacts.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             Func<MessageResult, object, Task<bool>> callback = (result, state) =>
             {
                 var tcs = new TaskCompletionSource<bool>();
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return tcs.Task;
             };
 
@@ -48,7 +48,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server
             {
                 await Task.Yield();
                 var tcs = new TaskCompletionSource<bool>();
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return await tcs.Task;
             };
 

--- a/test/Microsoft.AspNet.SignalR.Tests/Server/Transports/ForeverTransportFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Server/Transports/ForeverTransportFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -226,7 +226,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server.Transports
             Func<Task> cancelled = () =>
             {
                 var tcs = new TaskCompletionSource<object>();
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return tcs.Task;
             };
 
@@ -365,7 +365,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server.Transports
             Func<Task> writeCancelled = () =>
             {
                 var tcs = new TaskCompletionSource<object>();
-                tcs.SetCanceled();
+                tcs.TrySetCanceled();
                 return tcs.Task;
             };
 

--- a/test/Microsoft.AspNet.SignalR.Tests/Server/Transports/LongPollingTransportFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Server/Transports/LongPollingTransportFacts.cs
@@ -165,7 +165,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server.Transports
                 response.Setup(m => m.Flush()).Returns(TaskAsyncHelper.Empty);
                 response.SetupSet(m => m.ContentType = It.IsAny<string>()).Callback<string>(contentType =>
                 {
-                    transport._contentTypeTcs.SetResult(contentType);
+                    transport._contentTypeTcs.TrySetResult(contentType);
                 });
 
                 var hostContext = new HostContext(request.Object, response.Object);

--- a/test/Microsoft.AspNet.SignalR.Tests/TaskAsyncHelperFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/TaskAsyncHelperFacts.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -35,7 +35,7 @@ namespace Microsoft.AspNet.SignalR.Tests
             () =>
             {
                 var canceledTcs = new TaskCompletionSource<object>();
-                canceledTcs.SetCanceled();
+                canceledTcs.TrySetCanceled();
                 return canceledTcs.Task; // Sync Canceled
             },
             async () =>
@@ -68,8 +68,8 @@ namespace Microsoft.AspNet.SignalR.Tests
 
                 Action saveCulture = () =>
                 {
-                    cultureTcs.SetResult(Thread.CurrentThread.CurrentCulture);
-                    uiCultureTcs.SetResult(Thread.CurrentThread.CurrentUICulture);
+                    cultureTcs.TrySetResult(Thread.CurrentThread.CurrentCulture);
+                    uiCultureTcs.TrySetResult(Thread.CurrentThread.CurrentUICulture);
                 };
 
                 foreach (var taskGenerator in taskGenerators)


### PR DESCRIPTION
fixes #4100

converts calls to TaskCompletionSource.[SetResult|SetException|SetCanceled] to TaskCompletionSource.Try[SetResult|SetException|SetCanceled]

After conversations with @davidfowl, we decided to just put `Try` in everywhere to prevent any case where the exception in #4100 could slip through