### PR TITLE
Swallow unhandled rejection explicitly in ajax transport when using fetch

### DIFF
--- a/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
+++ b/src/Microsoft.AspNet.SignalR.JS/jquery.signalR.transports.common.js
@@ -458,7 +458,7 @@
                     keepalive: true,
                     headers: requestHeaders,
                     credentials: connection.withCredentials === true ? "include" : "same-origin"
-                });
+                }).catch(() => {});
             }
             else { 
                 // fetch is not available - fallback to $.ajax


### PR DESCRIPTION
At Excel Online we've noticed errors showing up in instrumentation when fetch fails to fetch when stopping a connection (e.g. on page unload).

This PR swallows that error explicitly instead of implicitly. Also good: actually handling the error would also meet our needs.

Cheers, love and thanks