### PR TITLE
Fix loc and enable component governance in official build

### DIFF
--- a/.vsts-pipelines/builds/ci-official.yml
+++ b/.vsts-pipelines/builds/ci-official.yml
@@ -20,6 +20,13 @@ phases:
       displayName: 'Run compliance check'
       inputs:
         targetType: F
+    # Detect OSS Components in use in the product. Only needs to run on one OS in the matrix.
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'
+      inputs:
+        # This funky GUID represents the product "ASP.NET and EF Core"
+        governanceProduct: 'c641993b-8380-e811-80c3-0004ffb4789e'
+        snapshotForceEnabled: true
 
     - task: ms-vseng.MicroBuildTasks.a0262b21-fb8f-46f8-bb9a-60ed560d4a87.MicroBuildLocalizationPlugin@1
       displayName: 'Install Localization Plugin'

--- a/build/loc/LocalizeDlls.targets
+++ b/build/loc/LocalizeDlls.targets
@@ -19,7 +19,7 @@
       </TfmTranslate>
 
       <!-- Now convert all these to Items that reference lsbuild.proj for parallelization -->
-      <TfmTranslateProjects Include="$(MSBuildThisFileDirectory)lsbuild.proj">
+      <TfmTranslateProjects Include="$(MSBuildThisFileDirectory)lsbuild.proj" Condition="'@(TfmTranslate)' != ''">
         <AdditionalProperties>
           MicroBuildPluginDirectory=$(MicroBuildPluginDirectory);
           TranslationInput=%(TfmTranslate.TranslationInput);
@@ -60,7 +60,7 @@
       </NoTfmTranslate>
 
       <!-- Now convert all these to Items that reference lsbuild.proj for parallelization -->
-      <NoTfmTranslateProjects Include="$(MSBuildThisFileDirectory)lsbuild.proj">
+      <NoTfmTranslateProjects Include="$(MSBuildThisFileDirectory)lsbuild.proj" Condition="'@(NoTfmTranslate)' != ''">
         <AdditionalProperties>
           MicroBuildPluginDirectory=$(MicroBuildPluginDirectory);
           TranslationInput=%(NoTfmTranslate.TranslationInput);

--- a/samples/Microsoft.AspNet.SignalR.Samples/Scripts/hubs.js
+++ b/samples/Microsoft.AspNet.SignalR.Samples/Scripts/hubs.js
@@ -56,7 +56,8 @@
                             continue;
                         }
 
-                        subscriptionMethod.call(hub, memberKey, makeProxyCallback(hub, memberValue));
+                        // Use the actual user-provided callback as the "identity" value for the registration.
+                        subscriptionMethod.call(hub, memberKey, makeProxyCallback(hub, memberValue), memberValue);
                     }
                 }
             }


### PR DESCRIPTION
BEFORE Merging: Check with @Eilon on the "governanceProduct" value.

This PR fixes a build failure in loc, adds a change from a previous bug fix that was missed and enables the Component Governance task to register OSS components to the build.