### PR TITLE
fix #4207 by adding 'Error' to negotiate response

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/NegotiationResponse.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/NegotiationResponse.cs
@@ -17,8 +17,9 @@ namespace Microsoft.AspNet.SignalR.Client
         public double? KeepAliveTimeout { get; set; }
         public double TransportConnectTimeout { get; set; }
 
-        // Protocol 2.0: Redirection
+        // Protocol 2.0: Redirection and custom Negotiation Errors
         public string RedirectUrl { get; set; }
         public string AccessToken { get; set; }
+        public string Error { get; set; }
     }
 }

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -22,6 +22,7 @@
         errorParsingNegotiateResponse: "Error parsing negotiate response.",
         errorRedirectionExceedsLimit: "Negotiate redirection limit exceeded.",
         errorDuringStartRequest: "Error during start request. Stopping the connection.",
+        errorFromServer: "Error message received from the server: '{0}'.",
         stoppedDuringStartRequest: "The connection was stopped during the start request.",
         errorParsingStartResponse: "Error parsing start response: '{0}'. Stopping the connection.",
         invalidStartResponse: "Invalid start response: '{0}'. Stopping the connection.",
@@ -729,86 +730,95 @@
                         }
 
                         // Check for a redirect response (which must have a ProtocolVersion of 2.0)
