### PR TITLE
update link to asp.net core signalr "repo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ASP.NET SignalR 
 
-**IMPORTANT**: This repository hosts code and project management for ASP.NET SignalR, for use in .NET Framework applications using System.Web or Katana. If you are looking for information on ASP.NET Core SignalR, see the https://github.com/aspnet/SignalR repository.
+**IMPORTANT**: This repository hosts code and project management for ASP.NET SignalR, for use in .NET Framework applications using System.Web or Katana. If you are looking for information on ASP.NET Core SignalR, see the https://github.com/aspnet/AspNetCore/tree/master/src/SignalR repository.
 
 ASP.NET SignalR is a library for ASP.NET developers that makes it incredibly simple to add real-time web functionality to your applications. What is "real-time web" functionality? It's the ability to have your server-side code push content to the connected clients as it happens, in real-time.
 


### PR DESCRIPTION
The existing link points to the archived repo:

![image](https://user-images.githubusercontent.com/14079228/66343248-3e49f800-e919-11e9-8fb5-d9b51c216bbe.png)
