### PR TITLE
fix #4126 by suppressing disconnect exception after logging

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/MessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/MessageBus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
@@ -134,7 +134,6 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 {
                     var messageResult = new MessageResult(items, totalCount);
 
-                    // REVIEW: If 'Invoke' faults, we fail to dispose and leak
                     bool result = await Invoke(messageResult, (s, o) => s.BeforeInvoke(o), state);
 
                     if (!result)

--- a/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Messaging/Subscription.cs
@@ -134,6 +134,7 @@ namespace Microsoft.AspNet.SignalR.Messaging
                 {
                     var messageResult = new MessageResult(items, totalCount);
 
+                    // REVIEW: If 'Invoke' faults, we fail to dispose and leak
                     bool result = await Invoke(messageResult, (s, o) => s.BeforeInvoke(o), state);
 
                     if (!result)

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
@@ -280,6 +280,7 @@ namespace Microsoft.AspNet.SignalR.Transports
                 if (response.Aborted)
                 {
                     // If this was a clean disconnect raise the event.
+                    // REVIEW: If this task is faulted, we return the faulted task up to Subscription.Work
                     return Abort().Then(() => TaskAsyncHelper.False);
                 }
             }

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/ForeverTransport.cs
@@ -280,7 +280,6 @@ namespace Microsoft.AspNet.SignalR.Transports
                 if (response.Aborted)
                 {
                     // If this was a clean disconnect raise the event.
-                    // REVIEW: If this task is faulted, we return the faulted task up to Subscription.Work
                     return Abort().Then(() => TaskAsyncHelper.False);
                 }
             }

--- a/src/Microsoft.AspNet.SignalR.Core/Transports/LongPollingTransport.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/LongPollingTransport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -163,7 +163,7 @@ namespace Microsoft.AspNet.SignalR.Transports
         {
             _counters.ConnectionsCurrentLongPolling.Increment();
         }
