### PR TITLE
Fix satellite dependency

### DIFF
--- a/src/Microsoft.AspNet.SignalR/loc/Microsoft.AspNet.SignalR.satellite.nuspec
+++ b/src/Microsoft.AspNet.SignalR/loc/Microsoft.AspNet.SignalR.satellite.nuspec
@@ -16,7 +16,7 @@
         <tags>Microsoft AspNet SignalR AspNetSignalR websockets real-time realtime comet HTTP streaming</tags>
         <dependencies>
             <dependency id="Microsoft.AspNet.SignalR.JS" version="$PackageVersion$" />
-            <dependency id="Microsoft.AspNet.SignalR.SystemWeb.en-US" version="$PackageVersion$" />
+            <dependency id="Microsoft.AspNet.SignalR.SystemWeb.$Locale$" version="$PackageVersion$" />
         </dependencies>
     </metadata>
     <files></files>


### PR DESCRIPTION
I've verified that this fixes nuget restore for projects that depend on Microsoft.AspNet.SignalR.$Locale$. "Microsoft.AspNet.SignalR.SystemWeb.en-US" has never existed, so I'm not sure how that got introduced. This should bring us back to parity with 2.3.0.

@davidfowl @muratg 	While this should fix the missing dependency issue, I think we should consider no longer publishing satellite packages unless we have a reasonable way to test it.

The experience just doesn't seem very good. For example, installing Microsoft.AspNet.SignalR.zh-Hans will bring in Microsoft.AspNet.SignalR.SystemWeb.zh-Hans, but it will not bring in Microsoft.AspNet.SignalR.Core.zh-Hans which seems pretty silly for a metapackage. This is because Microsoft.AspNet.SignalR.SystemWeb.zh-Hans depends on Microsoft.AspNet.SignalR.SystemWeb and that's it. There's no dependency on Core except for through the non-locale-specific SystemWeb package.

The SystemWeb satellite package seems particularly worthless since it doesn't define any resources. Of the 15 methods with localized intellisense docs in Microsoft.AspNet.SignalR.SystemWeb.xml, only GetHttpContext() still exists.

