### PR TITLE
fix #4160 by detecting ASP.NET Core Servers

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
@@ -350,5 +350,16 @@ namespace Microsoft.AspNet.SignalR.Client
                 return ResourceManager.GetString("Message_Reconnecting", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details..
+        /// </summary>
+        internal static string Error_AspNetCoreServerDetected
+        {
+            get
+            {
+                return ResourceManager.GetString("Error_AspNetCoreServerDetected", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -193,6 +193,6 @@
     <value>Error message received from the server: '{0}'.</value>
   </data>
   <data name="Error_AspNetCoreServerDetected" xml:space="preserve">
-    <value>Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.</value>
+    <value>Detected a connection attempt to an ASP.NET Core SignalR Server. This client only supports connecting to an ASP.NET SignalR Server. See https://aka.ms/signalr-core-differences for details.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -192,4 +192,7 @@
   <data name="Error_ErrorFromServer" xml:space="preserve">
     <value>Error message received from the server: '{0}'.</value>
   </data>
+  <data name="Error_AspNetCoreServerDetected" xml:space="preserve">
+    <value>Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/TransportHelper.cs
@@ -5,8 +5,9 @@ using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Client.Http;
-using Newtonsoft.Json;
 using Microsoft.AspNet.SignalR.Client.Infrastructure;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNet.SignalR.Client.Transports
 {
@@ -38,7 +39,15 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                                     throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, Resources.Error_ServerNegotiationFailed));
                                 }
 
-                                return JsonConvert.DeserializeObject<NegotiationResponse>(raw);
+                                // We need to parse it into a JObject first so that we can check if this is an ASP.NET Core SignalR server
+                                var jobj = JObject.Parse(raw);
+                                if(jobj.Property("availableTransports") != null)
+                                {
+                                    // This is ASP.NET Core!
+                                    throw new InvalidOperationException(Resources.Error_AspNetCoreServerDetected);
+                                }
+
+                                return jobj.ToObject<NegotiationResponse>();
                             });
         }
 

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -26,6 +26,7 @@
         errorParsingStartResponse: "Error parsing start response: '{0}'. Stopping the connection.",
         invalidStartResponse: "Invalid start response: '{0}'. Stopping the connection.",
         protocolIncompatible: "You are using a version of the client that isn't compatible with the server. Client version {0}, server version {1}.",
+        aspnetCoreSignalrServer: "Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.",
         sendFailed: "Send failed.",
         parseFailed: "Failed at parsing response: {0}",
         longPollFailed: "Long polling request failed.",
@@ -717,6 +718,14 @@
                             res = connection._parseResponse(result);
                         } catch (error) {
                             onFailed(signalR._.error(resources.errorParsingNegotiateResponse, error), connection);
+                            return;
+                        }
+
+                        // Check if the server is an ASP.NET Core app
+                        if (res.availableTransports) {
+                            protocolError = signalR._.error(resources.aspnetCoreSignalrServer);
+                            $(connection).triggerHandler(events.onError, [protocolError]);
+                            deferred.reject(protocolError);
                             return;
                         }
 

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -26,7 +26,7 @@
         errorParsingStartResponse: "Error parsing start response: '{0}'. Stopping the connection.",
         invalidStartResponse: "Invalid start response: '{0}'. Stopping the connection.",
         protocolIncompatible: "You are using a version of the client that isn't compatible with the server. Client version {0}, server version {1}.",
-        aspnetCoreSignalrServer: "Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.",
+        aspnetCoreSignalrServer: "Detected a connection attempt to an ASP.NET Core SignalR Server. This client only supports connecting to an ASP.NET SignalR Server. See https://aka.ms/signalr-core-differences for details.",
         sendFailed: "Send failed.",
         parseFailed: "Failed at parsing response: {0}",
         longPollFailed: "Long polling request failed.",

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/Properties/launchSettings.json
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Microsoft.AspNet.SignalR.Client.JS.Tests": {
+      "commandName": "Project",
+      "workingDirectory": "C:\\Users\\anurse\\Code\\SignalR\\SignalR\\test\\Microsoft.AspNet.SignalR.Client.JS.Tests"
+    }
+  }
+}

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/Properties/launchSettings.json
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Microsoft.AspNet.SignalR.Client.JS.Tests": {
-      "commandName": "Project",
-      "workingDirectory": "C:\\Users\\anurse\\Code\\SignalR\\SignalR\\test\\Microsoft.AspNet.SignalR.Client.JS.Tests"
-    }
-  }
-}

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/NegotiateFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/NegotiateFacts.js
@@ -133,5 +133,22 @@ testUtilities.module("Core - Negotiate Functional Tests");
             };
         });
 
+        QUnit.asyncTimeoutTest(transport = ": connection fails to start with useful error when connecting to ASP.NET Core", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+            var connection = testUtilities.createTestConnection(testName, end, assert, { wrapStart: false, url: "/aspnetcore-signalr", ignoreErrors: true });
+
+            connection.start()
+                .done(function () {
+                    assert.fail("should have failed to connect");
+                    end();
+                })
+                .catch(function (e) {
+                    assert.equal("Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.", e.message);
+                    end();
+                });
+
+            return function () {
+                connection.stop();
+            };
+        });
     });
 })($, window);

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/NegotiateFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/NegotiateFacts.js
@@ -142,7 +142,7 @@ testUtilities.module("Core - Negotiate Functional Tests");
                     end();
                 })
                 .catch(function (e) {
-                    assert.equal("Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.", e.message);
+                    assert.equal("Detected a connection attempt to an ASP.NET Core SignalR Server. This client only supports connecting to an ASP.NET SignalR Server. See https://aka.ms/signalr-core-differences for details.", e.message);
                     end();
                 });
 

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/ConnectionFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/ConnectionFacts.cs
@@ -486,7 +486,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                 {
                     var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => connection.Start(host.TransportFactory())).OrTimeout();
                     Assert.Equal(
-                        "Detected a connection attempt to an ASP.NET SignalR Server. This client only supports connecting to an ASP.NET Core SignalR Server. See https://aka.ms/signalr-core-differences for details.",
+                        "Detected a connection attempt to an ASP.NET Core SignalR Server. This client only supports connecting to an ASP.NET SignalR Server. See https://aka.ms/signalr-core-differences for details.",
                         ex.Message);
                 }
             }


### PR DESCRIPTION
fixes #4160

This change adds logic to the JS and .NET clients to detect ASP.NET Core servers using the 'availableTransports' property in the negotiate response, which is unique to ASP.NET Core