### PR TITLE
Migrate to 1ES hosted pools

### DIFF
--- a/.vsts-pipelines/templates/signalr-build.yml
+++ b/.vsts-pipelines/templates/signalr-build.yml
@@ -8,11 +8,11 @@ jobs:
 - job: Windows
   pool:
     ${{ if eq(parameters.pool, 'public') }}:
-      name: NetCorePublic-Pool
-      queue: BuildPool.Server.Amd64.VS2019.Open
+      name: NetCore1ESPool-Public
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019.Open
     ${{ if eq(parameters.pool, 'internal') }}:
-      name: NetCoreInternal-Pool
-      queue: BuildPool.Server.Amd64.VS2019
+      name: NetCore1ESPool-Internal
+      demands: ImageOverride -equals Build.Server.Amd64.VS2019
   variables:
     BuildConfiguration: Release
     ${{ insert }}: ${{ parameters.variables }}


### PR DESCRIPTION
We are migrating all repositories to 1ES hosted pools. The functionality stays the same but we have to update the yamls.

Tracking issue: https://github.com/dotnet/core-eng/issues/14276

/cc: @jonfortescue