### PR TITLE
Update package license to be .NET Foundation / Apache

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,14 +47,14 @@
     <!-- Assembly/NuSpec attributes -->
     <Company>Microsoft</Company>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageLicenseUrl>https://www.microsoft.com/web/webpi/eula/net_library_eula_ENU.htm</PackageLicenseUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OfficialBuild)' != 'true'">
     <!-- Assembly/NuSpec attributes -->
     <Company>.NET Foundation</Company>
     <Copyright>© Copyright (c) .NET Foundation. All rights reserved.</Copyright>
-    <PackageLicenseUrl>https://raw.github.com/SignalR/SignalR/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
 
   <!-- Locating Visual Studio -->

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -44,7 +44,6 @@
         <PropertyGroup>
             <_ConstantProperties>Configuration=$(Configuration)</_ConstantProperties>
             <_ConstantProperties>$(ConstantProperties);PackageVersion=$(PackageVersion)</_ConstantProperties>
-            <_ConstantProperties>$(ConstantProperties);LicenseUrl=http://example.com</_ConstantProperties>
         </PropertyGroup>
 
         <!-- We have to restore first -->


### PR DESCRIPTION
This change links to the 2.3.0 version of LICENSE.txt. That file hasn't changed since 2.3.0. The previous non-official PackageLicenseUrl referenced the "master" branch, but it's generally considered bad practice to link to a living branch. In aspnet/AspNetCore, the PackageLicenseUrl always points to the 2.0.0 version of its LICENSE.txt, so there's precedent.

https://github.com/aspnet/AspNetCore/blob/e7b00a55083a56971e0d340ad2a3d350fec05883/Directory.Build.props#L14

Fixes: #4326