### PR TITLE
Change Payload parameter value to be a stream instead of a byte array

### DIFF
--- a/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
+++ b/src/Microsoft.AspNet.SignalR.SqlServer/SqlSender.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
-using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNet.SignalR.Messaging;
 
@@ -43,14 +42,17 @@ namespace Microsoft.AspNet.SignalR.SqlServer
                 return TaskAsyncHelper.Empty;
             }
 
-            var parameter = _dbProviderFactory.CreateParameter();
-            parameter.ParameterName = "Payload";
-            parameter.DbType = DbType.Binary;
-            parameter.Value = SqlPayload.ToBytes(messages);
+            using (var stream = new MemoryStream(SqlPayload.ToBytes(messages)))
+            {
+                var parameter = _dbProviderFactory.CreateParameter();
+                parameter.ParameterName = "Payload";
+                parameter.DbType = DbType.Binary;
+                parameter.Value = stream;
 
-            var operation = new DbOperation(_connectionString, _insertDml, _trace, parameter);
+                var operation = new DbOperation(_connectionString, _insertDml, _trace, parameter);
 
-            return operation.ExecuteNonQueryAsync();
+                return operation.ExecuteNonQueryAsync();
+            }
         }
     }
 }


### PR DESCRIPTION
Change Payload parameter value to be a stream instead of a byte array
- The Payload SQL parameter will be `varbinary(max)` instead of `varbinary(nnn)` {where nnn is a value that changes based on the size of the messages}. This change will prevent the cache plan in SQL from becoming bloated.
- By using a stream type instead of a byte array, the resulting SQL statement will use the type `varbinary(max)` instead of `varbinary(nnn)` 

#4444 