### PR TITLE
Enable ESLint

### DIFF
--- a/src/Microsoft.AspNet.SignalR.JS/.eslintrc.js
+++ b/src/Microsoft.AspNet.SignalR.JS/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+    "env": {
+        "browser": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2015,
+        "sourceType": "module"
+    },
+    "rules": {
+        "eqeqeq": "error",
+        "no-redeclare": ["error", {"builtinGlobals": false}],
+        "no-unused-vars": "off",
+        "no-shadow-restricted-names": "off",
+        "no-prototype-builtins": "off"
+    }
+};

--- a/src/Microsoft.AspNet.SignalR.JS/build.ps1
+++ b/src/Microsoft.AspNet.SignalR.JS/build.ps1
@@ -29,6 +29,21 @@ foreach ($file in $files) {
     Write-Host "no issues found" -ForegroundColor Green
 }
 
+$hasError = $false;
+Write-Host "Running ESLint..." -ForegroundColor Yellow
+foreach ($file in $files) {
+    Write-Host "$file..."
+    & "./node_modules/.bin/eslint" "$file"
+    if ($LASTEXITCODE -ne 0) {
+        $hasError = $true;
+    }
+}
+
+if ($hasError) {
+    Write-Host "Error with ESLint"
+    exit 1;
+}
+
 # Combine all files into jquery.signalR.js
 if (!(Test-Path -path "$outputPath")) {
     New-Item "$outputPath" -Type Directory | Out-Null

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -254,7 +254,7 @@
 
     // .on() was added in version 1.7.0, .load() was removed in version 3.0.0 so we fallback to .load() if .on() does
     // not exist to not break existing applications
-    if (typeof _pageWindow.on == "function") {
+    if (typeof _pageWindow.on === "function") {
         _pageWindow.on("load", function () { _pageLoaded = true; });
     }
     else {

--- a/src/Microsoft.AspNet.SignalR.JS/package.json
+++ b/src/Microsoft.AspNet.SignalR.JS/package.json
@@ -29,5 +29,8 @@
         "jquery.signalR.min.js",
         "README.md",
         "LICENSE.md"
-    ]
+    ],
+    "devDependencies": {
+        "eslint": "^7.22.0"
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/SignalR/SignalR/issues/4361

Didn't add the no-extra-parens rule referenced in the issues because, a. it is a warning not an error, b. applying it seems like it broke if statements of the sort `if (something || (anotherthing && thirdthing))`. Turned it into `if (something || anotherthing && thirdthing)` which seems wrong.