### PR TITLE
 Make client redirect logic more similar to the core clients

### DIFF
--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -562,12 +562,12 @@
 
             connection.withCredentials = config.withCredentials;
 
-            setConnectionUrl(connection, connection.url);
-
             // Save the original url so that we can reset it when we stop and restart the connection
             connection._originalUrl = connection.url;
 
             connection.ajaxDataType = config.jsonp ? "jsonp" : "text";
+
+            setConnectionUrl(connection, connection.url);
 
             $(connection).bind(events.onStart, function (e, data) {
                 if ($.type(callback) === "function") {
@@ -1039,7 +1039,13 @@
 
             // Reset the URL and clear the access token
             delete connection.accessToken;
+            delete connection.protocol;
+            delete connection.host;
+            delete connection.baseUrl;
+            delete connection.wsProtocol;
+            delete connection.contentType;
             connection.url = connection._originalUrl;
+            connection._.redirectQs = null;
 
             // Trigger the disconnect event
             changeState(connection, connection.state, signalR.connectionState.disconnected);

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
@@ -279,11 +279,13 @@
             // Use addQs to start since it handles the ?/& prefix for us
             preparedUrl = transportLogic.addQs(url, "clientProtocol=" + connection.clientProtocol);
 
-            // Add the redirect-specified query string params if any
-            preparedUrl = transportLogic.addQs(preparedUrl, connection._.redirectQs);
-
-            // Add the user-specified query string params if any
-            preparedUrl = transportLogic.addQs(preparedUrl, connection.qs);
+            if (typeof (connection._.redirectQs) === "string") {
+                // Add the redirect-specified query string params if any
+                preparedUrl = transportLogic.addQs(preparedUrl, connection._.redirectQs);
+            } else {
+                // Otherwise, add the user-specified query string params if any
+                preparedUrl = transportLogic.addQs(preparedUrl, connection.qs);
+            }
 
             if (connection.token) {
                 preparedUrl += "&connectionToken=" + window.encodeURIComponent(connection.token);

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/RedirectFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/RedirectFacts.js
@@ -25,6 +25,22 @@ QUnit.asyncTimeoutTest("Can connect to endpoint which produces a redirect respon
     });
 });
 
+QUnit.asyncTimeoutTest("Original URL used when client stops after a redirect response", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+    var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect", hub: true });
+
+    connection.start().done(function () {
+        assert.comment("Connection succeeded");
+        assert.equal(connection.url, window.location.protocol + "//" + window.location.host + "/signalr/", "The client redirected to the /signalr endpoint.");
+        connection.stop();
+        assert.equal(connection.url, "redirect", "The client's URL is reset to the initial value after stopping.");
+        assert.isNotSet(connection.baseUrl, "The client's URL-related state is reset after stopping.");
+        end();
+    }).fail(function () {
+        assert.fail("Connection failed!");
+        end();
+    });
+});
+
 QUnit.asyncTimeoutTest("Can connect to endpoint which produces a redirect response with a query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
     // "/redirect-query-string2" -> "/signalr?name1=newValue&name3=value3"
     var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string2", hub: true }),
@@ -50,7 +66,7 @@ QUnit.asyncTimeoutTest("Can connect to endpoint which produces a redirect respon
     });
 });
 
