### PR TITLE
Wrap value in a stream to force parameter to be varbinary(max) to prevent SQL cache plan bloat

### DIFF
--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
@@ -43,10 +43,11 @@ namespace Microsoft.AspNet.SignalR.SqlServer
                 return TaskAsyncHelper.Empty;
             }
 
-            var parameter = _dbProviderFactory.CreateParameter();
+            var parameter = (SqlParameter)_dbProviderFactory.CreateParameter();
             parameter.ParameterName = "Payload";
             parameter.DbType = DbType.Binary;
             parameter.Value = SqlPayload.ToBytes(messages);
+            parameter.Size = -1; // Force parameter to be varbinary(max)
 
             var operation = new DbOperation(_connectionString, _insertDml, _trace, parameter);
 

--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
@@ -45,7 +45,7 @@ namespace Microsoft.AspNet.SignalR.SqlServer
 
             using (var stream = new MemoryStream(SqlPayload.ToBytes(messages)))
             {
-                var parameter = (SqlParameter)_dbProviderFactory.CreateParameter();
+                var parameter = _dbProviderFactory.CreateParameter();
                 parameter.ParameterName = "Payload";
                 parameter.DbType = DbType.Binary;
                 parameter.Value = stream;


### PR DESCRIPTION
Currently, the parameter will change and use the size of the data (e.g. @Payload varbinary(30) , @Payload varbinary(33)). This is causing cache bloating in SQL.  This pull request wraps the value in a stream and the resulting SQL will always use `varbinary(max)` as the parameter type for `@Payload`.