### PR TITLE
#4419 Added support for Sql Azure Managed Instance, which has an engine ID 8

### DIFF
--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlInstaller.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlInstaller.cs
@@ -53,7 +53,8 @@ namespace Microsoft.AspNet.SignalR.SqlServer
             var operation = new DbOperation(connectionString, "SELECT SERVERPROPERTY ( 'EngineEdition' )", _trace);
             var edition = (int)operation.ExecuteScalar();
 
-            return edition >= SqlEngineEdition.Standard && edition <= SqlEngineEdition.Express;
+            return edition >= SqlEngineEdition.Standard && edition <= SqlEngineEdition.Express ||
+                edition == SqlEngineEdition.SqlAzureManagedInstance;
         }
 
         private static class SqlEngineEdition
@@ -64,6 +65,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
             public const int Enterprise = 3;
             public const int Express = 4;
             public const int SqlAzure = 5;
+            public const int SqlAzureManagedInstance = 8;
         }
     }
 }


### PR DESCRIPTION
This changes allow signalR to be used with Sql Azure Managed Instances.

**Sql Azure Managed Instances** should be safely included in the supported DB Engines
Documentation reference: https://docs.microsoft.com/en-us/azure/sql-database/sql-database-managed-instance

**Engine ID is 8**
Documentation reference: https://docs.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql?redirectedfrom=MSDN&view=sql-server-ver15

**Testing**
I was unable to add tests to cover the changes because the updated class, **SqlInstaller.cs**, create instances of **DbOperation** which I cannot therefore mock.