### PR TITLE
Fixed lock contention when querying connections

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Transports/TransportHeartBeat.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Transports/TransportHeartBeat.cs
@@ -166,7 +166,7 @@ namespace Microsoft.AspNet.SignalR.Transports
 
         public IList<ITrackingConnection> GetConnections()
         {
-            return _connections.Values.Select(metadata => metadata.Connection).ToList();
+            return _connections.Select(p => p.Value.Connection).ToList();
         }
 
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We're tracing exceptions and don't want to crash the process.")]


### PR DESCRIPTION
Something that we noticed while analyzing Perfview trace taken during the incident with our service. Perfview showed that there was a lock contention on the `ConcurrentDictionary.Values` property that pointed to `TransportHeartBeat.GetConnections()` method.

`ConcurrentDictionary.Values` would create a snapshot of the dictionary which requires taking global lock of all dictionary buckets. We should not need snapshot behavior here and can use "lock-free" enumeration of the dictionary members.

This is a fix for https://github.com/SignalR/SignalR/issues/4416