### PR TITLE
Read TryWebSockets from last negotiate response in .NET client

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
@@ -187,6 +187,17 @@ namespace Microsoft.AspNet.SignalR.Client
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to No client transport is compatible with the server. This either means that the AutoTransport was configured was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all..
+        /// </summary>
+        internal static string Error_NoCompatibleTransportFound
+        {
+            get
+            {
+                return ResourceManager.GetString("Error_NoCompatibleTransportFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Possible deadlock detected. A callback registered with &quot;HubProxy.On&quot; or &quot;Connection.Received&quot; has been executing for at least {0} seconds..
         /// </summary>
         internal static string Error_PossibleDeadlockDetected

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
@@ -187,7 +187,7 @@ namespace Microsoft.AspNet.SignalR.Client
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to No client transport is compatible with the server. This either means that the AutoTransport was configured was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all..
+        ///   Looks up a localized string similar to No client transport is compatible with the server. This either means that the AutoTransport was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all..
         /// </summary>
         internal static string Error_NoCompatibleTransportFound
         {

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -195,4 +195,7 @@
   <data name="Error_AspNetCoreServerDetected" xml:space="preserve">
     <value>Detected a connection attempt to an ASP.NET Core SignalR Server. This client only supports connecting to an ASP.NET SignalR Server. See https://aka.ms/signalr-core-differences for details.</value>
   </data>
+  <data name="Error_NoCompatibleTransportFound" xml:space="preserve">
+    <value>No client transport is compatible with the server. This either means that the AutoTransport was configured was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -196,6 +196,6 @@
     <value>Detected a connection attempt to an ASP.NET Core SignalR Server. This client only supports connecting to an ASP.NET SignalR Server. See https://aka.ms/signalr-core-differences for details.</value>
   </data>
   <data name="Error_NoCompatibleTransportFound" xml:space="preserve">
-    <value>No client transport is compatible with the server. This either means that the AutoTransport was configured was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all.</value>
+    <value>No client transport is compatible with the server. This either means that the AutoTransport was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all.</value>
   </data>
 </root>


### PR DESCRIPTION
This fixes #4435 

#### Before:

```
02:22:03.0517617 - null - ChangeState(Disconnected, Connecting)
02:22:03.4398446 - PaDbxAX6F1J915s93MztvA4c7d46aa1 - SSE: GET https://notserverlessservice.service.signalr.net/aspnetclient/connect?clientProtocol=2.1&transport=serverSentEvents&connectionData=[{"Name":"ChatSampleHub"}]&connectionToken=PaDbxAX6F1J915s93MztvA4c7d46aa1&asrs_request_id=xEAfJaQDAAA%3D&asrs.op=%2Fsignalr
02:22:03.4807895 - PaDbxAX6F1J915s93MztvA4c7d46aa1 - SSE: OnMessage(Data: {"S":1,"M":[]})
02:22:03.5087902 - PaDbxAX6F1J915s93MztvA4c7d46aa1 - ChangeState(Connecting, Connected)
02:22:03.7990574 - PaDbxAX6F1J915s93MztvA4c7d46aa1 - SSE: OnMessage(Data: {})
```

#### After

```
02:23:45.3868953 - null - ChangeState(Disconnected, Connecting)
02:23:45.7129968 - pql9Bwbc_1lu9DJSKUKCpw4c7d46aa1 - WS Connecting to: wss://notserverlessservice.service.signalr.net/aspnetclient/connect?clientProtocol=2.1&transport=webSockets&connectionData=[{"Name":"ChatSampleHub"}]&connectionToken=pql9Bwbc_1lu9DJSKUKCpw4c7d46aa1&asrs_request_id=KoUbYqQDAAA%3D&asrs.op=%2Fsignalr
02:23:45.7609939 - pql9Bwbc_1lu9DJSKUKCpw4c7d46aa1 - WS: OnMessage({"S":1,"M":[]})
02:23:45.7899927 - pql9Bwbc_1lu9DJSKUKCpw4c7d46aa1 - ChangeState(Connecting, Connected)
02:23:45.7989927 - pql9Bwbc_1lu9DJSKUKCpw4c7d46aa1 - WS: OnMessage({})
```

@vicancy I see that https://github.com/Azure/azure-signalr/pull/774 has already made it to nuget.org. Impressive turnaround! I would keep that workaround in place indefinitely since you never know ho many pre-2.4.2 clients will stick around in the wild. Generally it's easier to update the server than it is to update every client.