-                        if (res.ProtocolVersion === "2.0" && res.RedirectUrl) {
-                            if (redirects === MAX_REDIRECTS) {
-                                onFailed(signalR._.error(resources.errorRedirectionExceedsLimit), connection);
+                        if (res.ProtocolVersion === "2.0") {
+                            if (res.Error) {
+                                protocolError = signalR._.error(signalR._.format(resources.errorFromServer, res.Error));
+                                $(connection).triggerHandler(events.onError, [protocolError]);
+                                deferred.reject(protocolError);
                                 return;
                             }
-
-                            if (config.transport === "auto") {
-                                // Redirected connections do not support foreverFrame
-                                config.transport = ["webSockets", "serverSentEvents", "longPolling"];
-                            }
-
-                            connection.log("Received redirect to: " + res.RedirectUrl);
-                            connection.accessToken = res.AccessToken;
-
-                            setConnectionUrl(connection, res.RedirectUrl);
-
-                            if (connection.ajaxDataType === "jsonp" && connection.accessToken) {
-                                onFailed(signalR._.error(resources.jsonpNotSupportedWithAccessToken), connection);
-                                return;
-                            }
-
-                            redirects++;
-                            negotiate(connection, callback);
-                        } else {
-                            keepAliveData = connection._.keepAliveData;
-                            connection.appRelativeUrl = res.Url;
-                            connection.id = res.ConnectionId;
-                            connection.token = res.ConnectionToken;
-                            connection.webSocketServerUrl = res.WebSocketServerUrl;
-
-                            // The long poll timeout is the ConnectionTimeout plus 10 seconds
-                            connection._.pollTimeout = res.ConnectionTimeout * 1000 + 10000; // in ms
-
-                            // Once the server has labeled the PersistentConnection as Disconnected, we should stop attempting to reconnect
-                            // after res.DisconnectTimeout seconds.
-                            connection.disconnectTimeout = res.DisconnectTimeout * 1000; // in ms
-
-                            // Add the TransportConnectTimeout from the response to the transportConnectTimeout from the client to calculate the total timeout
-                            connection._.totalTransportConnectTimeout = connection.transportConnectTimeout + res.TransportConnectTimeout * 1000;
-
-                            // If we have a keep alive
-                            if (res.KeepAliveTimeout) {
-                                // Register the keep alive data as activated
-                                keepAliveData.activated = true;
-
-                                // Timeout to designate when to force the connection into reconnecting converted to milliseconds
-                                keepAliveData.timeout = res.KeepAliveTimeout * 1000;
-
-                                // Timeout to designate when to warn the developer that the connection may be dead or is not responding.
-                                keepAliveData.timeoutWarning = keepAliveData.timeout * connection.keepAliveWarnAt;
-
-                                // Instantiate the frequency in which we check the keep alive.  It must be short in order to not miss/pick up any changes
-                                connection._.beatInterval = (keepAliveData.timeout - keepAliveData.timeoutWarning) / 3;
-                            } else {
-                                keepAliveData.activated = false;
-                            }
-
-                            connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
-
-                            $.each(signalR.transports, function (key) {
-                                if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
-                                    return true;
+                            else if (res.RedirectUrl) {
+                                if (redirects === MAX_REDIRECTS) {
+                                    onFailed(signalR._.error(resources.errorRedirectionExceedsLimit), connection);
+                                    return;
                                 }
-                                supportedTransports.push(key);
-                            });
 
-                            if ($.isArray(config.transport)) {
-                                $.each(config.transport, function (_, transport) {
-                                    if ($.inArray(transport, supportedTransports) >= 0) {
-                                        transports.push(transport);
-                                    }
-                                });
-                            } else if (config.transport === "auto") {
-                                transports = supportedTransports;
-                            } else if ($.inArray(config.transport, supportedTransports) >= 0) {
-                                transports.push(config.transport);
+                                if (config.transport === "auto") {
+                                    // Redirected connections do not support foreverFrame
+                                    config.transport = ["webSockets", "serverSentEvents", "longPolling"];
+                                }
+
+                                connection.log("Received redirect to: " + res.RedirectUrl);
+                                connection.accessToken = res.AccessToken;
+
+                                setConnectionUrl(connection, res.RedirectUrl);
+
+                                if (connection.ajaxDataType === "jsonp" && connection.accessToken) {
+                                    onFailed(signalR._.error(resources.jsonpNotSupportedWithAccessToken), connection);
+                                    return;
+                                }
+
+                                redirects++;
+                                negotiate(connection, callback);
+                                return;
                             }
-
-                            initialize(transports);
                         }
+
+                        keepAliveData = connection._.keepAliveData;
+                        connection.appRelativeUrl = res.Url;
+                        connection.id = res.ConnectionId;
+                        connection.token = res.ConnectionToken;
+                        connection.webSocketServerUrl = res.WebSocketServerUrl;
+
+                        // The long poll timeout is the ConnectionTimeout plus 10 seconds
+                        connection._.pollTimeout = res.ConnectionTimeout * 1000 + 10000; // in ms
+
+                        // Once the server has labeled the PersistentConnection as Disconnected, we should stop attempting to reconnect
+                        // after res.DisconnectTimeout seconds.
+                        connection.disconnectTimeout = res.DisconnectTimeout * 1000; // in ms
+
+                        // Add the TransportConnectTimeout from the response to the transportConnectTimeout from the client to calculate the total timeout
+                        connection._.totalTransportConnectTimeout = connection.transportConnectTimeout + res.TransportConnectTimeout * 1000;
+
+                        // If we have a keep alive
+                        if (res.KeepAliveTimeout) {
+                            // Register the keep alive data as activated
+                            keepAliveData.activated = true;
+
+                            // Timeout to designate when to force the connection into reconnecting converted to milliseconds
+                            keepAliveData.timeout = res.KeepAliveTimeout * 1000;
+
+                            // Timeout to designate when to warn the developer that the connection may be dead or is not responding.
+                            keepAliveData.timeoutWarning = keepAliveData.timeout * connection.keepAliveWarnAt;
+
+                            // Instantiate the frequency in which we check the keep alive.  It must be short in order to not miss/pick up any changes
+                            connection._.beatInterval = (keepAliveData.timeout - keepAliveData.timeoutWarning) / 3;
+                        } else {
+                            keepAliveData.activated = false;
+                        }
+
+                        connection.reconnectWindow = connection.disconnectTimeout + (keepAliveData.timeout || 0);
+
+                        $.each(signalR.transports, function (key) {
+                            if ((key.indexOf("_") === 0) || (key === "webSockets" && !res.TryWebSockets)) {
+                                return true;
+                            }
+                            supportedTransports.push(key);
+                        });
+
+                        if ($.isArray(config.transport)) {
+                            $.each(config.transport, function (_, transport) {
+                                if ($.inArray(transport, supportedTransports) >= 0) {
+                                    transports.push(transport);
+                                }
+                            });
+                        } else if (config.transport === "auto") {
+                            transports = supportedTransports;
+                        } else if ($.inArray(config.transport, supportedTransports) >= 0) {
+                            transports.push(config.transport);
+                        }
+
+                        initialize(transports);
                     };
 
                 return negotiate(connection, callback);

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/Microsoft.AspNet.SignalR.Client.JS.Tests.csproj
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/Microsoft.AspNet.SignalR.Client.JS.Tests.csproj
@@ -68,6 +68,10 @@
       <NpmModuleFile Include="node_modules/jquery/dist/jquery.min.js" Module="jquery" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Folder Include="Properties\" />
+    </ItemGroup>
+
     <Target Name="ComputeNpmModulePaths">
       <ItemGroup>
         <_ResolvedNpmModuleFile Include="%(NpmModuleFile.FullPath)">

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/package-lock.json
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/package-lock.json
@@ -1185,12 +1185,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1205,17 +1207,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1332,7 +1337,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1344,6 +1350,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1358,6 +1365,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1365,12 +1373,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1389,6 +1399,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1469,7 +1480,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1481,6 +1493,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1602,6 +1615,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/NegotiateFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/NegotiateFacts.js
@@ -134,4 +134,22 @@ testUtilities.module("Core - Negotiate Functional Tests");
         });
 
     });
