### PR TITLE
- Refactoring

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Redis/RedisConnection.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisConnection.cs
@@ -45,6 +45,7 @@ namespace Microsoft.AspNet.SignalR.Redis
                     {
                         _connection.Dispose();
                         _connection = null;
+
                         throw new InvalidOperationException("Failed to connect to Redis");
                     }
 
@@ -80,8 +81,7 @@ namespace Microsoft.AspNet.SignalR.Redis
                     _connection.Close(allowCommandsToComplete);
                 }
 
-                _connection.Dispose();
-                _disposed = true;
+                Dispose();
             }
         }
 
@@ -110,6 +110,11 @@ namespace Microsoft.AspNet.SignalR.Redis
                 if (_connection != null)
                 {
                     _trace.TraceVerbose("Disposing connection");
+
+                    _connection.ErrorMessage -= OnError;
+                    _connection.ConnectionFailed -= OnConnectionFailed;
+                    _connection.ConnectionRestored -= OnConnectionRestored;
+
                     _connection.Dispose();
                 }
 

--- a/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
+++ b/src/Microsoft.AspNet.SignalR.Redis/RedisMessageBus.cs
@@ -61,7 +61,7 @@ namespace Microsoft.AspNet.SignalR.Redis
                 {
                     var redisMessageBus = state as RedisMessageBus;
                     
-                    _ = ConnectWithRetry();
+                    _ = redisMessageBus.ConnectWithRetry();
                 }, this);
             }
         }


### PR DESCRIPTION
During analyses of code of SignalR.Redis project, I found a couple of minor issues. Actually, they are very minor and probably PR does not make sense, but since I have already done this, so I decided that why not?

Summary of changes:
- Removed possible null reference exception during disposing of `RedisConnection`;
- Removed duplication of code between `Dispose` and `Close`; 
- Added missed unsubscribes in `RedisConnection` and `RedisMessageBus`;
- Removed redundant closure when queuing a task to the pool. 