### PR TITLE
readme updates

### DIFF
--- a/src/Microsoft.AspNet.SignalR.JS/README.md
+++ b/src/Microsoft.AspNet.SignalR.JS/README.md
@@ -1,6 +1,10 @@
 # ASP.NET SignalR JavaScript Client
 
-This is the client for ASP.NET SignalR. Use this package if you are connecting to an application written in ASP.NET (using System.Web, or OWIN self-host). This package is **not compatible** with ASP.NET **Core** SignalR. If you are connecting to an ASP.NET Core application, use the `@microsoft/signalr` package.
+This is the client for ASP.NET SignalR. Use this package **only** if you are connecting to an application written in ASP.NET (using System.Web, or OWIN self-host).
+
+> Note: This package is **not compatible** with ASP.NET **Core** SignalR and is not the recommended client for building serverless applications with Azure SignalR Service.
+
+If you are connecting to an ASP.NET Core application, or building a serverless application that makes use of Azure SignalR Service,  use the [@microsoft/signalr](https://www.npmjs.com/package/@microsoft/signalr) package.
 
 ## Documentation
 

--- a/src/Microsoft.AspNet.SignalR.JS/README.md
+++ b/src/Microsoft.AspNet.SignalR.JS/README.md
@@ -1,8 +1,8 @@
+> Note: This package is **not compatible** with ASP.NET **Core** SignalR and is not the recommended client for building serverless applications with Azure SignalR Service.
+
 # ASP.NET SignalR JavaScript Client
 
 This is the client for ASP.NET SignalR. Use this package **only** if you are connecting to an application written in ASP.NET (using System.Web, or OWIN self-host).
-
-> Note: This package is **not compatible** with ASP.NET **Core** SignalR and is not the recommended client for building serverless applications with Azure SignalR Service.
 
 If you are connecting to an ASP.NET Core application, or building a serverless application that makes use of Azure SignalR Service,  use the [@microsoft/signalr](https://www.npmjs.com/package/@microsoft/signalr) package.
 


### PR DESCRIPTION
per the doc issue reported [here](https://github.com/dotnet/aspnetcore/issues/21618), this update makes it more up-front which client customers should use, when their only knowledge of SignalR Is from perusing NPM packages, or who find their way here via OG SignalR docs. 