+
+    QUnit.asyncTimeoutTest("start reports server error in negotiation response if present", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+        var connection = testUtilities.createTestConnection(testName, end, assert, { wrapStart: false, ignoreErrors: true, url: "/negotiate-error" }),
+            newTimeout = 4000;
+
+        connection.start()
+            .done(function () {
+                assert.fail("connection should have failed to initialize");
+                end();
+            }).catch(function (e) {
+                assert.equal("Error message received from the server: 'Server-provided negotiate error message!'.", e.message);
+                end();
+            });
+
+        return function () {
+            connection.stop();
+        };
+    });
 })($, window);

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/NegotiateFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/NegotiateFacts.cs
@@ -5,7 +5,7 @@ using Xunit;
 
 namespace Microsoft.AspNet.SignalR.Tests
 {
-    public class RedirectionFacts : HostedTest
+    public class NegotiateFacts : HostedTest
     {
         [Fact]
         public async Task CanConnectToEndpointWhichProducesARedirectResponse()
@@ -79,6 +79,22 @@ namespace Microsoft.AspNet.SignalR.Tests
                 {
                     // Should fail to connect.
                     await Assert.ThrowsAsync<TimeoutException>(() => connection.Start(host.TransportFactory()));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsErrorProvidedByServerIfNegotiateResponseContainsErrorMessage()
+        {
+            using (var host = CreateHost(HostType.Memory, TransportType.Auto))
+            {
+                host.Initialize();
+
+                using (var connection = CreateHubConnection(host, path: "/negotiate-error"))
+                {
+                    // Should fail to connect.
+                    var ex = await Assert.ThrowsAsync<Exception>(() => connection.Start(host.TransportFactory()));
+                    Assert.Equal("Error message received from the server: 'Server-provided negotiate error message!'.", ex.Message);
                 }
             }
         }

--- a/test/Microsoft.AspNet.SignalR.Tests.Common/App_Start/Initializer.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests.Common/App_Start/Initializer.cs
@@ -132,6 +132,28 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
                 RegisterSignalREndpoints(app, resolver, hubConfig);
             }
 
+            // Handle negotiate "Error" field
+            app.Use((context, next) =>
+            {
+                if(context.Request.Path.StartsWithSegments(new PathString("/negotiate-error")))
+                {
+                    // Send an error response
+                    context.Response.StatusCode = 200;
+                    context.Response.ContentType = "application/json";
+                    using (var writer = new JsonTextWriter(new StreamWriter(context.Response.Body)))
+                    {
+                        writer.WriteStartObject();
+                        writer.WritePropertyName("ProtocolVersion");
+                        writer.WriteValue("2.0");
+                        writer.WritePropertyName("Error");
+                        writer.WriteValue("Server-provided negotiate error message!");
+                        writer.WriteEndObject();
+                    }
+                    return Task.CompletedTask;
+                }
+                return next();
+            });
+
             // Redirectors:
 
             // Valid redirect chain
@@ -403,6 +425,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Common
             {
                 map.MapSignalR();
             });
+
 
             // Redirectors:
 


### PR DESCRIPTION
fixes #4207

This adds an "Error" field to the negotiate payload that contains an
error message provided by the server. If present, the `.start`/`.Start`
Task/Promise will be faulted with that error. This only works with
clients that support Protocol version 2.0, so it also has to have the
ProtocolVersion 2.0 value. This is designed to prevent older clients
from continuing to attempt to connect when they get the error response.
Since we use a new ProtocolVersion, older clients will fail with the
protocol incompatibility error.