### PR TITLE
Check if IAssemblyLocator dependency has changed before override

### DIFF
--- a/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
+++ b/src/Microsoft.AspNet.SignalR.Core/Owin/OwinExtensions.cs
@@ -224,13 +224,18 @@ namespace Owin
                     resolver.Register(typeof(ITraceManager), () => traceManager);
                 }
 
-                // Try to get the list of reference assemblies from the host
-                IEnumerable<Assembly> referenceAssemblies = env.GetReferenceAssemblies();
-                if (referenceAssemblies != null)
+                // Check if IAssemblyLocator dependency has changed, so custom defined IAssemblyLocator will not be overriden
+                IAssemblyLocator assemblyLocator = resolver.Resolve<IAssemblyLocator>();
+                if (assemblyLocator is DefaultAssemblyLocator)
                 {
-                    // Use this list as the assembly locator
-                    var assemblyLocator = new EnumerableOfAssemblyLocator(referenceAssemblies);
-                    resolver.Register(typeof(IAssemblyLocator), () => assemblyLocator);
+                    // Try to get the list of reference assemblies from the host
+                    IEnumerable<Assembly> referenceAssemblies = env.GetReferenceAssemblies();
+                    if (referenceAssemblies != null)
+                    {
+                        // Use this list as the assembly locator
+                        assemblyLocator = new EnumerableOfAssemblyLocator(referenceAssemblies);
+                        resolver.Register(typeof(IAssemblyLocator), () => assemblyLocator);
+                    }
                 }
 
                 resolver.InitializeHost(instanceName, token);


### PR DESCRIPTION
I came across the issue of a very long request to signalr/start, taking around 50 seconds in our application. While trying to fix the problem I thought about giving SignalR a list of assemblies to scan for hubs instead of scanning all assemblies in our project including all libraries we use.

But setting a new Activator for IAssemblyLocator in the DependencyResolver did not have any effect at all. So I digged deeper into the sourcecode of SignalR and found out that the OwinExtension overrides any custom IAssemblyLocator.

This should also fix the problem in issue #4582.
The startup time for SignalR decreased from around 50s to 302ms.