-        
+
         public override void DecrementConnectionsCount()
         {
             _counters.ConnectionsCurrentLongPolling.Decrement();

--- a/test/Microsoft.AspNet.SignalR.Tests/Messaging/MessageBrokerFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Messaging/MessageBrokerFacts.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Messaging;
+using Xunit;
+
+namespace Microsoft.AspNet.SignalR.Tests.Messaging
+{
+    public class MessageBrokerFacts
+    {
+        [Fact]
+        public async Task DoWorkDisposesSubscriptionIfWorkThrowsInline()
+        {
+            var subscription = new TestSubscription("test", () => throw new InvalidOperationException());
+            var counterManager = new TestPerformanceCounterManager();
+            var broker = new MessageBroker(counterManager) { Trace = new TraceSource($"SignalR.{nameof(MessageBroker)}.Test") };
+            var context = new MessageBroker.WorkContext(subscription, broker);
+
+            await MessageBroker.DoWork(context);
+
+            Assert.True(subscription.Disposed);
+        }
+
+        [Fact]
+        public async Task DoWorkDisposesSubscriptionIfWorkReturnsFaultedTask()
+        {
+            var subscription = new TestSubscription("test", () => Task.FromException(new InvalidOperationException()));
+            var counterManager = new TestPerformanceCounterManager();
+            var broker = new MessageBroker(counterManager) { Trace = new TraceSource($"SignalR.{nameof(MessageBroker)}.Test") };
+            var context = new MessageBroker.WorkContext(subscription, broker);
+
+            await MessageBroker.DoWork(context);
+
+            Assert.True(subscription.Disposed);
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SignalR.Tests/Messaging/TestSubscription.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Messaging/TestSubscription.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNet.SignalR.Messaging;
+
+namespace Microsoft.AspNet.SignalR.Tests.Messaging
+{
+    public class TestSubscription : ISubscription, IDisposable
+    {
+        private readonly Func<Task> _onWork;
+
+        public bool Disposed { get; private set; }
+
+        public string Identity { get; }
+
+        public TestSubscription(string identity, Func<Task> onWork)
+        {
+            Identity = identity;
+            _onWork = onWork;
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+
+        public bool SetQueued()
+        {
+            return true;
+        }
+
+        public bool UnsetQueued()
+        {
+            return true;
+        }
+
+        public Task Work()
+        {
+            return _onWork();
+        }
+    }
+}

--- a/test/Microsoft.AspNet.SignalR.Tests/Server/Transports/ForeverTransportFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/Server/Transports/ForeverTransportFacts.cs
@@ -276,7 +276,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server.Transports
                                                          callback = cb;
                                                          state = st;
 
-                                                         bool result = await cb(new PersistentResponse() { Aborted = true } , st);
+                                                         bool result = await cb(new PersistentResponse() { Aborted = true }, st);
 
                                                          if (!result)
                                                          {
@@ -408,7 +408,7 @@ namespace Microsoft.AspNet.SignalR.Tests.Server.Transports
                                                      It.IsAny<int>(),
                                                      It.IsAny<object>()))
                 .Returns<string, Func<PersistentResponse, object, Task<bool>>, int, object>(
-                    (messageId, callback, maxMessages, state) => 
+                    (messageId, callback, maxMessages, state) =>
                     {
                         callback(new PersistentResponse(), state);
                         return DisposableAction.Empty;

--- a/test/Microsoft.AspNet.SignalR.Tests/TestPerformanceCounterManager.cs
+++ b/test/Microsoft.AspNet.SignalR.Tests/TestPerformanceCounterManager.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using System.Threading;
+using Microsoft.AspNet.SignalR.Infrastructure;
+
+namespace Microsoft.AspNet.SignalR.Tests
+{
+    public class TestPerformanceCounterManager : IPerformanceCounterManager
+    {
+        public IPerformanceCounter ConnectionsConnected => new TestPerformanceCounter(nameof(ConnectionsConnected));
+
+        public IPerformanceCounter ConnectionsReconnected => new TestPerformanceCounter(nameof(ConnectionsReconnected));
+
+        public IPerformanceCounter ConnectionsDisconnected => new TestPerformanceCounter(nameof(ConnectionsDisconnected));
+
+        public IPerformanceCounter ConnectionsCurrentForeverFrame => new TestPerformanceCounter(nameof(ConnectionsCurrentForeverFrame));
+
+        public IPerformanceCounter ConnectionsCurrentLongPolling => new TestPerformanceCounter(nameof(ConnectionsCurrentLongPolling));
+
+        public IPerformanceCounter ConnectionsCurrentServerSentEvents => new TestPerformanceCounter(nameof(ConnectionsCurrentServerSentEvents));
+
+        public IPerformanceCounter ConnectionsCurrentWebSockets => new TestPerformanceCounter(nameof(ConnectionsCurrentWebSockets));
+
+        public IPerformanceCounter ConnectionsCurrent => new TestPerformanceCounter(nameof(ConnectionsCurrent));
+
+        public IPerformanceCounter ConnectionMessagesReceivedTotal => new TestPerformanceCounter(nameof(ConnectionMessagesReceivedTotal));
+
+        public IPerformanceCounter ConnectionMessagesSentTotal => new TestPerformanceCounter(nameof(ConnectionMessagesSentTotal));
+
+        public IPerformanceCounter ConnectionMessagesReceivedPerSec => new TestPerformanceCounter(nameof(ConnectionMessagesReceivedPerSec));
+
+        public IPerformanceCounter ConnectionMessagesSentPerSec => new TestPerformanceCounter(nameof(ConnectionMessagesSentPerSec));
+
+        public IPerformanceCounter MessageBusMessagesReceivedTotal => new TestPerformanceCounter(nameof(MessageBusMessagesReceivedTotal));
+
+        public IPerformanceCounter MessageBusMessagesReceivedPerSec => new TestPerformanceCounter(nameof(MessageBusMessagesReceivedPerSec));
+
+        public IPerformanceCounter ScaleoutMessageBusMessagesReceivedPerSec => new TestPerformanceCounter(nameof(ScaleoutMessageBusMessagesReceivedPerSec));
+
+        public IPerformanceCounter MessageBusMessagesPublishedTotal => new TestPerformanceCounter(nameof(MessageBusMessagesPublishedTotal));
+
+        public IPerformanceCounter MessageBusMessagesPublishedPerSec => new TestPerformanceCounter(nameof(MessageBusMessagesPublishedPerSec));
+
+        public IPerformanceCounter MessageBusSubscribersCurrent => new TestPerformanceCounter(nameof(MessageBusSubscribersCurrent));
+
+        public IPerformanceCounter MessageBusSubscribersTotal => new TestPerformanceCounter(nameof(MessageBusSubscribersTotal));
+
+        public IPerformanceCounter MessageBusSubscribersPerSec => new TestPerformanceCounter(nameof(MessageBusSubscribersPerSec));
+
+        public IPerformanceCounter MessageBusAllocatedWorkers => new TestPerformanceCounter(nameof(MessageBusAllocatedWorkers));
+
+        public IPerformanceCounter MessageBusBusyWorkers => new TestPerformanceCounter(nameof(MessageBusBusyWorkers));
+
+        public IPerformanceCounter MessageBusTopicsCurrent => new TestPerformanceCounter(nameof(MessageBusTopicsCurrent));
+
+        public IPerformanceCounter ErrorsAllTotal => new TestPerformanceCounter(nameof(ErrorsAllTotal));
+
+        public IPerformanceCounter ErrorsAllPerSec => new TestPerformanceCounter(nameof(ErrorsAllPerSec));
+
+        public IPerformanceCounter ErrorsHubResolutionTotal => new TestPerformanceCounter(nameof(ErrorsHubResolutionTotal));
+
+        public IPerformanceCounter ErrorsHubResolutionPerSec => new TestPerformanceCounter(nameof(ErrorsHubResolutionPerSec));
+
+        public IPerformanceCounter ErrorsHubInvocationTotal => new TestPerformanceCounter(nameof(ErrorsHubInvocationTotal));
+
+        public IPerformanceCounter ErrorsHubInvocationPerSec => new TestPerformanceCounter(nameof(ErrorsHubInvocationPerSec));
+
+        public IPerformanceCounter ErrorsTransportTotal => new TestPerformanceCounter(nameof(ErrorsTransportTotal));
+
+        public IPerformanceCounter ErrorsTransportPerSec => new TestPerformanceCounter(nameof(ErrorsTransportPerSec));
+
+        public IPerformanceCounter ScaleoutStreamCountTotal => new TestPerformanceCounter(nameof(ScaleoutStreamCountTotal));
+
+        public IPerformanceCounter ScaleoutStreamCountOpen => new TestPerformanceCounter(nameof(ScaleoutStreamCountOpen));
+
+        public IPerformanceCounter ScaleoutStreamCountBuffering => new TestPerformanceCounter(nameof(ScaleoutStreamCountBuffering));
+
+        public IPerformanceCounter ScaleoutErrorsTotal => new TestPerformanceCounter(nameof(ScaleoutErrorsTotal));
+
+        public IPerformanceCounter ScaleoutErrorsPerSec => new TestPerformanceCounter(nameof(ScaleoutErrorsPerSec));
+
+        public IPerformanceCounter ScaleoutSendQueueLength => new TestPerformanceCounter(nameof(ScaleoutSendQueueLength));
+
+        public void Initialize(string instanceName, CancellationToken hostShutdownToken)
+        {
+        }
+
+        public IPerformanceCounter LoadCounter(string categoryName, string counterName, string instanceName, bool isReadOnly) => new TestPerformanceCounter(counterName);
+
+        private class TestPerformanceCounter : IPerformanceCounter
+        {
+            public string CounterName { get; }
+
+            public long RawValue { get; set; }
+
+            public TestPerformanceCounter(string counterName)
+            {
+                CounterName = counterName;
+            }
+
+            public void Close()
+            {
+            }
+
+            public long Decrement()
+            {
+                RawValue--;
+                return RawValue;
+            }
+
+            public long Increment()
+            {
+                RawValue++;
+                return RawValue;
+            }
+
+            public long IncrementBy(long value)
+            {
+                RawValue += value;
+                return RawValue;
+            }
+
+            public CounterSample NextSample()
+            {
+                return default(CounterSample);
+            }
+
+            public void RemoveInstance()
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4126

If OnDisconnected throws or returns a faulted task, we don't dispose the MessageBus subscriptions associated with that connection. This results in the topic and associated messages leaking since nothing is left to dispose them.

This change suppresses the exception that arises in OnDisconnect after logging it so that the rest of the pipeline can carry on.

I haven't yet figured out a good way to test this. I did manual verification that there is indeed a leak in this scenario and that this change resolves the leak. cc @halter73 on this one as well since it's a bit obscure and I'd certainly value another set of SignalR-experienced 👀. It's only WIP because I might try to get a test figured out (though there isn't great existing coverage to base this on AFAICT) and I left some `// REVIEW` comments in place to illustrate the async flow for reviewers and I don't want them checked in.

TODO:
* [x] Remove `// REVIEW` comments put there to help reviewers understand the flow