-QUnit.asyncTimeoutTest("Can merge redirect query string with user query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+QUnit.asyncTimeoutTest("Does not merge user query string with redirect query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
     // "/redirect-query-string2" -> "/signalr?name1=newValue&name3=value3"
     var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string2", hub: true }),
         proxies = connection.createHubProxies(),
@@ -65,7 +81,7 @@ QUnit.asyncTimeoutTest("Can merge redirect query string with user query string",
         assert.comment("Connection succeeded");
 
         hub.server.getQueryStringValue("foo").then(function (response) {
-            assert.equal(response, "bar", "The client preserved 'foo=bar' from connection.qs.");
+            assert.equal(response, null, "'foo=bar' is absent from connection.qs. In practice, the redirect should reflect the query string.");
             return hub.server.getQueryStringValue("name1");
         }).then(function (response) {
             assert.equal(response, "newValue", "The client preserved 'name1=newValue' from redirect query string.");
@@ -73,6 +89,62 @@ QUnit.asyncTimeoutTest("Can merge redirect query string with user query string",
         }).then(function (response) {
             assert.equal(response, "value3", "The client preserved 'name3=value3' from redirect query string.");
             assert.deepEqual(connection.qs, origQs, "The client did not change the 'qs' property to include pairs from redirect.")
+            end();
+        }).fail(function () {
+            assert.fail("Invocation failed!");
+            end();
+        });
+    }).fail(function () {
+        assert.fail("Connection failed!");
+        end();
+    });
+});
+
+QUnit.asyncTimeoutTest("Preserves user query string if last redirect does not include a query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+    // "/redirect-query-string-clear?foo=bar"
+    // -> "/redirect-query-string-clear2?clearedName=clearedValue"
+    // -> "/signalr?foo=bar"
+    var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string-clear", hub: true }),
+        proxies = connection.createHubProxies(),
+        hub = proxies.redirectTestHub,
+        origQs = {
+            foo: "bar"
+        };
+
+    connection.qs = origQs;
+
+    connection.start().done(function () {
+        assert.comment("Connection succeeded");
+
+        hub.server.getQueryStringValue("foo").then(function (response) {
+            assert.equal(response, "bar", "The client preserved 'foo=bar' from connection.qs.");
+            return hub.server.getQueryStringValue("clearedName");
+        }).then(function (response) {
+            assert.equal(response, null, "The client did not preserve a query string key-value pair only specified in an intermediate RedirectUrl.");
+            end();
+        }).fail(function () {
+            assert.fail("Invocation failed!");
+            end();
+        });
+    }).fail(function () {
+        assert.fail("Connection failed!");
+        end();
+    });
+});
+
+QUnit.asyncTimeoutTest("Clears redirect query string if last redirect does not include a query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+    // "/redirect-query-string-clear"
+    // -> "/redirect-query-string-clear2?clearedName=clearedValue"
+    // -> "/signalr"
+    var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string-clear", hub: true }),
+        proxies = connection.createHubProxies(),
+        hub = proxies.redirectTestHub;
+
+    connection.start().done(function () {
+        assert.comment("Connection succeeded");
+
+        hub.server.getQueryStringValue("clearedName").then(function (response) {
+            assert.equal(response, null, "The client did not preserve a query string key-value pair only specified in an intermediate redirect query string.");
             end();
         }).fail(function () {
             assert.fail("Invocation failed!");
@@ -117,30 +189,6 @@ QUnit.asyncTimeoutTest("Only preserves last redirect query string", testUtilitie
     });
 });
 
-QUnit.asyncTimeoutTest("Clears redirect query string if last redirect doesn't have one", testUtilities.defaultTestTimeout, function (end, assert, testName) {
-    // "/redirect-query-string-clear"
-    // -> "/redirect-query-string-clear2?clearedName=clearedValue"
-    // -> "/signalr"
-    var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string-clear", hub: true }),
-        proxies = connection.createHubProxies(),
-        hub = proxies.redirectTestHub;
-
-    connection.start().done(function () {
-        assert.comment("Connection succeeded");
-
-        hub.server.getQueryStringValue("clearedName").then(function (response) {
-            assert.equal(response, null, "The client did not preserve a query string key-value pair only specified in an intermediate redirect query string.");
-            end();
-        }).fail(function () {
-            assert.fail("Invocation failed!");
-            end();
-        });
-    }).fail(function () {
-        assert.fail("Connection failed!");
-        end();
-    });
-});
-
 QUnit.asyncTimeoutTest("Can connect to endpoint which produces a redirect response with an invalid query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
     // "/redirect-query-string-invalid" -> "/signalr?redirect=invalid&/?=/&"
     var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string-invalid", hub: true }),
@@ -157,6 +205,27 @@ QUnit.asyncTimeoutTest("Can connect to endpoint which produces a redirect respon
             assert.fail("Invocation failed!");
             end();
         });
+    }).fail(function () {
+        assert.fail("Connection failed!");
+        end();
+    });
+});
+
+QUnit.asyncTimeoutTest("Original query string used when client stops after redirect response with a query string", testUtilities.defaultTestTimeout, function (end, assert, testName) {
+    // "/redirect-query-string2" -> "/signalr?name1=newValue&name3=value3"
+    var connection = testUtilities.createTestConnection(testName, end, assert, { url: "redirect-query-string2", hub: true });
+
+    connection.start().done(function () {
+        assert.comment("Connection succeeded");
+
+        assert.ok(connection._.redirectQs.includes("name1=newValue"), "The client preserved 'name1=newValue' from redirect query string.");
+        assert.ok(connection._.redirectQs.includes("name3=value3"), connection._.redirectQs, "The client preserved 'name3=value3' from redirect query string.");
+
+        connection.stop();
+
+        assert.equal(connection._.redirectQs, null, "The client cleared the redirect query string.");
+
+        end();
     }).fail(function () {
         assert.fail("Connection failed!");
         end();

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/RedirectFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/FunctionalTests/Core/RedirectFacts.js
@@ -174,7 +174,7 @@ QUnit.asyncTimeoutTest("Only preserves last redirect query string", testUtilitie
             assert.equal(response, "value3", "The client preserved 'name3=value3' from redirect query string.");
             return hub.server.getQueryStringValue("origName1");
         }).then(function (response) {
-            assert.equal(response, "value1", "The client preserved 'name1=value1' from the first redirect query string for the next request in the redirect chain.");
+            assert.equal(response, "value1", "The client preserved 'origName1=value1' from the first redirect query string for the next request in the redirect chain.");
             return hub.server.getQueryStringValue("name2");
         }).then(function (response) {
             assert.equal(response, null, "The client did not preserve a query string key-value pair only specified in an intermediate redirect query string.");

--- a/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/NegotiateFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.FunctionalTests/Client/NegotiateFacts.cs
@@ -96,7 +96,7 @@ namespace Microsoft.AspNet.SignalR.Tests
                     Assert.Equal("value3", await hub.Invoke<string>("GetQueryStringValue", "name3"));
 
                     // Verify that (Hub)Connection.QueryString only contains what was specified by the user, not the redirect.
-                    // IConnection.QueryString contains what only what was set via redirect. This is what's used by the client to actually build URLs.
+                    // IConnection.QueryString contains only what was set via redirect. This is what's used by the client to actually build URLs.
                     Assert.Contains("foo=bar", connection.QueryString);
                     Assert.DoesNotContain("foo=bar", ((Client.IConnection)connection).QueryString);
 


### PR DESCRIPTION
@vicancy This is a follow up to #4300. The main changes are:

1. The user-specified query string is no longer merged with the redirect query string. The redirecting server is expected to reflect the user-specified query string.
2. The connection's URL and query string are now reset to their initial user-specified values when the connection stops instead of retaining their redirected values.
3. The .NET client's "Connection.Url" property no longer matches the redirect value and instead always maintains its initial value.
4. The JS clients "url" property does reflect the redirect value until the client stops, because the public url and related properties are used in various internal places. This is the already-existing behavior, and it does seem worthwhile to untangle it to behave like the .NET client.
5. Both the .NET clients "Connection.QueryString" property and the JS clients "qs" property never match the redirect query string and instead always maintain their initial value.