### PR TITLE
Fix verifyLastActive tests broken by Chrome timer throttling fix

### DIFF
--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/UnitTests/Common/UtilityFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/UnitTests/Common/UtilityFacts.js
@@ -30,6 +30,7 @@ QUnit.test("markActive stops connection if called after extended period of time.
         stopCalled = false;
 
     connection._.lastActiveAt = new Date(new Date().valueOf() - 3000).getTime()
+    connection._.keepAliveData.activated = true;
     connection.reconnectWindow = 2900;
 
     connection.stop = function () {

--- a/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/UnitTests/Connections/ConnectionStateFacts.js
+++ b/test/Microsoft.AspNet.SignalR.Client.JS.Tests/wwwroot/Tests/UnitTests/Connections/ConnectionStateFacts.js
@@ -52,6 +52,7 @@ QUnit.test("lastError set when error occurrs", function (assert) {
 QUnit.test("verifyLastActive fires onError if timeout occurs", function (assert) {
     var connection = testUtilities.createHubConnection();
     connection._.lastActiveAt = new Date(0);
+    connection._.keepAliveData.activated = true;
     connection.error(function(err) {
         assert.equal(err.source, "TimeoutException", "Disconnected event has expected close reason");
     });


### PR DESCRIPTION
#4544 regressed this