### PR TITLE
Update jquery.signalR.core.js

### DIFF
--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -979,7 +979,6 @@
             }
 
             // Always clean up private non-timeout based state.
-            delete connection._.config;
             delete connection._.deferredStartHandler;
 
             // This needs to be checked despite the connection state because a connection start can be deferred until page load.
@@ -992,9 +991,15 @@
                     deferral.reject(signalR._.error(resources.stoppedWhileLoading));
                 }
 
+                //clean config
+                delete connection._.config;
+                
                 // Short-circuit because the start has not been fully started.
                 return;
             }
+
+            //clean config
+            delete connection._.config;
 
             if (connection.state === signalR.connectionState.disconnected) {
                 return;

--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.core.js
@@ -978,12 +978,15 @@
                 _pageWindow.unbind("load", connection._.deferredStartHandler);
             }
 
+            var waitForPageLoad = !connection._.config || connection._.config.waitForPageLoad === true;
+
             // Always clean up private non-timeout based state.
             delete connection._.deferredStartHandler;
+            delete connection._.config;
 
             // This needs to be checked despite the connection state because a connection start can be deferred until page load.
             // If we've deferred the start due to a page load we need to unbind the "onLoad" -> start event.
-            if (!_pageLoaded && (!connection._.config || connection._.config.waitForPageLoad === true)) {
+            if (!_pageLoaded && waitForPageLoad) {
                 connection.log("Stopping connection prior to negotiate.");
 
                 // If we have a deferral we should reject it
@@ -991,15 +994,9 @@
                     deferral.reject(signalR._.error(resources.stoppedWhileLoading));
                 }
 
-                //clean config
-                delete connection._.config;
-                
                 // Short-circuit because the start has not been fully started.
                 return;
             }
-
-            //clean config
-            delete connection._.config;
 
             if (connection.state === signalR.connectionState.disconnected) {
                 return;


### PR DESCRIPTION
"config" is cleared before it is checked in "if" condition and skips disconnection if page is still loading