### PR TITLE
Change official build pool

### DIFF
--- a/.vsts-pipelines/builds/ci-official.yml
+++ b/.vsts-pipelines/builds/ci-official.yml
@@ -9,7 +9,7 @@ trigger:
 phases:
 - template: ../templates/signalr-build.yml
   parameters:
-    queueName: DotNetCore-Windows
+    pool: internal
     variables:
       SignType: real
       Localize: true

--- a/.vsts-pipelines/builds/ci-public.yml
+++ b/.vsts-pipelines/builds/ci-public.yml
@@ -6,6 +6,6 @@ trigger:
 phases:
 - template: ../templates/signalr-build.yml
   parameters:
-    queueName: Hosted VS2017
+    pool: public
     variables:
       SkipCodeSign: true

--- a/.vsts-pipelines/templates/signalr-build.yml
+++ b/.vsts-pipelines/templates/signalr-build.yml
@@ -1,13 +1,18 @@
 parameters:
-  queueName: ''
+  pool: ''
   beforeBuild: []
   afterBuild: []
   variables:
 
 phases:
 - phase: Windows
-  queue:
-    name: ${{ parameters.queueName }}
+  pool:
+    ${{ if eq(parameters.pool, 'public') }}:
+      name: NetCorePublic-Pool
+      queue: BuildPool.Server.Amd64.VS2019.Open
+    ${{ if eq(parameters.pool, 'internal') }}:
+      name: NetCoreInternal-Pool
+      queue: BuildPool.Server.Amd64.VS2019
   variables:
     BuildConfiguration: Release
     ${{ insert }}: ${{ parameters.variables }}


### PR DESCRIPTION
@anurse @davidfowl 

@mmitche The [signalr-build.yml template](https://github.com/SignalR/SignalR/blob/cb6c9a91e9771d1bc7748f8ae1823fb29ed81a92/.vsts-pipelines/templates/signalr-build.yml) appears to be pretty outdated and doesn't use arcade's eng/common/templates/jobs/jobs.yml like dotnet/extensions does. Do I need to specify "queue: BuildPool.Server.Amd64.VS2019" like dotnet/extensions does [here](https://github.com/dotnet/extensions/blob/75759edc975749e1a8c4198c0078755a1822eac8/azure-pipelines.yml#L83)?