### PR TITLE
Update lastMessageAt in markLastMessage

### DIFF
--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -628,7 +628,9 @@
                             signalR.transports._logic.monitorKeepAlive(connection);
                         }
 
-                        signalR.transports._logic.startHeartbeat(connection);
+                        if (connection._.keepAliveData.activated) {
+                            signalR.transports._logic.startHeartbeat(connection);
+                        }
 
                         // Used to ensure low activity clients maintain their authentication.
                         // Must be configured once a transport has been decided to perform valid ping requests.

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
@@ -639,6 +639,7 @@
 
         markLastMessage: function (connection) {
             connection._.lastMessageAt = new Date().getTime();
+            connection._.lastActiveAt = connection._.lastMessageAt;
         },
 
         markActive: function (connection) {

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/UnitTests/Connections/ConnectionStateFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/UnitTests/Connections/ConnectionStateFacts.js
@@ -59,6 +59,18 @@ QUnit.test("verifyLastActive fires onError if timeout occurs", function (assert)
     $.signalR.transports._logic.verifyLastActive(connection);
 });
 
+QUnit.test("markLastMessage updates lastActiveAt", function (assert) {
+    var connection = testUtilities.createHubConnection();
+
+    delete connection._.lastMessageAt;
+    delete connection._.lastActiveAt;
+
+    $.signalR.transports._logic.markLastMessage(connection);
+
+    assert.isSet(connection._.lastMessageAt);
+    assert.isSet(connection._.lastActiveAt);
+});
+
 QUnit.test("lastError cleared when connection starts.", function (assert) {
     var connection = testUtilities.createHubConnection(function () { }, assert, "", undefined, false);
     connection.lastError = new Error();

--- a/version.props
+++ b/version.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionPrefix>2.4.2</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionSuffix>preview2</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
     <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>


### PR DESCRIPTION
I'm hoping this fixes #4536.

`markLastMessage` should still run frequently enough to keep `lastMessageAt` up-to-date despite chrome's new timer throttling because `markLastMessage` called by "network response handlers". This means we have to effectively disable our `lastMessageAt` checking logic if keep-alives are disabled.