### PR TITLE
Fall back or reconnect but not both (.NET client)

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.Designer.cs
@@ -296,6 +296,18 @@ namespace Microsoft.AspNet.SignalR.Client
             }
         }
 
+
+        /// <summary>
+        ///   Looks up a localized string similar to The transport disconnected before the connection could be fully initialized..
+        /// </summary>
+        internal static string Error_TransportDisconnectedBeforeConnectionFullyInitialized
+        {
+            get
+            {
+                return ResourceManager.GetString("Error_TransportDisconnectedBeforeConnectionFullyInitialized", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Transport failed trying to connect..
         /// </summary>

--- a/src/Microsoft.AspNet.SignalR.Client/Resources.resx
+++ b/src/Microsoft.AspNet.SignalR.Client/Resources.resx
@@ -198,4 +198,7 @@
   <data name="Error_NoCompatibleTransportFound" xml:space="preserve">
     <value>No client transport is compatible with the server. This either means that the AutoTransport was configured to use only WebSockets which is not compatible with the server or that the AutoTransport was configured with no sub-transports at all.</value>
   </data>
+  <data name="Error_TransportDisconnectedBeforeConnectionFullyInitialized" xml:space="preserve">
+    <value>The transport disconnected before the connection could be fully initialized.</value>
+  </data>
 </root>

--- a/src/Microsoft.AspNet.SignalR.Client/Transports/ClientTransportBase.cs
+++ b/src/Microsoft.AspNet.SignalR.Client/Transports/ClientTransportBase.cs
@@ -105,16 +105,17 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
         protected abstract void OnStartFailed();
 
         // internal for testing
-        protected internal void TransportFailed(Exception ex)
+        protected internal bool TryFailStart(Exception ex)
         {
             // will be no-op if handler already finished (either succeeded or failed)
+            // will return true if start failed for any reason.
             if (ex == null)
             {
-                _initializationHandler.Fail();
+                return _initializationHandler.TryFailStart();
             }
             else
             {
-                _initializationHandler.Fail(ex);
+                return _initializationHandler.TryFailStart(ex);
             }
         }
 

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TransportInitializationHandlerFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TransportInitializationHandlerFacts.cs
@@ -30,7 +30,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
 
             initHandler.OnFailure += () => failureInvokedTcs.TrySetResult(null);
 
-            initHandler.Fail();
+            initHandler.TryFailStart();
 
             await failureInvokedTcs.Task.OrTimeout();
 
@@ -63,7 +63,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                 .Returns<IHttpClient, IConnection, string, string>(
                     (httpClient, connection, connectionData, transport) =>
                     {
-                        initHandler.Fail(exception);
+                        initHandler.TryFailStart(exception);
                         return Task.FromResult("{ \"Response\" : \"started\" }");
                     });
 
@@ -188,7 +188,7 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                     (httpClient, connection, connectionData, transport) => Task.FromResult("{ \"Response\" : \"started\" }"));
 
             initHandler.InitReceived();
-            initHandler.Fail();
+            initHandler.TryFailStart();
 
             await initHandler.Task;
             Assert.False(onFailureInvoked);

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TransportInitializationHandlerFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Infrastructure/TransportInitializationHandlerFacts.cs
@@ -7,7 +7,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Client.Http;
 using Microsoft.AspNet.SignalR.Client.Transports;
-using Microsoft.AspNet.SignalR.Infrastructure;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
@@ -30,7 +29,8 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
 
             initHandler.OnFailure += () => failureInvokedTcs.TrySetResult(null);
 
-            initHandler.TryFailStart();
+            Assert.True(initHandler.TryFailStart());
+            Assert.True(initHandler.TryFailStart());
 
             await failureInvokedTcs.Task.OrTimeout();
 
@@ -188,7 +188,8 @@ namespace Microsoft.AspNet.SignalR.Client.Infrastructure
                     (httpClient, connection, connectionData, transport) => Task.FromResult("{ \"Response\" : \"started\" }"));
 
             initHandler.InitReceived();
-            initHandler.TryFailStart();
+            Assert.False(initHandler.TryFailStart());
+            Assert.False(initHandler.TryFailStart());
 
             await initHandler.Task;
             Assert.False(onFailureInvoked);

--- a/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Transports/AutoTransportFacts.cs
+++ b/test/Microsoft.AspNet.SignalR.Client.Tests/Client/Transports/AutoTransportFacts.cs
@@ -41,7 +41,7 @@ namespace Microsoft.AspNet.SignalR.Client.Transports
                 .Setup(c => c.Get(It.IsAny<string>(), It.IsAny<Action<IRequest>>(), It.IsAny<bool>()))
                 .Returns<string, Action<IRequest>, bool>(async (url, prepareRequest, isLongRunning) =>
                 {
-                    mockFailingTransport.Object.TransportFailed(exception);
+                    mockFailingTransport.Object.TryFailStart(exception);
 
                     await waitForException.Task;
 


### PR DESCRIPTION
There was a race observed in the .NET client's ServerSentEventsTransport that caused the client to both try to fall back from SSE to long polling, and also reconnect with SSE. The following server logs show the buggy behavior.

UTC time | connection Id | Event | Method | URL
-- | -- | -- | -- | --
2019-12-02T00:21:12.2371847Z | foo | Request End | GET | http://ne-1.service.signalr.net/aspnetclient/connect?clientProtocol=2.1&transport=serverSentEvents&connectionData=[%7B%22Name%22:%22SomeHub%22%7D]&connectionToken=bar&asrs_request_id=baz%3D&asrs.op=%2Fsignalr
2019-12-02T00:21:12.2372764Z | foo | Request Start | POST | http://ne-1.service.signalr.net/aspnetclient/connect?clientProtocol=2.1&transport=longPolling&connectionData=[%7B%22Name%22:%22SomeHub%22%7D]&connectionToken=bar&asrs_request_id=baz%3D&asrs.op=%2Fsignalr
2019-12-02T00:21:14.2524252Z | foo | Request Start | GET | http://ne-1.service.signalr.net/aspnetclient/reconnect?clientProtocol=2.1&transport=serverSentEvents&connectionData=[%7B%22Name%22:%2222SomeHub%22%7D]&connectionToken=bar&asrs_request_id=baz%3D&asrs.op=%2Fsignalr


The following is what I believe happened. In the list I talk about the SSE transport, but since all the client transports share a lot of logic in ClientTransportBase, I believe this bug could have happened with any of the client's three transports.

1. The transport connects with SSE but doesn't get an init message before the TransportInitializationHandler times out IClientTransport.Start() causing it to return a faulted task which in turn causes the AutoTransport to fall back to long polling.
2. At about exactly the same time, the server closes the SSE /connect response with a FIN (this can be seen in the logs).
3. The SSE transport's EventSourceStreamReader.Closed handler runs.

Normally, Start() timing out would result in the SSE transports _stop flag being set in OnStartFailed() which would cause the Closed handler not to reconnect. Unfortunately, the TransportInitializationHandler only calls OnStartFailed() on a background thread after the decision to fault the Start() task has been made. This means there's a window right after the TransportInitializationHandler decides to timeout Start() where the _stop flag is still not set allowing the SSE transport to both reconnect and return a faulted Start() task.

The fix is for each transport to always try to fault IClientTransport.Start() if there's a transport disconnect/error. Then, if Start() was faulted for any reason (perhaps it was faulted even before this due to a timeout), don't try to reconnect. If the AutoTransport is in use, the faulted Start() results in a transport fallback, so not reconnecting is crucial.

@vicancy